### PR TITLE
Improve XML list parsing

### DIFF
--- a/Sources/AWSSDKSwiftCore/Serializer/XMLNodeSerializer.swift
+++ b/Sources/AWSSDKSwiftCore/Serializer/XMLNodeSerializer.swift
@@ -122,10 +122,16 @@ public class XMLNodeSerializer {
             let memberChildren: [XMLNode]
 
             if arrayNodes.isEmpty {
-                jsonStr += "{"
-                memberChildren = memberNode.children.filter({ !keys.contains($0.elementName) })
-                jsonStr += _serialize(nodeTree: memberChildren)
-                jsonStr += "}"
+                if memberNode.children.isEmpty {
+                    jsonStr += "["
+                    jsonStr.append(contentsOf: memberNode.values.flatMap(formatAsJSONValue))
+                    jsonStr += "]"
+                } else {
+                    jsonStr += "{"
+                    memberChildren = memberNode.children.filter({ !keys.contains($0.elementName) })
+                    jsonStr += _serialize(nodeTree: memberChildren)
+                    jsonStr += "}"
+                }
             } else {
                 memberChildren = node.children.filter({ !keys.contains($0.elementName) })
                 for (_, nodes) in arrayNodes {

--- a/Tests/AWSSDKSwiftCoreTests/SerializersTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/SerializersTests.swift
@@ -51,9 +51,11 @@ class SerializersTests: XCTestCase {
     struct A: AWSShape {
         public static var members: [AWSShapeMember] = [
             AWSShapeMember(label: "structure", required: true, type: .structure),
-            AWSShapeMember(label: "structures", required: false, type: .list),
+            AWSShapeMember(label: "dList", required: true, type: .list),
+            AWSShapeMember(label: "cList", required: true, type: .list),
             AWSShapeMember(label: "array", required: true, type: .list),
-            AWSShapeMember(label: "member", required: true, type: .list)
+            AWSShapeMember(label: "structureWithMember", required: true, type: .structure),
+            AWSShapeMember(label: "structureWithMembers", required: false, type: .list),
         ]
 
         let structure = B()

--- a/Tests/AWSSDKSwiftCoreTests/XMLParserTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/XMLParserTests.swift
@@ -35,7 +35,14 @@ class XML2ParserTests: XCTestCase {
     }
 
     func testParseStringList() {
-        let data = "<BackendServerDescriptions>\n          <member>\n            <InstancePort>80</InstancePort>\n            <PolicyNames>\n              <member>TFEnableProxyProtocol</member>\n            </PolicyNames>\n          </member>\n          <member>\n            <InstancePort>443</InstancePort>\n            <PolicyNames>\n              <member>TFEnableProxyProtocol</member>\n            </PolicyNames>\n          </member>\n        </BackendServerDescriptions>".data(using: .utf8)!
+        let data = """
+                   <BackendServerDescriptions>
+                     <member><InstancePort>80</InstancePort>
+                             <PolicyNames><member>TFEnableProxyProtocol</member></PolicyNames></member>
+                     <member><InstancePort>443</InstancePort>
+                             <PolicyNames><member>TFEnableProxyProtocol</member></PolicyNames></member>
+                   </BackendServerDescriptions>
+                   """.data(using: .utf8)!
         let parser = XML2Parser(data: data)
         let node = try! parser.parse()
         let jsonString = XMLNodeSerializer(node: node).serializeToJSON()

--- a/Tests/AWSSDKSwiftCoreTests/XMLParserTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/XMLParserTests.swift
@@ -14,6 +14,7 @@ class XML2ParserTests: XCTestCase {
     static var allTests : [(String, (XML2ParserTests) -> () throws -> Void)] {
         return [
             ("testparse", testparse),
+            ("testParseStringList", testParseStringList),
             ("testSerializeJSON", testSerializeJSON)
         ]
     }
@@ -32,6 +33,16 @@ class XML2ParserTests: XCTestCase {
         XCTAssertEqual(node.children.first!.children.flatMap({ $0.values }), ["aaaaa", "bbbbb", "foobar"])
         XCTAssertEqual(node.children.last!.elementName, "CanonicalRequest")
     }
+
+    func testParseStringList() {
+        let data = "<BackendServerDescriptions>\n          <member>\n            <InstancePort>80</InstancePort>\n            <PolicyNames>\n              <member>TFEnableProxyProtocol</member>\n            </PolicyNames>\n          </member>\n          <member>\n            <InstancePort>443</InstancePort>\n            <PolicyNames>\n              <member>TFEnableProxyProtocol</member>\n            </PolicyNames>\n          </member>\n        </BackendServerDescriptions>".data(using: .utf8)!
+        let parser = XML2Parser(data: data)
+        let node = try! parser.parse()
+        let jsonString = XMLNodeSerializer(node: node).serializeToJSON()
+        XCTAssertEqual(jsonString, """
+{"BackendServerDescriptions":[{"InstancePort":80,"PolicyNames":["TFEnableProxyProtocol"]},{"InstancePort":443,"PolicyNames":["TFEnableProxyProtocol"]}]}
+""")
+    }
     
     func testSerializeJSON() {
         let parser = XML2Parser(data: dataSourceXML)
@@ -41,5 +52,6 @@ class XML2ParserTests: XCTestCase {
         let error = jsonDict["Error"] as! [String: Any]
         XCTAssertEqual(error["Code"] as! String, "SignatureDoesNotMatch")
     }
+
 }
 


### PR DESCRIPTION
When calling ELB's `describe-load-balancers`, I found we were parsing the XML incorrectly, creating JSON like this:

```
"BackendServerDescriptions":[{"InstancePort":8080,"PolicyNames":{}},{"InstancePort":8443,"PolicyNames":{}}]
```

Converting that into the respective shape didn't work as expected, since we're somehow turning `<PolicyNames><member>TFEnableProxyProtocol</member></PolicyNames>` into `"PolicyNames":{}`. 

This is [specified correctly](https://github.com/aws/aws-sdk-go/blob/master/models/apis/elasticloadbalancing/2012-06-01/api-2.json#L1357) in our JSON definition, so it's definitely how we're converting it.


I've just submitted the below test case in the hopes that someone else knows how to fix this while I sleep on it 🤔 