### PR TITLE
Add shared credentials support

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -11,6 +11,15 @@
         }
       },
       {
+        "package": "INIParser",
+        "repositoryURL": "https://github.com/PerfectlySoft/Perfect-INIParser.git",
+        "state": {
+          "branch": null,
+          "revision": "0952aac9ca54324ff25191569fd9c48eec424772",
+          "version": "3.0.2"
+        }
+      },
+      {
         "package": "swift-nio",
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -9,10 +9,19 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio.git", from: "1.8.0"),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "1.1.0"),
-        .package(url: "https://github.com/Yasumoto/HypertextApplicationLanguage.git", .upToNextMajor(from: "1.1.0"))
+        .package(url: "https://github.com/Yasumoto/HypertextApplicationLanguage.git", .upToNextMajor(from: "1.1.0")),
+        .package(url: "https://github.com/PerfectlySoft/Perfect-INIParser.git", .upToNextMajor(from: "3.0.0")),
     ],
     targets: [
-        .target(name: "AWSSDKSwiftCore", dependencies: ["HypertextApplicationLanguage", "NIO", "NIOHTTP1", "NIOOpenSSL"]),
+        .target(
+            name: "AWSSDKSwiftCore",
+            dependencies: [
+                "HypertextApplicationLanguage",
+                "NIO",
+                "NIOHTTP1",
+                "NIOOpenSSL",
+                "INIParser",
+            ]),
         .testTarget(name: "AWSSDKSwiftCoreTests", dependencies: ["AWSSDKSwiftCore"])
     ]
 )

