### PR TITLE
Fixes various query serialization issues

### DIFF
--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -482,13 +482,14 @@ extension AWSClient {
         }
 
         for (key, value) in response.head.headers {
-            if let index = Output.headerParams.index(where: { $0.key.lowercased() == key.description.lowercased() }) {
+            let headerParams = Output.headerParams
+            if let index = headerParams.firstIndex(where: { $0.key.lowercased() == key.description.lowercased() }) {
                 if let number = Double(value) {
-                    outputDict[Output.headerParams[index].key] = number.truncatingRemainder(dividingBy: 1) == 0 ? Int(number) : number
+                    outputDict[headerParams[index].key] = number.truncatingRemainder(dividingBy: 1) == 0 ? Int(number) : number
                 } else if let boolean = Bool(value) {
-                    outputDict[Output.headerParams[index].key] = boolean
+                    outputDict[headerParams[index].key] = boolean
                 } else {
-                    outputDict[Output.headerParams[index].key] = value
+                    outputDict[headerParams[index].key] = value
                 }
             }
         }

--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -316,8 +316,7 @@ extension AWSClient {
             }
 
         case .query:
-            let data = try AWSShapeEncoder().encodeToJSONUTF8Data(input)
-            var dict = try JSONSerializer().serializeToFlatDictionary(data)
+            var dict = AWSShapeEncoder().encodeToQueryDictionary(input)
 
             dict["Action"] = operationName
             dict["Version"] = apiVersion

--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -483,7 +483,7 @@ extension AWSClient {
 
         for (key, value) in response.head.headers {
             let headerParams = Output.headerParams
-            if let index = headerParams.firstIndex(where: { $0.key.lowercased() == key.description.lowercased() }) {
+            if let index = headerParams.index(where: { $0.key.lowercased() == key.description.lowercased() }) {
                 if let number = Double(value) {
                     outputDict[headerParams[index].key] = number.truncatingRemainder(dividingBy: 1) == 0 ? Int(number) : number
                 } else if let boolean = Bool(value) {

--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -490,7 +490,12 @@ extension AWSClient {
             }
         }
 
-        return try DictionaryDecoder().decode(Output.self, from: outputDict)
+        switch responseBody {
+        case .xml:
+            return try UntypedDictionaryDecoder().decode(Output.self, from: outputDict)
+        default:
+            return try DictionaryDecoder().decode(Output.self, from: outputDict)
+        }
     }
 
     private func validateBody(for response: Response, payloadPath: String?, members: [AWSShapeMember]) throws -> Body {

--- a/Sources/AWSSDKSwiftCore/Decoder/UntypedDictionaryDecoder.swift
+++ b/Sources/AWSSDKSwiftCore/Decoder/UntypedDictionaryDecoder.swift
@@ -1,0 +1,1229 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+import Foundation
+
+//===----------------------------------------------------------------------===//
+// Dictionary Decoder
+//===----------------------------------------------------------------------===//
+/// `UntypedDictionaryDecoder` facilitates the decoding of Dictionary into semantic `Decodable` types.
+open class UntypedDictionaryDecoder {
+    // MARK: Options
+    /// The strategy to use for decoding `Date` values.
+    public enum DateDecodingStrategy {
+        /// Defer to `Date` for decoding. This is the default strategy.
+        case deferredToDate
+        
+        /// Decode the `Date` as a UNIX timestamp from a Dictionary number.
+        case secondsSince1970
+        
+        /// Decode the `Date` as UNIX millisecond timestamp from a Dictionary number.
+        case millisecondsSince1970
+        
+        /// Decode the `Date` as an ISO-8601-formatted string (in RFC 3339 format).
+        @available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
+        case iso8601
+        
+        /// Decode the `Date` as a string parsed by the given formatter.
+        case formatted(DateFormatter)
+        
+        /// Decode the `Date` as a custom value decoded by the given closure.
+        case custom((_ decoder: Decoder) throws -> Date)
+    }
+    
+    /// The strategy to use for decoding `Data` values.
+    public enum DataDecodingStrategy {
+        case raw
+    }
+    
+    /// The strategy to use for non-Dictionary-conforming floating-point values (IEEE 754 infinity and NaN).
+    public enum NonConformingFloatDecodingStrategy {
+        /// Throw upon encountering non-conforming values. This is the default strategy.
+        case `throw`
+        
+        /// Decode the values from the given representation strings.
+        case convertFromString(positiveInfinity: String, negativeInfinity: String, nan: String)
+    }
+    
+    /// The strategy to use in decoding dates. Defaults to `.deferredToDate`.
+    open var dateDecodingStrategy: DateDecodingStrategy = .deferredToDate
+    
+    /// The strategy to use in decoding binary data. Defaults to `.base64`.
+    open var dataDecodingStrategy: DataDecodingStrategy = .raw
+    
+    /// The strategy to use in decoding non-conforming numbers. Defaults to `.throw`.
+    open var nonConformingFloatDecodingStrategy: NonConformingFloatDecodingStrategy = .throw
+    
+    /// Contextual user-provided information for use during decoding.
+    open var userInfo: [CodingUserInfoKey : Any] = [:]
+    
+    /// Options set on the top-level encoder to pass down the decoding hierarchy.
+    fileprivate struct _Options {
+        let dateDecodingStrategy: DateDecodingStrategy
+        let dataDecodingStrategy: DataDecodingStrategy
+        let nonConformingFloatDecodingStrategy: NonConformingFloatDecodingStrategy
+        let userInfo: [CodingUserInfoKey : Any]
+    }
+    
+    /// The options set on the top-level decoder.
+    fileprivate var options: _Options {
+        return _Options(dateDecodingStrategy: dateDecodingStrategy,
+                        dataDecodingStrategy: dataDecodingStrategy,
+                        nonConformingFloatDecodingStrategy: nonConformingFloatDecodingStrategy,
+                        userInfo: userInfo)
+    }
+    
+    // MARK: - Constructing a Dictionary Decoder
+    /// Initializes `self` with default strategies.
+    public init() {}
+    
+    // MARK: - Decoding Values
+    /// Decodes a top-level value of the given type from the given Dictionary representation.
+    ///
+    /// - parameter type: The type of the value to decode.
+    /// - parameter data: The data to decode from.
+    /// - returns: A value of the requested type.
+    /// - throws: `DecodingError.dataCorrupted` if values requested from the payload are corrupted, or if the given data is not valid Dictionary.
+    /// - throws: An error if any value throws an error during decoding.
+    open func decode<T : Decodable>(_ type: T.Type, from dictionary: Any) throws -> T {
+        let topLevel = dictionary
+        let decoder = _UntypedDictionaryDecoder(referencing: topLevel, options: self.options)
+        guard let value = try decoder.unbox(topLevel, as: T.self) else {
+            throw DecodingError.valueNotFound(T.self, DecodingError.Context(codingPath: [], debugDescription: "The given data did not contain a top-level value."))
+        }
+        
+        return value
+    }
+}
+
+// MARK: - _UntypedDictionaryDecoder
+fileprivate class _UntypedDictionaryDecoder : Decoder {
+    // MARK: Properties
+    /// The decoder's storage.
+    fileprivate var storage: _DictionaryDecodingStorage
+    
+    /// Options set on the top-level decoder.
+    fileprivate let options: UntypedDictionaryDecoder._Options
+    
+    /// The path to the current point in encoding.
+    fileprivate(set) public var codingPath: [CodingKey]
+    
+    /// Contextual user-provided information for use during encoding.
+    public var userInfo: [CodingUserInfoKey : Any] {
+        return self.options.userInfo
+    }
+    
+    // MARK: - Initialization
+    /// Initializes `self` with the given top-level container and options.
+    fileprivate init(referencing container: Any, at codingPath: [CodingKey] = [], options: UntypedDictionaryDecoder._Options) {
+        self.storage = _DictionaryDecodingStorage()
+        self.storage.push(container: container)
+        self.codingPath = codingPath
+        self.options = options
+    }
+    
+    // MARK: - Decoder Methods
+    public func container<Key>(keyedBy type: Key.Type) throws -> KeyedDecodingContainer<Key> {
+        guard !(self.storage.topContainer is NSNull) else {
+            throw DecodingError.valueNotFound(KeyedDecodingContainer<Key>.self,
+                                              DecodingError.Context(codingPath: self.codingPath,
+                                                                    debugDescription: "Cannot get keyed decoding container -- found null value instead."))
+        }
+        
+        guard let topContainer = self.storage.topContainer as? [String : Any] else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: [String : Any].self, reality: self.storage.topContainer)
+        }
+        
+        let container = _DictionaryKeyedDecodingContainer<Key>(referencing: self, wrapping: topContainer)
+        return KeyedDecodingContainer(container)
+    }
+    
+    public func unkeyedContainer() throws -> UnkeyedDecodingContainer {
+        guard !(self.storage.topContainer is NSNull) else {
+            throw DecodingError.valueNotFound(UnkeyedDecodingContainer.self,
+                                              DecodingError.Context(codingPath: self.codingPath,
+                                                                    debugDescription: "Cannot get unkeyed decoding container -- found null value instead."))
+        }
+        
+        let topContainer = self.storage.topContainer as? [Any] ?? [self.storage.topContainer]
+        return _DictionaryUnkeyedDecodingContainer(referencing: self, wrapping: topContainer)
+    }
+    
+    public func singleValueContainer() throws -> SingleValueDecodingContainer {
+        return self
+    }
+}
+
+// MARK: - Decoding Storage
+fileprivate struct _DictionaryDecodingStorage {
+    // MARK: Properties
+    /// The container stack.
+    /// Elements may be any one of the Dictionary types (NSNull, NSNumber, String, Array, [String : Any]).
+    private(set) fileprivate var containers: [Any] = []
+    
+    // MARK: - Initialization
+    /// Initializes `self` with no containers.
+    fileprivate init() {}
+    
+    // MARK: - Modifying the Stack
+    fileprivate var count: Int {
+        return self.containers.count
+    }
+    
+    fileprivate var topContainer: Any {
+        precondition(self.containers.count > 0, "Empty container stack.")
+        return self.containers.last!
+    }
+    
+    fileprivate mutating func push(container: Any) {
+        self.containers.append(container)
+    }
+    
+    fileprivate mutating func popContainer() {
+        precondition(self.containers.count > 0, "Empty container stack.")
+        self.containers.removeLast()
+    }
+}
+
+// MARK: Decoding Containers
+fileprivate struct _DictionaryKeyedDecodingContainer<K : CodingKey> : KeyedDecodingContainerProtocol {
+    typealias Key = K
+    
+    // MARK: Properties
+    /// A reference to the decoder we're reading from.
+    private let decoder: _UntypedDictionaryDecoder
+    
+    /// A reference to the container we're reading from.
+    private let container: [String : Any]
+    
+    /// The path of coding keys taken to get to this point in decoding.
+    private(set) public var codingPath: [CodingKey]
+    
+    // MARK: - Initialization
+    /// Initializes `self` by referencing the given decoder and container.
+    fileprivate init(referencing decoder: _UntypedDictionaryDecoder, wrapping container: [String : Any]) {
+        self.decoder = decoder
+        self.container = container
+        self.codingPath = decoder.codingPath
+    }
+    
+    // MARK: - KeyedDecodingContainerProtocol Methods
+    public var allKeys: [Key] {
+        return self.container.keys.compactMap { Key(stringValue: $0) }
+    }
+    
+    public func contains(_ key: Key) -> Bool {
+        return self.container[key.stringValue] != nil
+    }
+    
+    public func decodeNil(forKey key: Key) throws -> Bool {
+        guard let entry = self.container[key.stringValue] else {
+            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(key) (\"\(key.stringValue)\")."))
+        }
+        
+        return entry is NSNull
+    }
+    
+    public func decode(_ type: Bool.Type, forKey key: Key) throws -> Bool {
+        guard let entry = self.container[key.stringValue] else {
+            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(key) (\"\(key.stringValue)\")."))
+        }
+        
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+        
+        guard let value = try self.decoder.unbox(entry, as: Bool.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
+        }
+        
+        return value
+    }
+    
+    public func decode(_ type: Int.Type, forKey key: Key) throws -> Int {
+        guard let entry = self.container[key.stringValue] else {
+            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(key) (\"\(key.stringValue)\")."))
+        }
+        
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+        
+        guard let value = try self.decoder.unbox(entry, as: Int.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
+        }
+        
+        return value
+    }
+    
+    public func decode(_ type: Int8.Type, forKey key: Key) throws -> Int8 {
+        guard let entry = self.container[key.stringValue] else {
+            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(key) (\"\(key.stringValue)\")."))
+        }
+        
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+        
+        guard let value = try self.decoder.unbox(entry, as: Int8.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
+        }
+        
+        return value
+    }
+    
+    public func decode(_ type: Int16.Type, forKey key: Key) throws -> Int16 {
+        guard let entry = self.container[key.stringValue] else {
+            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(key) (\"\(key.stringValue)\")."))
+        }
+        
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+        
+        guard let value = try self.decoder.unbox(entry, as: Int16.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
+        }
+        
+        return value
+    }
+    
+    public func decode(_ type: Int32.Type, forKey key: Key) throws -> Int32 {
+        guard let entry = self.container[key.stringValue] else {
+            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(key) (\"\(key.stringValue)\")."))
+        }
+        
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+        
+        guard let value = try self.decoder.unbox(entry, as: Int32.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
+        }
+        
+        return value
+    }
+    
+    public func decode(_ type: Int64.Type, forKey key: Key) throws -> Int64 {
+        guard let entry = self.container[key.stringValue] else {
+            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(key) (\"\(key.stringValue)\")."))
+        }
+        
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+        
+        guard let value = try self.decoder.unbox(entry, as: Int64.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
+        }
+        
+        return value
+    }
+    
+    public func decode(_ type: UInt.Type, forKey key: Key) throws -> UInt {
+        guard let entry = self.container[key.stringValue] else {
+            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(key) (\"\(key.stringValue)\")."))
+        }
+        
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+        
+        guard let value = try self.decoder.unbox(entry, as: UInt.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
+        }
+        
+        return value
+    }
+    
+    public func decode(_ type: UInt8.Type, forKey key: Key) throws -> UInt8 {
+        guard let entry = self.container[key.stringValue] else {
+            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(key) (\"\(key.stringValue)\")."))
+        }
+        
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+        
+        guard let value = try self.decoder.unbox(entry, as: UInt8.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
+        }
+        
+        return value
+    }
+    
+    public func decode(_ type: UInt16.Type, forKey key: Key) throws -> UInt16 {
+        guard let entry = self.container[key.stringValue] else {
+            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(key) (\"\(key.stringValue)\")."))
+        }
+        
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+        
+        guard let value = try self.decoder.unbox(entry, as: UInt16.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
+        }
+        
+        return value
+    }
+    
+    public func decode(_ type: UInt32.Type, forKey key: Key) throws -> UInt32 {
+        guard let entry = self.container[key.stringValue] else {
+            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(key) (\"\(key.stringValue)\")."))
+        }
+        
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+        
+        guard let value = try self.decoder.unbox(entry, as: UInt32.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
+        }
+        
+        return value
+    }
+    
+    public func decode(_ type: UInt64.Type, forKey key: Key) throws -> UInt64 {
+        guard let entry = self.container[key.stringValue] else {
+            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(key) (\"\(key.stringValue)\")."))
+        }
+        
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+        
+        guard let value = try self.decoder.unbox(entry, as: UInt64.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
+        }
+        
+        return value
+    }
+    
+    public func decode(_ type: Float.Type, forKey key: Key) throws -> Float {
+        guard let entry = self.container[key.stringValue] else {
+            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(key) (\"\(key.stringValue)\")."))
+        }
+        
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+        
+        guard let value = try self.decoder.unbox(entry, as: Float.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
+        }
+        
+        return value
+    }
+    
+    public func decode(_ type: Double.Type, forKey key: Key) throws -> Double {
+        guard let entry = self.container[key.stringValue] else {
+            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(key) (\"\(key.stringValue)\")."))
+        }
+        
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+        
+        guard let value = try self.decoder.unbox(entry, as: Double.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
+        }
+        
+        return value
+    }
+    
+    public func decode(_ type: String.Type, forKey key: Key) throws -> String {
+        guard let entry = self.container[key.stringValue] else {
+            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(key) (\"\(key.stringValue)\")."))
+        }
+        
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+        
+        guard let value = try self.decoder.unbox(entry, as: String.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
+        }
+        
+        return value
+    }
+    
+    public func decode<T : Decodable>(_ type: T.Type, forKey key: Key) throws -> T {
+        guard let entry = self.container[key.stringValue] else {
+            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(key) (\"\(key.stringValue)\")."))
+        }
+        
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+        
+        guard let value = try self.decoder.unbox(entry, as: T.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
+        }
+        
+        return value
+    }
+    
+    public func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type, forKey key: Key) throws -> KeyedDecodingContainer<NestedKey> {
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+        
+        guard let value = self.container[key.stringValue] else {
+            throw DecodingError.keyNotFound(key,
+                                            DecodingError.Context(codingPath: self.codingPath,
+                                                                  debugDescription: "Cannot get \(KeyedDecodingContainer<NestedKey>.self) -- no value found for key \"\(key.stringValue)\""))
+        }
+        
+        guard let dictionary = value as? [String : Any] else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: [String : Any].self, reality: value)
+        }
+        
+        let container = _DictionaryKeyedDecodingContainer<NestedKey>(referencing: self.decoder, wrapping: dictionary)
+        return KeyedDecodingContainer(container)
+    }
+    
+    public func nestedUnkeyedContainer(forKey key: Key) throws -> UnkeyedDecodingContainer {
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+        
+        guard let value = self.container[key.stringValue] else {
+            throw DecodingError.keyNotFound(key,
+                                            DecodingError.Context(codingPath: self.codingPath,
+                                                                  debugDescription: "Cannot get UnkeyedDecodingContainer -- no value found for key \"\(key.stringValue)\""))
+        }
+        
+        guard let array = value as? [Any] else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: [Any].self, reality: value)
+        }
+        
+        return _DictionaryUnkeyedDecodingContainer(referencing: self.decoder, wrapping: array)
+    }
+    
+    private func _superDecoder(forKey key: CodingKey) throws -> Decoder {
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+        
+        let value: Any = self.container[key.stringValue] ?? NSNull()
+        return _UntypedDictionaryDecoder(referencing: value, at: self.decoder.codingPath, options: self.decoder.options)
+    }
+    
+    public func superDecoder() throws -> Decoder {
+        return try _superDecoder(forKey: _DictionaryKey.super)
+    }
+    
+    public func superDecoder(forKey key: Key) throws -> Decoder {
+        return try _superDecoder(forKey: key)
+    }
+}
+
+fileprivate struct _DictionaryUnkeyedDecodingContainer : UnkeyedDecodingContainer {
+    // MARK: Properties
+    /// A reference to the decoder we're reading from.
+    private let decoder: _UntypedDictionaryDecoder
+    
+    /// A reference to the container we're reading from.
+    private let container: [Any]
+    
+    /// The path of coding keys taken to get to this point in decoding.
+    private(set) public var codingPath: [CodingKey]
+    
+    /// The index of the element we're about to decode.
+    private(set) public var currentIndex: Int
+    
+    // MARK: - Initialization
+    /// Initializes `self` by referencing the given decoder and container.
+    fileprivate init(referencing decoder: _UntypedDictionaryDecoder, wrapping container: [Any]) {
+        self.decoder = decoder
+        self.container = container
+        self.codingPath = decoder.codingPath
+        self.currentIndex = 0
+    }
+    
+    // MARK: - UnkeyedDecodingContainer Methods
+    public var count: Int? {
+        return self.container.count
+    }
+    
+    public var isAtEnd: Bool {
+        return self.currentIndex >= self.count!
+    }
+    
+    public mutating func decodeNil() throws -> Bool {
+        guard !self.isAtEnd else {
+            throw DecodingError.valueNotFound(Any?.self, DecodingError.Context(codingPath: self.decoder.codingPath + [_DictionaryKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
+        }
+        
+        if self.container[self.currentIndex] is NSNull {
+            self.currentIndex += 1
+            return true
+        } else {
+            return false
+        }
+    }
+    
+    public mutating func decode(_ type: Bool.Type) throws -> Bool {
+        guard !self.isAtEnd else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_DictionaryKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
+        }
+        
+        self.decoder.codingPath.append(_DictionaryKey(index: self.currentIndex))
+        defer { self.decoder.codingPath.removeLast() }
+        
+        guard let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: Bool.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_DictionaryKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
+        }
+        
+        self.currentIndex += 1
+        return decoded
+    }
+    
+    public mutating func decode(_ type: Int.Type) throws -> Int {
+        guard !self.isAtEnd else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_DictionaryKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
+        }
+        
+        self.decoder.codingPath.append(_DictionaryKey(index: self.currentIndex))
+        defer { self.decoder.codingPath.removeLast() }
+        
+        guard let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: Int.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_DictionaryKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
+        }
+        
+        self.currentIndex += 1
+        return decoded
+    }
+    
+    public mutating func decode(_ type: Int8.Type) throws -> Int8 {
+        guard !self.isAtEnd else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_DictionaryKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
+        }
+        
+        self.decoder.codingPath.append(_DictionaryKey(index: self.currentIndex))
+        defer { self.decoder.codingPath.removeLast() }
+        
+        guard let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: Int8.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_DictionaryKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
+        }
+        
+        self.currentIndex += 1
+        return decoded
+    }
+    
+    public mutating func decode(_ type: Int16.Type) throws -> Int16 {
+        guard !self.isAtEnd else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_DictionaryKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
+        }
+        
+        self.decoder.codingPath.append(_DictionaryKey(index: self.currentIndex))
+        defer { self.decoder.codingPath.removeLast() }
+        
+        guard let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: Int16.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_DictionaryKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
+        }
+        
+        self.currentIndex += 1
+        return decoded
+    }
+    
+    public mutating func decode(_ type: Int32.Type) throws -> Int32 {
+        guard !self.isAtEnd else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_DictionaryKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
+        }
+        
+        self.decoder.codingPath.append(_DictionaryKey(index: self.currentIndex))
+        defer { self.decoder.codingPath.removeLast() }
+        
+        guard let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: Int32.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_DictionaryKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
+        }
+        
+        self.currentIndex += 1
+        return decoded
+    }
+    
+    public mutating func decode(_ type: Int64.Type) throws -> Int64 {
+        guard !self.isAtEnd else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_DictionaryKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
+        }
+        
+        self.decoder.codingPath.append(_DictionaryKey(index: self.currentIndex))
+        defer { self.decoder.codingPath.removeLast() }
+        
+        guard let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: Int64.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_DictionaryKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
+        }
+        
+        self.currentIndex += 1
+        return decoded
+    }
+    
+    public mutating func decode(_ type: UInt.Type) throws -> UInt {
+        guard !self.isAtEnd else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_DictionaryKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
+        }
+        
+        self.decoder.codingPath.append(_DictionaryKey(index: self.currentIndex))
+        defer { self.decoder.codingPath.removeLast() }
+        
+        guard let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: UInt.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_DictionaryKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
+        }
+        
+        self.currentIndex += 1
+        return decoded
+    }
+    
+    public mutating func decode(_ type: UInt8.Type) throws -> UInt8 {
+        guard !self.isAtEnd else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_DictionaryKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
+        }
+        
+        self.decoder.codingPath.append(_DictionaryKey(index: self.currentIndex))
+        defer { self.decoder.codingPath.removeLast() }
+        
+        guard let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: UInt8.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_DictionaryKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
+        }
+        
+        self.currentIndex += 1
+        return decoded
+    }
+    
+    public mutating func decode(_ type: UInt16.Type) throws -> UInt16 {
+        guard !self.isAtEnd else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_DictionaryKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
+        }
+        
+        self.decoder.codingPath.append(_DictionaryKey(index: self.currentIndex))
+        defer { self.decoder.codingPath.removeLast() }
+        
+        guard let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: UInt16.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_DictionaryKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
+        }
+        
+        self.currentIndex += 1
+        return decoded
+    }
+    
+    public mutating func decode(_ type: UInt32.Type) throws -> UInt32 {
+        guard !self.isAtEnd else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_DictionaryKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
+        }
+        
+        self.decoder.codingPath.append(_DictionaryKey(index: self.currentIndex))
+        defer { self.decoder.codingPath.removeLast() }
+        
+        guard let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: UInt32.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_DictionaryKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
+        }
+        
+        self.currentIndex += 1
+        return decoded
+    }
+    
+    public mutating func decode(_ type: UInt64.Type) throws -> UInt64 {
+        guard !self.isAtEnd else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_DictionaryKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
+        }
+        
+        self.decoder.codingPath.append(_DictionaryKey(index: self.currentIndex))
+        defer { self.decoder.codingPath.removeLast() }
+        
+        guard let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: UInt64.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_DictionaryKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
+        }
+        
+        self.currentIndex += 1
+        return decoded
+    }
+    
+    public mutating func decode(_ type: Float.Type) throws -> Float {
+        guard !self.isAtEnd else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_DictionaryKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
+        }
+        
+        self.decoder.codingPath.append(_DictionaryKey(index: self.currentIndex))
+        defer { self.decoder.codingPath.removeLast() }
+        
+        guard let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: Float.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_DictionaryKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
+        }
+        
+        self.currentIndex += 1
+        return decoded
+    }
+    
+    public mutating func decode(_ type: Double.Type) throws -> Double {
+        guard !self.isAtEnd else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_DictionaryKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
+        }
+        
+        self.decoder.codingPath.append(_DictionaryKey(index: self.currentIndex))
+        defer { self.decoder.codingPath.removeLast() }
+        
+        guard let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: Double.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_DictionaryKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
+        }
+        
+        self.currentIndex += 1
+        return decoded
+    }
+    
+    public mutating func decode(_ type: String.Type) throws -> String {
+        guard !self.isAtEnd else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_DictionaryKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
+        }
+        
+        self.decoder.codingPath.append(_DictionaryKey(index: self.currentIndex))
+        defer { self.decoder.codingPath.removeLast() }
+        
+        guard let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: String.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_DictionaryKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
+        }
+        
+        self.currentIndex += 1
+        return decoded
+    }
+    
+    public mutating func decode<T : Decodable>(_ type: T.Type) throws -> T {
+        guard !self.isAtEnd else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_DictionaryKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
+        }
+        
+        self.decoder.codingPath.append(_DictionaryKey(index: self.currentIndex))
+        defer { self.decoder.codingPath.removeLast() }
+        
+        guard let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: T.self) else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_DictionaryKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
+        }
+        
+        self.currentIndex += 1
+        return decoded
+    }
+    
+    public mutating func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type) throws -> KeyedDecodingContainer<NestedKey> {
+        self.decoder.codingPath.append(_DictionaryKey(index: self.currentIndex))
+        defer { self.decoder.codingPath.removeLast() }
+        
+        guard !self.isAtEnd else {
+            throw DecodingError.valueNotFound(KeyedDecodingContainer<NestedKey>.self,
+                                              DecodingError.Context(codingPath: self.codingPath,
+                                                                    debugDescription: "Cannot get nested keyed container -- unkeyed container is at end."))
+        }
+        
+        let value = self.container[self.currentIndex]
+        guard !(value is NSNull) else {
+            throw DecodingError.valueNotFound(KeyedDecodingContainer<NestedKey>.self,
+                                              DecodingError.Context(codingPath: self.codingPath,
+                                                                    debugDescription: "Cannot get keyed decoding container -- found null value instead."))
+        }
+        
+        guard let dictionary = value as? [String : Any] else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: [String : Any].self, reality: value)
+        }
+        
+        self.currentIndex += 1
+        let container = _DictionaryKeyedDecodingContainer<NestedKey>(referencing: self.decoder, wrapping: dictionary)
+        return KeyedDecodingContainer(container)
+    }
+    
+    public mutating func nestedUnkeyedContainer() throws -> UnkeyedDecodingContainer {
+        self.decoder.codingPath.append(_DictionaryKey(index: self.currentIndex))
+        defer { self.decoder.codingPath.removeLast() }
+        
+        guard !self.isAtEnd else {
+            throw DecodingError.valueNotFound(UnkeyedDecodingContainer.self,
+                                              DecodingError.Context(codingPath: self.codingPath,
+                                                                    debugDescription: "Cannot get nested keyed container -- unkeyed container is at end."))
+        }
+        
+        let value = self.container[self.currentIndex]
+        guard !(value is NSNull) else {
+            throw DecodingError.valueNotFound(UnkeyedDecodingContainer.self,
+                                              DecodingError.Context(codingPath: self.codingPath,
+                                                                    debugDescription: "Cannot get keyed decoding container -- found null value instead."))
+        }
+        
+        guard let array = value as? [Any] else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: [Any].self, reality: value)
+        }
+        
+        self.currentIndex += 1
+        return _DictionaryUnkeyedDecodingContainer(referencing: self.decoder, wrapping: array)
+    }
+    
+    public mutating func superDecoder() throws -> Decoder {
+        self.decoder.codingPath.append(_DictionaryKey(index: self.currentIndex))
+        defer { self.decoder.codingPath.removeLast() }
+        
+        guard !self.isAtEnd else {
+            throw DecodingError.valueNotFound(Decoder.self,
+                                              DecodingError.Context(codingPath: self.codingPath,
+                                                                    debugDescription: "Cannot get superDecoder() -- unkeyed container is at end."))
+        }
+        
+        let value = self.container[self.currentIndex]
+        self.currentIndex += 1
+        return _UntypedDictionaryDecoder(referencing: value, at: self.decoder.codingPath, options: self.decoder.options)
+    }
+}
+
+extension _UntypedDictionaryDecoder : SingleValueDecodingContainer {
+    // MARK: SingleValueDecodingContainer Methods
+    private func expectNonNull<T>(_ type: T.Type) throws {
+        guard !self.decodeNil() else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.codingPath, debugDescription: "Expected \(type) but found null value instead."))
+        }
+    }
+    
+    public func decodeNil() -> Bool {
+        return self.storage.topContainer is NSNull
+    }
+    
+    public func decode(_ type: Bool.Type) throws -> Bool {
+        try expectNonNull(Bool.self)
+        return try self.unbox(self.storage.topContainer, as: Bool.self)!
+    }
+    
+    public func decode(_ type: Int.Type) throws -> Int {
+        try expectNonNull(Int.self)
+        return try self.unbox(self.storage.topContainer, as: Int.self)!
+    }
+    
+    public func decode(_ type: Int8.Type) throws -> Int8 {
+        try expectNonNull(Int8.self)
+        return try self.unbox(self.storage.topContainer, as: Int8.self)!
+    }
+    
+    public func decode(_ type: Int16.Type) throws -> Int16 {
+        try expectNonNull(Int16.self)
+        return try self.unbox(self.storage.topContainer, as: Int16.self)!
+    }
+    
+    public func decode(_ type: Int32.Type) throws -> Int32 {
+        try expectNonNull(Int32.self)
+        return try self.unbox(self.storage.topContainer, as: Int32.self)!
+    }
+    
+    public func decode(_ type: Int64.Type) throws -> Int64 {
+        try expectNonNull(Int64.self)
+        return try self.unbox(self.storage.topContainer, as: Int64.self)!
+    }
+    
+    public func decode(_ type: UInt.Type) throws -> UInt {
+        try expectNonNull(UInt.self)
+        return try self.unbox(self.storage.topContainer, as: UInt.self)!
+    }
+    
+    public func decode(_ type: UInt8.Type) throws -> UInt8 {
+        try expectNonNull(UInt8.self)
+        return try self.unbox(self.storage.topContainer, as: UInt8.self)!
+    }
+    
+    public func decode(_ type: UInt16.Type) throws -> UInt16 {
+        try expectNonNull(UInt16.self)
+        return try self.unbox(self.storage.topContainer, as: UInt16.self)!
+    }
+    
+    public func decode(_ type: UInt32.Type) throws -> UInt32 {
+        try expectNonNull(UInt32.self)
+        return try self.unbox(self.storage.topContainer, as: UInt32.self)!
+    }
+    
+    public func decode(_ type: UInt64.Type) throws -> UInt64 {
+        try expectNonNull(UInt64.self)
+        return try self.unbox(self.storage.topContainer, as: UInt64.self)!
+    }
+    
+    public func decode(_ type: Float.Type) throws -> Float {
+        try expectNonNull(Float.self)
+        return try self.unbox(self.storage.topContainer, as: Float.self)!
+    }
+    
+    public func decode(_ type: Double.Type) throws -> Double {
+        try expectNonNull(Double.self)
+        return try self.unbox(self.storage.topContainer, as: Double.self)!
+    }
+    
+    public func decode(_ type: String.Type) throws -> String {
+        try expectNonNull(String.self)
+        return try self.unbox(self.storage.topContainer, as: String.self)!
+    }
+    
+    public func decode<T : Decodable>(_ type: T.Type) throws -> T {
+        try expectNonNull(T.self)
+        return try self.unbox(self.storage.topContainer, as: T.self)!
+    }
+}
+
+// MARK: - Concrete Value Representations
+extension _UntypedDictionaryDecoder {
+    /// Returns the given value unboxed from a container.
+    fileprivate func unbox(_ value: Any, as type: Bool.Type) throws -> Bool? {
+        guard !(value is NSNull) else { return nil }
+        guard let stringValue = value as? String else {throw DecodingError._typeMismatch(at: self.codingPath, expectation: String.self, reality: value)}
+        
+        if let bool = Bool(stringValue) {
+            return bool
+        }
+        
+        throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+    }
+    
+    fileprivate func unbox(_ value: Any, as type: Int.Type) throws -> Int? {
+        guard !(value is NSNull) else { return nil }
+        guard let stringValue = value as? String else {throw DecodingError._typeMismatch(at: self.codingPath, expectation: String.self, reality: value)}
+
+        if let number = Int(stringValue) {
+            return number
+        }
+        
+        throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+    }
+    
+    fileprivate func unbox(_ value: Any, as type: Int8.Type) throws -> Int8? {
+        guard !(value is NSNull) else { return nil }
+        guard let stringValue = value as? String else {throw DecodingError._typeMismatch(at: self.codingPath, expectation: String.self, reality: value)}
+
+        if let number = Int8(stringValue) {
+            return number
+        }
+        
+        throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+    }
+    
+    fileprivate func unbox(_ value: Any, as type: Int16.Type) throws -> Int16? {
+        guard !(value is NSNull) else { return nil }
+        guard let stringValue = value as? String else {throw DecodingError._typeMismatch(at: self.codingPath, expectation: String.self, reality: value)}
+
+        if let number = Int16(stringValue) {
+            return number
+        }
+        
+        throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+    }
+    
+    fileprivate func unbox(_ value: Any, as type: Int32.Type) throws -> Int32? {
+        guard !(value is NSNull) else { return nil }
+        guard let stringValue = value as? String else {throw DecodingError._typeMismatch(at: self.codingPath, expectation: String.self, reality: value)}
+
+        if let number = Int32(stringValue) {
+            return number
+        }
+        
+        throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+    }
+    
+    fileprivate func unbox(_ value: Any, as type: Int64.Type) throws -> Int64? {
+        guard !(value is NSNull) else { return nil }
+        guard let stringValue = value as? String else {throw DecodingError._typeMismatch(at: self.codingPath, expectation: String.self, reality: value)}
+
+        if let number = Int64(stringValue) {
+            return number
+        }
+        
+        throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+    }
+    
+    fileprivate func unbox(_ value: Any, as type: UInt.Type) throws -> UInt? {
+        guard !(value is NSNull) else { return nil }
+        guard let stringValue = value as? String else {throw DecodingError._typeMismatch(at: self.codingPath, expectation: String.self, reality: value)}
+
+        if let number = UInt(stringValue) {
+            return number
+        }
+        
+        throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+    }
+    
+    fileprivate func unbox(_ value: Any, as type: UInt8.Type) throws -> UInt8? {
+        guard !(value is NSNull) else { return nil }
+        guard let stringValue = value as? String else {throw DecodingError._typeMismatch(at: self.codingPath, expectation: String.self, reality: value)}
+
+        if let number = UInt8(stringValue) {
+            return number
+        }
+        
+        throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+    }
+    
+    fileprivate func unbox(_ value: Any, as type: UInt16.Type) throws -> UInt16? {
+        guard !(value is NSNull) else { return nil }
+        guard let stringValue = value as? String else {throw DecodingError._typeMismatch(at: self.codingPath, expectation: String.self, reality: value)}
+
+        if let number = UInt16(stringValue) {
+            return number
+        }
+        
+        throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+    }
+    
+    fileprivate func unbox(_ value: Any, as type: UInt32.Type) throws -> UInt32? {
+        guard !(value is NSNull) else { return nil }
+        guard let stringValue = value as? String else {throw DecodingError._typeMismatch(at: self.codingPath, expectation: String.self, reality: value)}
+
+        if let number = UInt32(stringValue) {
+            return number
+        }
+        
+        throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+    }
+    
+    fileprivate func unbox(_ value: Any, as type: UInt64.Type) throws -> UInt64? {
+        guard !(value is NSNull) else { return nil }
+        guard let stringValue = value as? String else {throw DecodingError._typeMismatch(at: self.codingPath, expectation: String.self, reality: value)}
+
+        if let number = UInt64(stringValue) {
+            return number
+        }
+        
+        throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+    }
+    
+    fileprivate func unbox(_ value: Any, as type: Float.Type) throws -> Float? {
+        guard !(value is NSNull) else { return nil }
+        guard let stringValue = value as? String else {throw DecodingError._typeMismatch(at: self.codingPath, expectation: String.self, reality: value)}
+
+        if let number = Float(stringValue) {
+            return number
+        }
+        
+        throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+    }
+    
+    fileprivate func unbox(_ value: Any, as type: Double.Type) throws -> Double? {
+        guard !(value is NSNull) else { return nil }
+        guard let stringValue = value as? String else {throw DecodingError._typeMismatch(at: self.codingPath, expectation: String.self, reality: value)}
+
+        if let number = Double(stringValue) {
+            return number
+        }
+        
+        throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+    }
+    
+    fileprivate func unbox(_ value: Any, as type: String.Type) throws -> String? {
+        guard !(value is NSNull) else { return nil }
+        guard let stringValue = value as? String else {throw DecodingError._typeMismatch(at: self.codingPath, expectation: String.self, reality: value)}
+
+        return stringValue
+    }
+
+    /*fileprivate func unbox(_ value: Any, as type: Date.Type) throws -> Date? {
+        guard !(value is NSNull) else { return nil }
+        guard let stringValue = value as? String else {throw DecodingError._typeMismatch(at: self.codingPath, expectation: String.self, reality: value)}
+
+        guard let date = Date(stringValue) else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+        }
+        
+        return date
+    }*/
+    
+    fileprivate func unbox(_ value: Any, as type: Data.Type) throws -> Data? {
+        guard !(value is NSNull) else { return nil }
+        guard let stringValue = value as? String else {throw DecodingError._typeMismatch(at: self.codingPath, expectation: String.self, reality: value)}
+
+        switch self.options.dataDecodingStrategy {
+        case .raw:
+            return stringValue.data(using: .utf8)
+        }
+    }
+    
+    fileprivate func unbox(_ value: Any, as type: Decimal.Type) throws -> Decimal? {
+        guard !(value is NSNull) else { return nil }
+        guard let stringValue = value as? String else {throw DecodingError._typeMismatch(at: self.codingPath, expectation: String.self, reality: value)}
+
+        
+        if let number = Double(stringValue) {
+            return Decimal(number)
+        }
+        
+        throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+    }
+    
+    fileprivate func unbox<T : Decodable>(_ value: Any, as type: T.Type) throws -> T? {
+        let decoded: T
+        if T.self == Date.self || T.self == NSDate.self {
+            guard let date = try self.unbox(value, as: Date.self) else { return nil }
+            decoded = date as! T
+        } else if T.self == Data.self || T.self == NSData.self {
+            guard let data = try self.unbox(value, as: Data.self) else { return nil }
+            decoded = data as! T
+        } else if T.self == URL.self || T.self == NSURL.self {
+            guard let urlString = try self.unbox(value, as: String.self) else {
+                return nil
+            }
+            
+            guard let url = URL(string: urlString) else {
+                throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath,
+                                                                        debugDescription: "Invalid URL string."))
+            }
+            
+            decoded = (url as! T)
+        } else if T.self == Decimal.self || T.self == NSDecimalNumber.self {
+            guard let decimal = try self.unbox(value, as: Decimal.self) else { return nil }
+            decoded = decimal as! T
+        } else {
+            self.storage.push(container: value)
+            decoded = try T(from: self)
+            self.storage.popContainer()
+        }
+        
+        return decoded
+    }
+}
+
+//===----------------------------------------------------------------------===//
+// Shared Key Types
+//===----------------------------------------------------------------------===//
+fileprivate struct _DictionaryKey : CodingKey {
+    public var stringValue: String
+    public var intValue: Int?
+    
+    public init?(stringValue: String) {
+        self.stringValue = stringValue
+        self.intValue = nil
+    }
+    
+    public init?(intValue: Int) {
+        self.stringValue = "\(intValue)"
+        self.intValue = intValue
+    }
+    
+    fileprivate init(index: Int) {
+        self.stringValue = "Index \(index)"
+        self.intValue = index
+    }
+    
+    fileprivate static let `super` = _DictionaryKey(stringValue: "super")!
+}
+
+//===----------------------------------------------------------------------===//
+// Shared ISO8601 Date Formatter
+//===----------------------------------------------------------------------===//
+// NOTE: This value is implicitly lazy and _must_ be lazy. We're compiled against the latest SDK (w/ ISO8601DateFormatter), but linked against whichever Foundation the user has. ISO8601DateFormatter might not exist, so we better not hit this code path on an older OS.
+@available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
+fileprivate var _iso8601Formatter: ISO8601DateFormatter = {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = .withInternetDateTime
+    return formatter
+}()
+
+//===----------------------------------------------------------------------===//
+// Error Utilities
+//===----------------------------------------------------------------------===//
+fileprivate extension EncodingError {
+    /// Returns a `.invalidValue` error describing the given invalid floating-point value.
+    ///
+    ///
+    /// - parameter value: The value that was invalid to encode.
+    /// - parameter path: The path of `CodingKey`s taken to encode this value.
+    /// - returns: An `EncodingError` with the appropriate path and debug description.
+    fileprivate static func _invalidFloatingPointValue<T : FloatingPoint>(_ value: T, at codingPath: [CodingKey]) -> EncodingError {
+        let valueDescription: String
+        if value == T.infinity {
+            valueDescription = "\(T.self).infinity"
+        } else if value == -T.infinity {
+            valueDescription = "-\(T.self).infinity"
+        } else {
+            valueDescription = "\(T.self).nan"
+        }
+        
+        let debugDescription = "Unable to encode \(valueDescription) directly in Dictionary. Use DictionaryEncoder.NonConformingFloatEncodingStrategy.convertToString to specify how the value should be encoded."
+        return .invalidValue(value, EncodingError.Context(codingPath: codingPath, debugDescription: debugDescription))
+    }
+}
+

