### PR TITLE
URLEncode the equals sign _just_ in the value of a query string

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ install:
 
 script:
   - swift build
-  - swift test
+  - swift test -Xswiftc -DDEBUG

--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -315,12 +315,12 @@ extension AWSClient {
 
             for key in keys {
                 if let value = dict[key] {
-                    queryItems.append("\(key)=\(value)")
+                    let stringValue = "\(value)"
+                    queryItems.append("\(key)=\(stringValue.replacingOccurrences(of: "=", with: "%3D"))")
                 }
             }
 
             if let params = queryItems.joined(separator: "&").addingPercentEncoding(withAllowedCharacters: CharacterSet(charactersIn: String.uriAWSQueryAllowed.joined())) {
-
                 if path.contains("?") {
                     path += "&" + params
                 } else {

--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -314,11 +314,14 @@ extension AWSClient {
             dict["Action"] = operationName
             dict["Version"] = apiVersion
 
-            if let urlEncodedQueryParams = urlEncodeQueryParams(fromDictionary: dict) {
-                body = .text(urlEncodedQueryParams)
+            switch httpMethod {
+            case "GET":
+                queryParams = queryParams.merging(dict) { $1 }
+            default:
+                if let urlEncodedQueryParams = urlEncodeQueryParams(fromDictionary: dict) {
+                    body = .text(urlEncodedQueryParams)
+                }
             }
-
-            queryParams = queryParams.merging(dict) { $1 }
 
         case .restxml:
             if let payload = Input.payloadPath, let payloadBody = mirror.getAttribute(forKey: payload.toSwiftVariableCase()) {

--- a/Sources/AWSSDKSwiftCore/Message/AWSRequest.swift
+++ b/Sources/AWSSDKSwiftCore/Message/AWSRequest.swift
@@ -78,6 +78,13 @@ public struct AWSRequest {
         switch serviceProtocol.type {
         case .json, .restjson:
             headers["Content-Type"] = serviceProtocol.contentTypeString
+        case .query:
+            switch awsRequest.httpMethod {
+            case "POST":
+                headers["Content-Type"] = "application/x-www-form-urlencoded"
+            default:
+                break
+            }
         default:
             break
         }

--- a/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
@@ -44,6 +44,8 @@ class AWSClientTests: XCTestCase {
             )
             XCTAssertEqual(awsRequest.url.absoluteString, "\(sesClient.endpoint)/")
             XCTAssertEqual(String(describing: awsRequest.body), "text(\"Action=SendEmail&Version=2013-12-01&value=%3Chtml%3E%3Cbody%3E%3Ca%20href%3D%22https://redsox.com%22%3ETest%3C/a%3E%3C/body%3E%3C/html%3E\")")
+            let nioRequest = try awsRequest.toNIORequest()
+            XCTAssertEqual(nioRequest.head.headers["Content-Type"][0], "application/x-www-form-urlencoded")
         } catch {
             XCTFail(error.localizedDescription)
         }
@@ -68,6 +70,8 @@ class AWSClientTests: XCTestCase {
                 input: input
             )
             XCTAssertEqual(awsRequest.url.absoluteString, "\(kinesisClient.endpoint)/")
+            let nioRequest = try awsRequest.toNIORequest()
+            XCTAssertEqual(nioRequest.head.headers["Content-Type"][0], "application/x-amz-json-1.1")
         } catch {
             XCTFail(error.localizedDescription)
         }

--- a/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
@@ -1,0 +1,121 @@
+//
+//  AWSClient.swift
+//  AWSSDKSwift
+//
+//  Created by Jonathan McAllister on 2018/10/13.
+//
+//
+
+import Foundation
+import NIOHTTP1
+import XCTest
+@testable import AWSSDKSwiftCore
+
+class AWSClientTests: XCTestCase {
+
+    struct C: AWSShape {
+        public static var members: [AWSShapeMember] = [
+            AWSShapeMember(label: "value", required: true, type: .string)
+        ]
+
+        let value = "<html><body><a href=\"https://redsox.com\">Test</a></body></html>"
+    }
+
+    func testCreateAWSRequest() {
+        let input = C()
+
+        let sesClient = AWSClient(
+            accessKeyId: "foo",
+            secretAccessKey: "bar",
+            region: nil,
+            service: "email",
+            serviceProtocol: ServiceProtocol(type: .query),
+            apiVersion: "2013-12-01",
+            middlewares: [],
+            possibleErrorTypes: [SESErrorType.self]
+        )
+
+        do {
+            let awsRequest = try sesClient.debugCreateAWSRequest(
+                operation: "SendEmail",
+                path: "/",
+                httpMethod: "POST",
+                input: input
+            )
+            XCTAssertEqual(awsRequest.url.absoluteString, "\(sesClient.endpoint)/?Action=SendEmail&Version=2013-12-01&value=%3Chtml%3E%3Cbody%3E%3Ca%20href%3D%22https://redsox.com%22%3ETest%3C/a%3E%3C/body%3E%3C/html%3E")
+            XCTAssertEqual(String(describing: awsRequest.body), "text(\"Action=SendEmail&Version=2013-12-01&value=%3Chtml%3E%3Cbody%3E%3Ca%20href%3D%22https://redsox.com%22%3ETest%3C/a%3E%3C/body%3E%3C/html%3E\")")
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
+
+        let kinesisClient = AWSClient(
+            accessKeyId: "foo",
+            secretAccessKey: "bar",
+            region: nil,
+            amzTarget: "Kinesis_20131202",
+            service: "kinesis",
+            serviceProtocol: ServiceProtocol(type: .json, version: ServiceProtocol.Version(major: 1, minor: 1)),
+            apiVersion: "2013-12-02",
+            middlewares: [],
+            possibleErrorTypes: [KinesisErrorType.self]
+        )
+
+        do {
+            let awsRequest = try kinesisClient.debugCreateAWSRequest(
+                operation: "PutRecord",
+                path: "/",
+                httpMethod: "POST",
+                input: input
+            )
+            XCTAssertEqual(awsRequest.url.absoluteString, "\(kinesisClient.endpoint)/")
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
+    }
+
+    static var allTests : [(String, (AWSClientTests) -> () throws -> Void)] {
+        return [
+            ("testCreateAWSRequest", testCreateAWSRequest)
+        ]
+    }
+}
+
+/// Error enum for Kinesis
+public enum KinesisErrorType: AWSErrorType {
+    case resourceNotFoundException(message: String?)
+}
+
+extension KinesisErrorType {
+    public init?(errorCode: String, message: String?){
+        var errorCode = errorCode
+        if let index = errorCode.index(of: "#") {
+            errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
+        }
+        switch errorCode {
+        case "ResourceNotFoundException":
+            self = .resourceNotFoundException(message: message)
+        default:
+            return nil
+        }
+    }
+}
+
+/// Error enum for SES
+public enum SESErrorType: AWSErrorType {
+    case messageRejected(message: String?)
+}
+
+extension SESErrorType {
+    public init?(errorCode: String, message: String?){
+        var errorCode = errorCode
+        if let index = errorCode.index(of: "#") {
+            errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
+        }
+        switch errorCode {
+        case "MessageRejected":
+            self = .messageRejected(message: message)
+        default:
+            return nil
+        }
+    }
+}

--- a/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
@@ -42,7 +42,7 @@ class AWSClientTests: XCTestCase {
                 httpMethod: "POST",
                 input: input
             )
-            XCTAssertEqual(awsRequest.url.absoluteString, "\(sesClient.endpoint)/?Action=SendEmail&Version=2013-12-01&value=%3Chtml%3E%3Cbody%3E%3Ca%20href%3D%22https://redsox.com%22%3ETest%3C/a%3E%3C/body%3E%3C/html%3E")
+            XCTAssertEqual(awsRequest.url.absoluteString, "\(sesClient.endpoint)/")
             XCTAssertEqual(String(describing: awsRequest.body), "text(\"Action=SendEmail&Version=2013-12-01&value=%3Chtml%3E%3Cbody%3E%3Ca%20href%3D%22https://redsox.com%22%3ETest%3C/a%3E%3C/body%3E%3C/html%3E\")")
         } catch {
             XCTFail(error.localizedDescription)


### PR DESCRIPTION
I was trying to [upload a certificate](https://docs.aws.amazon.com/IAM/latest/APIReference/API_UploadServerCertificate.html) which included a `=` and it was failing AWS' parsing.