### PR TITLE
properly serialize the payloadPath object as json / xml

### DIFF
--- a/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
@@ -21,6 +21,38 @@ class AWSClientTests: XCTestCase {
         let value = "<html><body><a href=\"https://redsox.com\">Test</a></body></html>"
     }
 
+    struct E: AWSShape {
+        public static var members: [AWSShapeMember] = [
+            AWSShapeMember(label: "Member", required: true, type: .list),
+        ]
+
+        let Member = ["memberKey": "memberValue", "memberKey2": "memberValue2"]
+
+        private enum CodingKeys: String, CodingKey {
+            case Member = "Member"
+        }
+    }
+
+    struct F: AWSShape {
+        public static let payloadPath: String? = "fooParams"
+
+        public static var members: [AWSShapeMember] = [
+            AWSShapeMember(label: "Member", required: true, type: .list),
+            AWSShapeMember(label: "fooParams", required: false, type: .structure),
+        ]
+
+        public let fooParams: E?
+
+        public init(fooParams: E? = nil) {
+            self.fooParams = fooParams
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case fooParams = "fooParams"
+        }
+
+    }
+
     func testCreateAWSRequest() {
         let input = C()
 
@@ -100,6 +132,55 @@ class AWSClientTests: XCTestCase {
 
             XCTAssertEqual(awsRequest.url.absoluteString, "https://s3.amazonaws.com/Bucket?list-type=2")
             _ = try awsRequest.toNIORequest()
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
+
+        // encode Shape with payloadPath
+        //
+        let input2 = E()
+        let input3 = F(fooParams: input2)
+
+        // encode for restxml
+        //
+        do {
+            let awsRequest = try s3Client.debugCreateAWSRequest(
+                operation: "payloadPath",
+                path: "/Bucket?list-type=2",
+                httpMethod: "POST",
+                input: input3
+            )
+
+            XCTAssertNotNil(awsRequest.body)
+            if let xmlData = try awsRequest.body.asData() {
+                let xmlNode = try XML2Parser(data: xmlData).parse()
+                let json = XMLNodeSerializer(node: xmlNode).serializeToJSON()
+                let json_data = json.data(using: .utf8)!
+                let dict = try! JSONSerializer().serializeToDictionary(json_data)
+                let fromJson = dict["E"]! as! [String: String]
+                XCTAssertEqual(fromJson["MemberKey"], "memberValue")
+            }
+            _ = try awsRequest.toNIORequest()
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
+
+        // encode for json
+        //
+        do {
+            let awsRequest = try kinesisClient.debugCreateAWSRequest(
+                operation: "PutRecord",
+                path: "/",
+                httpMethod: "POST",
+                input: input3
+            )
+            XCTAssertNotNil(awsRequest.body)
+            if let jsonData = try awsRequest.body.asData() {
+                let jsonBody = try! JSONSerialization.jsonObject(with: jsonData, options: .allowFragments) as! [String:Any]
+                let fromJson = jsonBody["Member"]! as! [String: String]
+                XCTAssertEqual(fromJson["memberKey"], "memberValue")
+            }
+
         } catch {
             XCTFail(error.localizedDescription)
         }


### PR DESCRIPTION
 if the shape has a payload path and it defines a shape, we need to properly serialize that shape.

unfortunately, when the protocol is JSON convincing the compiler that the reflection object is a generic AWSShape that's encodable is not as simple as a switch statement... so we need to serialize the full input to JSON, back to a dictionary, parse the payloadPath out and serialize that... a bit ugly, but effective.

Thank you to @adam-fowler for finding this bug and sharing the solution.