--- a/Sources/AWSSDKSwiftCore/Decoder/UntypedDictionaryDecoder.swift
+++ b/Sources/AWSSDKSwiftCore/Decoder/UntypedDictionaryDecoder.swift
@@ -132,9 +132,8 @@ fileprivate class _UntypedDictionaryDecoder : Decoder {
     // MARK: - Decoder Methods
     public func container<Key>(keyedBy type: Key.Type) throws -> KeyedDecodingContainer<Key> {
         guard !(self.storage.topContainer is NSNull) else {
-            throw DecodingError.valueNotFound(KeyedDecodingContainer<Key>.self,
-                                              DecodingError.Context(codingPath: self.codingPath,
-                                                                    debugDescription: "Cannot get keyed decoding container -- found null value instead."))
+            let container = _DictionaryKeyedDecodingContainer<Key>(referencing: self, wrapping: [:])
+            return KeyedDecodingContainer(container)
         }
         
         guard let topContainer = self.storage.topContainer as? [String : Any] else {
@@ -147,9 +146,7 @@ fileprivate class _UntypedDictionaryDecoder : Decoder {
     
     public func unkeyedContainer() throws -> UnkeyedDecodingContainer {
         guard !(self.storage.topContainer is NSNull) else {
-            throw DecodingError.valueNotFound(UnkeyedDecodingContainer.self,
-                                              DecodingError.Context(codingPath: self.codingPath,
-                                                                    debugDescription: "Cannot get unkeyed decoding container -- found null value instead."))
+            return _DictionaryUnkeyedDecodingContainer(referencing: self, wrapping: [])
         }
         
         let topContainer = self.storage.topContainer as? [Any] ?? [self.storage.topContainer]

--- a/Sources/AWSSDKSwiftCore/Serializer/XMLNodeSerializer.swift
+++ b/Sources/AWSSDKSwiftCore/Serializer/XMLNodeSerializer.swift
@@ -21,7 +21,7 @@ private func dquote(_ str: String) -> String {
 }
 
 private func formatAsJSONValue(_ str: String) -> String {
-    if let number = Double(str) {
+    /*if let number = Double(str) {
         if number.truncatingRemainder(dividingBy: 1) == 0 {
             return Int(number).description
         } else {
@@ -31,9 +31,9 @@ private func formatAsJSONValue(_ str: String) -> String {
         return str.lowercased()
     } else if str == "null" {
         return str
-    } else {
+    } else {*/
         return dquote(str)
-    }
+//    }
 }
 
 public class XMLNodeSerializer {

--- a/Sources/AWSSDKSwiftCore/Serializer/XMLNodeSerializer.swift
+++ b/Sources/AWSSDKSwiftCore/Serializer/XMLNodeSerializer.swift
@@ -21,19 +21,7 @@ private func dquote(_ str: String) -> String {
 }
 
 private func formatAsJSONValue(_ str: String) -> String {
-    /*if let number = Double(str) {
-        if number.truncatingRemainder(dividingBy: 1) == 0 {
-            return Int(number).description
-        } else {
-            return number.description
-        }
-    } else if ["false", "true"].contains(where: { $0 == str.lowercased() }) {
-        return str.lowercased()
-    } else if str == "null" {
-        return str
-    } else {*/
-        return dquote(str)
-//    }
+    return dquote(str)
 }
 
 public class XMLNodeSerializer {

--- a/Sources/AWSSDKSwiftCore/Serializer/XMLNodeSerializer.swift
+++ b/Sources/AWSSDKSwiftCore/Serializer/XMLNodeSerializer.swift
@@ -57,6 +57,8 @@ public class XMLNodeSerializer {
                     xmlStr += "<\(node.elementName)\(attr)>"
                     _serialize(nodeTree: node.children)
                     xmlStr += "</\(node.elementName)>"
+                } else if node.hasNoValue() {
+                    xmlStr += "<\(node.elementName)\(attr)/>"
                 }
             }
         }
@@ -106,6 +108,8 @@ public class XMLNodeSerializer {
                 } else {
                     _processNodeWithChildren(node, &jsonStr, arrayNodes, keys)
                 }
+            } else if node.hasNoValue() {
+                jsonStr += "null"
             }
             return jsonStr
         }

--- a/Sources/AWSSDKSwiftCore/Serializer/XMLNodeSerializer.swift
+++ b/Sources/AWSSDKSwiftCore/Serializer/XMLNodeSerializer.swift
@@ -85,42 +85,46 @@ public class XMLNodeSerializer {
 
             for (index, node) in nodeTree.enumerated() {
                 jsonStr += dquote(node.elementName) + ":"
-
-                if node.hasArrayValue() {
-                    jsonStr += "[" +  node.values.map({ formatAsJSONValue($0) }).joined(separator: ",") + "]"
-                    if nodeTree.count-index > 1 { jsonStr+="," }
-                }
-
-                if node.hasSingleValue() {
-                    jsonStr += formatAsJSONValue(node.values[0])
-                    if nodeTree.count-index > 1 { jsonStr+="," }
-                }
-
-                if node.hasChildren() {
-                    var grouped: [String: [XMLNode]] = [:]
-                    node.children.forEach {
-                        if grouped[$0.elementName] == nil { grouped[$0.elementName] = [] }
-                        grouped[$0.elementName]?.append($0)
-                    }
-                    let arrayNodes = grouped.filter({ $0.value.count > 1 })
-                    let keys = arrayNodes.map({ $0.key })
-
-                    if let memberNode = node.children.first, memberNode.elementName.lowerFirst() == "member" {
-                        _processNodeWithMember(node, memberNode, &jsonStr, arrayNodes, keys)
-                    } else {
-                        _processNodeWithChildren(node, &jsonStr, arrayNodes, keys)
-                    }
-
-                    if nodeTree.count-1-index > 0 { jsonStr += "," }
-                }
+                jsonStr += _serializeValue(node: node)
+                if nodeTree.count-index > 1 { jsonStr+="," }
             }
 
             return jsonStr
         }
 
+        func _serializeValue(node: XMLNode) -> String {
+            var jsonStr = ""
+            if node.hasArrayValue() {
+                jsonStr += "[" +  node.values.map({ formatAsJSONValue($0) }).joined(separator: ",") + "]"
+            }
+            
+            if node.hasSingleValue() {
+                jsonStr += formatAsJSONValue(node.values[0])
+            }
+            
+            if node.hasChildren() {
+                var grouped: [String: [XMLNode]] = [:]
+                node.children.forEach {
+                    if grouped[$0.elementName] == nil { grouped[$0.elementName] = [] }
+                    grouped[$0.elementName]?.append($0)
+                }
+                let arrayNodes = grouped.filter({ $0.value.count > 1 })
+                let keys = arrayNodes.map({ $0.key })
+                
+                if let memberNode = node.children.first, memberNode.elementName.lowerFirst() == "member" {
+                    _processNodeWithMember(node, memberNode, &jsonStr, arrayNodes, keys)
+                } else if let memberNode = node.children.first, memberNode.elementName.lowerFirst() == "entry" {
+                    _processNodeWithEntry(node, memberNode, &jsonStr, arrayNodes, keys)
+                } else {
+                    _processNodeWithChildren(node, &jsonStr, arrayNodes, keys)
+                }
+            }
+            return jsonStr
+        }
+        
         func _processNodeWithMember(_ node: XMLNode, _ memberNode: XMLNode, _ jsonStr: inout String, _ arrayNodes: [String: [XMLNode]], _ keys: [String]) {
             let memberChildren: [XMLNode]
-
+            
             if arrayNodes.isEmpty {
                 if memberNode.children.isEmpty {
                     jsonStr += "["
@@ -146,7 +150,34 @@ public class XMLNodeSerializer {
                 }
             }
         }
-
+        
+        func _processNodeWithEntry(_ node: XMLNode, _ memberNode: XMLNode, _ jsonStr: inout String, _ arrayNodes: [String: [XMLNode]], _ keys: [String]) {
+            let memberChildren: [XMLNode]
+            
+            if arrayNodes.isEmpty {
+                if memberNode.children.isEmpty {
+                    jsonStr += "["
+                    jsonStr.append(contentsOf: memberNode.values.flatMap(formatAsJSONValue))
+                    jsonStr += "]"
+                } else {
+                    jsonStr += "{"
+                    memberChildren = memberNode.children.filter({ !keys.contains($0.elementName) })
+                    jsonStr += _serialize(nodeTree: memberChildren)
+                    jsonStr += "}"
+                }
+            } else {
+                memberChildren = node.children.filter({ !keys.contains($0.elementName) })
+                for (_, nodes) in arrayNodes {
+                    jsonStr += "{"
+                    let keyValuePairs = nodes.map({ return (key: $0.children.first(where:{$0.elementName.lowerFirst() == "key"}), value: $0.children.first(where:{$0.elementName.lowerFirst() == "value"})) })
+                    let validKeyValuePairs = keyValuePairs.filter({ ($0.key != nil && $0.value != nil)})
+                    jsonStr += validKeyValuePairs.map({"\(_serializeValue(node:$0.key!)):\(_serializeValue(node:$0.value!))"}).joined(separator: ",")
+                    jsonStr += "}"
+                    if memberChildren.count > 0 { jsonStr += "," }
+                }
+            }
+        }
+        
         func _processNodeWithChildren(_ node: XMLNode, _ jsonStr: inout String, _ arrayNodes: [String: [XMLNode]], _ keys: [String]) {
             jsonStr += "{"
             let newChildren = node.children.filter({ !keys.contains($0.elementName) })

--- a/Sources/AWSSDKSwiftCore/XML/XMLNode.swift
+++ b/Sources/AWSSDKSwiftCore/XML/XMLNode.swift
@@ -17,6 +17,10 @@ public class XMLNode {
         return values.count == 0
     }
     
+    func hasNoValue() -> Bool {
+        return values.count == 0
+    }
+    
     func hasSingleValue() -> Bool {
         return values.count == 1
     }

--- a/Sources/AWSSDKSwiftCore/XML/XMLParser.swift
+++ b/Sources/AWSSDKSwiftCore/XML/XMLParser.swift
@@ -79,9 +79,6 @@ public class XML2Parser: NSObject, XMLParserDelegate {
     
     public func parser(_ parser: XMLParser, didEndElement elementName: String, namespaceURI: String?, qualifiedName qName: String?) {
         if let currentElementName = currentNode?.elementName, currentElementName.lowercased() == elementName.lowercased() {
-            if currentNode?.children.count == 0, currentNode?.values.count == 0 {
-                currentNode?.values.append("null")
-            }
             currentNode = currentNode?.parent
         }
         lastElementName = elementName.upperFirst()

--- a/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
@@ -19,6 +19,10 @@ class AWSClientTests: XCTestCase {
         ]
 
         let value = "<html><body><a href=\"https://redsox.com\">Test</a></body></html>"
+
+        private enum CodingKeys: String, CodingKey {
+            case value = "Value"
+        }
     }
 
     struct E: AWSShape {
@@ -75,7 +79,7 @@ class AWSClientTests: XCTestCase {
                 input: input
             )
             XCTAssertEqual(awsRequest.url.absoluteString, "\(sesClient.endpoint)/")
-            XCTAssertEqual(String(describing: awsRequest.body), "text(\"Action=SendEmail&Version=2013-12-01&value=%3Chtml%3E%3Cbody%3E%3Ca%20href%3D%22https://redsox.com%22%3ETest%3C/a%3E%3C/body%3E%3C/html%3E\")")
+            XCTAssertEqual(String(describing: awsRequest.body), "text(\"Action=SendEmail&Value=%3Chtml%3E%3Cbody%3E%3Ca%20href%3D%22https://redsox.com%22%3ETest%3C/a%3E%3C/body%3E%3C/html%3E&Version=2013-12-01\")")
             let nioRequest = try awsRequest.toNIORequest()
             XCTAssertEqual(nioRequest.head.headers["Content-Type"][0], "application/x-www-form-urlencoded")
         } catch {

--- a/Tests/AWSSDKSwiftCoreTests/SerializersTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/SerializersTests.swift
@@ -115,7 +115,8 @@ class SerializersTests: XCTestCase {
         XCTAssertEqual(swmSecondFromJson["memberKey2"], "memberValue2")
     }
 
-    func testLowercasedBoolean() {
+    // not a valid test
+    func testLowercasedBoolean() {/*
         let node = try! XML2Parser(data: "<A>True</A>".data(using: .utf8)!).parse()
         let str = XMLNodeSerializer(node: node).serializeToJSON()
         XCTAssertEqual(str, "{\"A\":true}")
@@ -123,7 +124,7 @@ class SerializersTests: XCTestCase {
         let outputDict = try! JSONSerialization.jsonObject(with: str.data(using: .utf8)!, options: []) as? [String: Any] ?? [:]
         XCTAssertEqual(outputDict["A"] as? Bool, true)
         XCTAssertEqual(outputDict.count, 1)
-    }
+    */}
 
     func testSerializeToFlatDictionary() {
         let data = try! JSONEncoder().encode(A())
@@ -140,7 +141,7 @@ class SerializersTests: XCTestCase {
         return [
             ("testSerializeToXML", testSerializeToXML),
             ("testSerializeToDictionaryAndJSON", testSerializeToDictionaryAndJSON),
-            ("testLowercasedBoolean", testLowercasedBoolean),
+//            ("testLowercasedBoolean", testLowercasedBoolean),
             ("testSerializeToFlatDictionary", testSerializeToFlatDictionary)
         ]
     }

--- a/Tests/AWSSDKSwiftCoreTests/XMLParserTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/XMLParserTests.swift
@@ -18,15 +18,15 @@ class XML2ParserTests: XCTestCase {
             ("testSerializeJSON", testSerializeJSON)
         ]
     }
-    
+
     var dataSourceXML: Data {
         return "<Error>\n<Hoge><Fuga>aaaaa</Fuga><Fuga>bbbbb</Fuga><Foo>foobar</Foo></Hoge>\n<Code>SignatureDoesNotMatch</Code>\n<Message>\nThe request signature we calculated does not match the signature you provided. Check your key and signing method.\n</Message>\n<AWSAccessKeyId>AKIAJBYT3ZMEZF7Q5MSQ</AWSAccessKeyId>\n<StringToSign>\nAWS4-HMAC-SHA256 20170404T052101Z 20170404/ap-northeast-1/s3/aws4_request 07f340ff9b3aa2329b665ea08b5635a95726f2550b9892ef83b57796d142402f\n</StringToSign>\n<SignatureProvided>\n8005f7c0ed4b2591cb5a08a4da89fc1e6b8f1eb726135ff4cb2beb2da84474fe?content-type=application/json\n</SignatureProvided>\n<StringToSignBytes>\n41 57 53 34 2d 48 4d 41 43 2d 53 48 41 32 35 36 0a 32 30 31 37 30 34 30 34 54 30 35 32 31 30 31 5a 0a 32 30 31 37 30 34 30 34 2f 61 70 2d 6e 6f 72 74 68 65 61 73 74 2d 31 2f 73 33 2f 61 77 73 34 5f 72 65 71 75 65 73 74 0a 30 37 66 33 34 30 66 66 39 62 33 61 61 32 33 32 39 62 36 36 35 65 61 30 38 62 35 36 33 35 61 39 35 37 32 36 66 32 35 35 30 62 39 38 39 32 65 66 38 33 62 35 37 37 39 36 64 31 34 32 34 30 32 66\n</StringToSignBytes>\n<CanonicalRequest>\nGET /foo X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=AKIAJBYT3ZMEZF7Q5MSQ%2F20170404%2Fap-northeast-1%2Fs3%2Faws4_request&X-Amz-Date=20170404T052101Z&X-Amz-Expires=86400&X-Amz-SignedHeaders=host&location= host:s3-ap-northeast-1.amazonaws.com host UNSIGNED-PAYLOAD\n</CanonicalRequest>\n<CanonicalRequestBytes>\n47 45 54 0a 2f 63 68 61 74 63 61 73 74 2d 73 74 61 67 69 6e 67 0a 58 2d 41 6d 7a 2d 41 6c 67 6f 72 69 74 68 6d 3d 41 57 53 34 2d 48 4d 41 43 2d 53 48 41 32 35 36 26 58 2d 41 6d 7a 2d 43 6f 6e 74 65 6e 74 2d 53 68 61 32 35 36 3d 55 4e 53 49 47 4e 45 44 2d 50 41 59 4c 4f 41 44 26 58 2d 41 6d 7a 2d 43 72 65 64 65 6e 74 69 61 6c 3d 41 4b 49 41 4a 42 59 54 33 5a 4d 45 5a 46 37 51 35 4d 53 51 25 32 46 32 30 31 37 30 34 30 34 25 32 46 61 70 2d 6e 6f 72 74 68 65 61 73 74 2d 31 25 32 46 73 33 25 32 46 61 77 73 34 5f 72 65 71 75 65 73 74 26 58 2d 41 6d 7a 2d 44 61 74 65 3d 32 30 31 37 30 34 30 34 54 30 35 32 31 30 31 5a 26 58 2d 41 6d 7a 2d 45 78 70 69 72 65 73 3d 38 36 34 30 30 26 58 2d 41 6d 7a 2d 53 69 67 6e 65 64 48 65 61 64 65 72 73 3d 68 6f 73 74 26 6c 6f 63 61 74 69 6f 6e 3d 0a 68 6f 73 74 3a 73 33 2d 61 70 2d 6e 6f 72 74 68 65 61 73 74 2d 31 2e 61 6d 61 7a 6f 6e 61 77 73 2e 63 6f 6d 0a 0a 68 6f 73 74 0a 55 4e 53 49 47 4e 45 44 2d 50 41 59 4c 4f 41 44\n</CanonicalRequestBytes>\n<RequestId>95C9643CC5D5DA03</RequestId>\n<HostId>\nq6hqG4Dfdh4fADOc4ow9OPrBnBdo5lRGVKJixkzT70N0z8zo0/2bjZ/a+LS6pneiuTCVEXYtP1E=\n</HostId>\n</Error>".data(using: .utf8)!
     }
-    
+
     func testparse() {
         let parser = XML2Parser(data: dataSourceXML)
         let node = try! parser.parse()
-        
+
         XCTAssertEqual(node.elementName, "Error")
         XCTAssertEqual(node.children.first!.elementName, "Hoge")
         XCTAssertEqual(node.children.first!.children.first!.elementName, "Fuga")
@@ -47,10 +47,10 @@ class XML2ParserTests: XCTestCase {
         let node = try! parser.parse()
         let jsonString = XMLNodeSerializer(node: node).serializeToJSON()
         XCTAssertEqual(jsonString, """
-{"BackendServerDescriptions":[{"InstancePort":80,"PolicyNames":["TFEnableProxyProtocol"]},{"InstancePort":443,"PolicyNames":["TFEnableProxyProtocol"]}]}
+{"BackendServerDescriptions":[{"InstancePort":"80","PolicyNames":["TFEnableProxyProtocol"]},{"InstancePort":"443","PolicyNames":["TFEnableProxyProtocol"]}]}
 """)
     }
-    
+
     func testSerializeJSON() {
         let parser = XML2Parser(data: dataSourceXML)
         let node = try! parser.parse()
@@ -61,4 +61,3 @@ class XML2ParserTests: XCTestCase {
     }
 
 }
-


### PR DESCRIPTION
These changes fix a number of issues relating to serialization of AWSShapes as queries and parsing of response XML.

1. UntypedDictionaryDecoder: Currently when response xml is parsed, it is converted to json, then a dictionary and then into AWSShapes. During the conversion from xml to json the types of values are guessed by their contents. So a number becomes an integer, "true" becomes a boolean etc. This causes an issue when a number is used for a string. Although we want a string we get integer and then we get a typeMismatch error during the decode to AWSShape. I have fixed this by not assuming types during the xml to json conversion (everything is a string). Then I added an UntypedDictionaryDecoder which is an exact replica of the DictionaryDecoder except the unbox functions attempt to do a string to type conversion instead of just returning the type. Fixes``` STS.GetCallerIdentity``` (still need to add ```public init() {} ``` to ```GetCallerIdentityRequest``` to get this working).

2. When encoding AWSShapes to queries strings dictionaries are serialised incorrectly (reported in https://github.com/swift-aws/aws-sdk-swift/issues/106). This change fixes that. I replaced the convert AWSShape to json and then flat dictionary with encodeToQueryDictionary() which creates the flat dictionary directly from the AWSShape. Fixes many SNS functions which include attribute dictionaries, including ```SNS.CreatePlatformApplication, SNS.CreateEndpoint, SNS.Subscribe...```.

3. XMLNodeSerializer.serializeToJson() never supported the output of dictionaries. This change fixes that. Fixes functions that return dictionaries in xml, like ```SNS.GetEndpointAttributes```. 

4. The final fix is to ensure query params with no value passed through to createAWSRequest() alongside the path actually get added to the final url. Previously the param was added to the queryParams dictionary. Adding nil to a dictionary only removes a value at that key. Because of this params with no value were never getting added onto the final url. Fixes any function whose path is of the from "/path?query" like ```S3.GetBucketTagging```.

5. Changed some tests where assumptions had been made which aren't necessarily valid. ie anything where type is guessed at when parsing xml. 

I have tried to keep all of these changes as isolated as possible. The one I would suggest might cause any issues is number 1 as it changes how xml is converted to json. The resultant json won't have typed data in it anymore, everything will be strings. I only came across issue 4 because I was trying out various services that used xml to verify this was ok.

Sorry these are all bunched into one pull request. I can separate them out if necessary  