### PR TITLE
JSONSerializer and Dictionaries fix

### DIFF
--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -67,10 +67,10 @@ public struct AWSClient {
         let credential: CredentialProvider
         if let accessKey = accessKeyId, let secretKey = secretAccessKey {
             credential = Credential(accessKeyId: accessKey, secretAccessKey: secretKey)
-        } else if let scredential = try? SharedCredential() {
-                credential = scredential
         } else if let ecredential = EnvironementCredential() {
             credential = ecredential
+        } else if let scredential = try? SharedCredential() {
+            credential = scredential
         } else {
             credential = Credential(accessKeyId: "", secretAccessKey: "")
         }

--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -65,16 +65,14 @@ public struct AWSClient {
 
     public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, region givenRegion: Region?, amzTarget: String? = nil, service: String, serviceProtocol: ServiceProtocol, apiVersion: String, endpoint: String? = nil, serviceEndpoints: [String: String] = [:], partitionEndpoint: String? = nil, middlewares: [AWSRequestMiddleware] = [], possibleErrorTypes: [AWSErrorType.Type]? = nil) {
         let credential: CredentialProvider
-        if let scredential = try? SharedCredential() {
-            credential = scredential
+        if let accessKey = accessKeyId, let secretKey = secretAccessKey {
+            credential = Credential(accessKeyId: accessKey, secretAccessKey: secretKey)
+        } else if let scredential = try? SharedCredential() {
+                credential = scredential
+        } else if let ecredential = EnvironementCredential() {
+            credential = ecredential
         } else {
-            if let accessKey = accessKeyId, let secretKey = secretAccessKey {
-                credential = Credential(accessKeyId: accessKey, secretAccessKey: secretKey)
-            } else if let ecredential = EnvironementCredential() {
-                credential = ecredential
-            } else {
-                credential = Credential(accessKeyId: "", secretAccessKey: "")
-            }
+            credential = Credential(accessKeyId: "", secretAccessKey: "")
         }
 
         let region: Region

--- a/Sources/AWSSDKSwiftCore/Serializer/JSONSerializer.swift
+++ b/Sources/AWSSDKSwiftCore/Serializer/JSONSerializer.swift
@@ -11,27 +11,28 @@ struct JSONSerializer {
     func serializeToDictionary(_ data: Data) throws -> [String: Any] {
         return try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] ?? [:]
     }
-    
+
     func serializeToFlatDictionary(_ data: Data) throws -> [String: Any] {
         func flatten(dictionary: [String: Any]) -> [String: Any] {
             var flatted: [String: Any] = [:]
-            
+
             func destructiveFlatten(dictionary: [String: Any]) {
                 for (key, value) in dictionary {
                     switch value {
                     case let value as [String: Any]:
-                        for (key2, value2) in flatten(dictionary: value) {
-                            switch value2 {
+                        for iterator in flatten(dictionary: value).enumerated() {
+                            switch iterator.element.value {
                             case let value2 as [String: Any]:
                                 destructiveFlatten(dictionary: value2)
-                                
+
                             case let values as [Any]: // TODO: values<Element> might be dictionary...
                                 for iterator in values.enumerated() {
                                     flatted["\(key).member.\(iterator.offset+1)"] = iterator.element
                                 }
-                                
+
                             default:
-                                flatted["\(key).\(key2)"] = value2
+                                flatted["\(key).entry.\(iterator.offset+1).key"] = iterator.element.key
+                                flatted["\(key).entry.\(iterator.offset+1).value"] = iterator.element.value
                             }
                         }
                         
@@ -39,18 +40,18 @@ struct JSONSerializer {
                         for iterator in values.enumerated() {
                             flatted["\(key).member.\(iterator.offset+1)"] = iterator.element
                         }
-                        
+
                     default:
                         flatted[key] = value
                     }
                 }
             }
-            
+
             destructiveFlatten(dictionary: dictionary)
-            
+
             return flatted
         }
-        
+
         return flatten(dictionary: try serializeToDictionary(data))
     }
 }


### PR DESCRIPTION
serializeToFlatDictionary() was not serializing dictionaries correctly. They were being serialized as follows
```
<dictionary name>.<key name>=value
```
When they should have been serialized as follows
```
<dictionary name>.entry.N.key=<key name>
<dictionary name>.entry.N.value=<value>
```
where N is the index of the key,entry pair

I also added code to fix the shared credentials fix from Issue #48 