--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -65,7 +65,7 @@ public struct AWSClient {
 
     public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, region givenRegion: Region?, amzTarget: String? = nil, service: String, serviceProtocol: ServiceProtocol, apiVersion: String, endpoint: String? = nil, serviceEndpoints: [String: String] = [:], partitionEndpoint: String? = nil, middlewares: [AWSRequestMiddleware] = [], possibleErrorTypes: [AWSErrorType.Type]? = nil) {
         let credential: CredentialProvider
-        if let scredential = SharedCredential.default {
+        if let scredential = try? SharedCredential() {
             credential = scredential
         } else {
             if let accessKey = accessKeyId, let secretKey = secretAccessKey {

--- a/Tests/AWSSDKSwiftCoreTests/CredentialTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/CredentialTests.swift
@@ -1,0 +1,215 @@
+//
+//  CredentialTests.swift
+//  AWSSDKSwiftCorePackageDescription
+//
+//  Created by Oliver ONeill on 2/9/18.
+//
+
+import Foundation
+import XCTest
+@testable import AWSSDKSwiftCore
+
+class CredentialTests: XCTestCase {
+    /// Fake parser that returns mocked values and keeps track of calls to parse
+    class FakeParser: SharedCredentialsConfigParser {
+        var calls: [String] = []
+        private let toReturn: [String: [String:String]]
+        init(toReturn: [String: [String:String]]) {
+            self.toReturn = toReturn
+        }
+        func parse(filename: String) throws -> [String : [String : String]] {
+            calls.append(filename)
+            return toReturn
+        }
+    }
+
+    func testSharedCredentials() {
+        // Given
+        let profile = "profile1"
+        let accessKey = "FAKE-ACCESS-KEY123"
+        let secretKey = "Asecretreglkjrd"
+        let sessionToken = "xyz"
+        let expected = [
+            profile: [
+                "aws_access_key_id": accessKey,
+                "aws_secret_access_key": secretKey,
+                "aws_session_token": sessionToken,
+            ]
+        ]
+        let filename = "example/file/path/credentials"
+        let parser = FakeParser(toReturn: expected)
+        do {
+            // When
+            let credentials = try SharedCredential(
+                filename: filename,
+                profile: profile,
+                parser: parser
+            )
+            // Then
+            XCTAssertEqual(accessKey, credentials.accessKeyId)
+            XCTAssertEqual(secretKey, credentials.secretAccessKey)
+            XCTAssertEqual(sessionToken, credentials.sessionToken)
+            // Verify called with correct filename
+            XCTAssertEqual(filename, parser.calls.first)
+        } catch {
+            XCTFail("Unexpected failure \(error)")
+        }
+    }
+
+    func testSharedCredentialsMissingSessionToken() {
+        // Given
+        let profile = "profile1"
+        let accessKey = "FAKE-ACCESS-KEY123"
+        let secretKey = "Asecretreglkjrd"
+        let expected = [
+            profile: [
+                "aws_access_key_id": accessKey,
+                "aws_secret_access_key": secretKey,
+            ]
+        ]
+        let filename = "example/file/path/credentials"
+        let parser = FakeParser(toReturn: expected)
+        do {
+            // When
+            let credentials = try SharedCredential(
+                filename: filename,
+                profile: profile,
+                parser: parser
+            )
+            // Then
+            XCTAssertEqual(accessKey, credentials.accessKeyId)
+            XCTAssertEqual(secretKey, credentials.secretAccessKey)
+            XCTAssertNil(credentials.sessionToken)
+        } catch {
+            XCTFail("Unexpected failure \(error)")
+        }
+    }
+
+    func testSharedCredentialsMissingAccessKey() {
+        // Given
+        let profile = "profile1"
+        let secretKey = "Asecretreglkjrd"
+        let expected = [
+            profile: [
+                "aws_secret_access_key": secretKey,
+            ]
+        ]
+        let filename = "example/file/path/credentials"
+        let parser = FakeParser(toReturn: expected)
+        do {
+            // When
+            let _ = try SharedCredential(
+                filename: filename,
+                profile: profile,
+                parser: parser
+            )
+            XCTFail("Unexpected success")
+        } catch let e as SharedCredential.SharedCredentialError {
+            XCTAssertEqual(
+                SharedCredential.SharedCredentialError.missingAccessKeyId,
+                e
+            )
+        } catch {
+            XCTFail("Unexpected failure \(error)")
+        }
+    }
+
+    func testSharedCredentialsMissingSecretKey() {
+        // Given
+        let profile = "profile1"
+        let accessKey = "FAKE-ACCESS-KEY123"
+        let expected = [
+            profile: [
+                "aws_access_key_id": accessKey,
+            ]
+        ]
+        let filename = "example/file/path/credentials"
+        let parser = FakeParser(toReturn: expected)
+        do {
+            // When
+            let _ = try SharedCredential(
+                filename: filename,
+                profile: profile,
+                parser: parser
+            )
+            XCTFail("Unexpected success")
+        } catch let e as SharedCredential.SharedCredentialError {
+            XCTAssertEqual(
+                SharedCredential.SharedCredentialError.missingSecretAccessKey,
+                e
+            )
+        } catch {
+            XCTFail("Unexpected failure \(error)")
+        }
+    }
+
+    func testSharedCredentialsMissingProfile() {
+        // Given
+        let profile = "profile1"
+        let accessKey = "FAKE-ACCESS-KEY123"
+        let expected = [
+            // Different profile
+            "profile2": [
+                "aws_access_key_id": accessKey,
+            ]
+        ]
+        let filename = "example/file/path/credentials"
+        let parser = FakeParser(toReturn: expected)
+        do {
+            // When
+            let _ = try SharedCredential(
+                filename: filename,
+                profile: profile,
+                parser: parser
+            )
+            XCTFail("Unexpected success")
+        } catch let e as SharedCredential.SharedCredentialError {
+            XCTAssertEqual(
+                SharedCredential.SharedCredentialError.missingProfile(profile),
+                e
+            )
+        } catch {
+            XCTFail("Unexpected failure \(error)")
+        }
+    }
+
+    func testSharedCredentialsParseFailure() {
+        // Given
+        enum FakeError: Error, Equatable {
+            case test
+        }
+        class ErrorParser: SharedCredentialsConfigParser {
+            func parse(filename: String) throws -> [String : [String : String]] {
+                throw FakeError.test
+            }
+        }
+        let parser = ErrorParser()
+        do {
+            // When
+            let _ = try SharedCredential(
+                filename: "x",
+                profile: "y",
+                parser: parser
+            )
+            XCTFail("Unexpected success")
+        } catch let e as FakeError {
+            XCTAssertEqual(
+                FakeError.test,
+                e
+            )
+        } catch {
+            XCTFail("Unexpected failure \(error)")
+        }
+    }
+
+    static var allTests : [(String, (CredentialTests) -> () throws -> Void)] {
+        return [
+            ("testSharedCredentials", testSharedCredentials),
+            ("testSharedCredentialsMissingSessionToken", testSharedCredentialsMissingSessionToken),
+            ("testSharedCredentialsMissingAccessKey", testSharedCredentialsMissingAccessKey),
+            ("testSharedCredentialsMissingSecretKey", testSharedCredentialsMissingSecretKey),
+            ("testSharedCredentialsMissingProfile", testSharedCredentialsMissingProfile),
+            ("testSharedCredentialsParseFailure", testSharedCredentialsParseFailure),
+        ]
+    }
+}


### PR DESCRIPTION
I've added INIParser as a dependency for reading the config files.

I also removed the SharedCredential.default property since I was unsure what it was intended for. Instead when AWSClient is created, it will attempt to create a SharedCredentials object.