### PR TITLE
update nio and nio-ssl to latest 1.x versions

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "695afc5205aaa49fca092b94b479ff71c43d9d3c",
-          "version": "1.8.0"
+          "revision": "5d8148c8b45dfb449276557f22120694567dd1d2",
+          "version": "1.9.5"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
         "state": {
           "branch": null,
-          "revision": "0adc938bc8de3d3829b842f9767d81c7480b8403",
-          "version": "1.1.1"
+          "revision": "8380fa29a2af784b067d8ee01c956626ca29f172",
+          "version": "1.3.1"
         }
       },
       {

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ let package = Package(
     targets: [
         .target(
             name: "MyAWSTool",
-            dependencies: ["Cloudfront", "Elasticloadbalancing", "Elasticloadbalancingv2",  "Iam"]),
+            dependencies: ["CloudFront", "ELB", "ELBV2",  "IAM"]),
         .testTarget(
             name: "MyAWSToolTests",
             dependencies: ["MyAWSTool"]),


### PR DESCRIPTION
nio-ssl 1.3.1 introduces a compilation warning, but I think this is ok based on 

https://github.com/apple/swift-nio-ssl/issues/44