### PR TITLE
Resurrect custom endpoint request

### DIFF
--- a/Sources/AWSSDKSwiftCore/Message/AWSRequest.swift
+++ b/Sources/AWSSDKSwiftCore/Message/AWSRequest.swift
@@ -30,6 +30,20 @@ extension URL {
     }
 }
 
+extension HTTPRequestHead {
+    var hostWithPort: String? {
+        return URL(string: uri)?.hostWithPort
+    }
+    
+    var host: String? {
+        return URL(string: uri)?.host
+    }
+    
+    var port: Int? {
+        return URL(string: uri)?.port
+    }
+}
+
 public struct AWSRequest {
     public let region: Region
     public var url: URL

--- a/Sources/AWSSDKSwiftCore/Signers/V4.swift
+++ b/Sources/AWSSDKSwiftCore/Signers/V4.swift
@@ -42,7 +42,7 @@ extension Signers {
             return sha256(data).hexdigest()
         }
 
-        public init(credential: CredentialProvider, region: Region, service: String, endpoint: String?) {
+        public init(credential: CredentialProvider, region: Region, service: String, endpoint: String? = nil) {
             self.credential = credential
             self.region = region
             self.service = service

--- a/Sources/AWSSDKSwiftCore/Signers/V4.swift
+++ b/Sources/AWSSDKSwiftCore/Signers/V4.swift
@@ -16,6 +16,8 @@ extension Signers {
         public let region: Region
 
         public let service: String
+        
+        public let endpoint: String?
 
         let identifier = "aws4_request"
 
@@ -40,10 +42,11 @@ extension Signers {
             return sha256(data).hexdigest()
         }
 
-        public init(credential: CredentialProvider, region: Region, service: String) {
+        public init(credential: CredentialProvider, region: Region, service: String, endpoint: String?) {
             self.credential = credential
             self.region = region
             self.service = service
+            self.endpoint = endpoint
         }
 
         public func signedURL(url: URL, date: Date = Date(), expires: Int = 86400) -> URL {
@@ -126,7 +129,7 @@ extension Signers {
         }
 
         func getCredential() -> CredentialProvider {
-            if credential.isEmpty() || credential.nearExpiration() {
+            if endpoint == nil && (credential.isEmpty() || credential.nearExpiration()) {
                 do {
                     self.credential = try MetaDataService.getCredential()
                 } catch {

--- a/Tests/AWSSDKSwiftCoreTests/SignersV4Tests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/SignersV4Tests.swift
@@ -20,7 +20,8 @@ class SignersV4Tests: XCTestCase {
             ("testCanonicalRequest", testCanonicalRequest),
             ("testSignature", testSignature),
             ("testSignedHeadersForS3", testSignedHeadersForS3),
-            ("testSignedQuery", testSignedQuery)
+            ("testSignedQuery", testSignedQuery),
+            ("testGivingCustomEndpointAndEmptyCredential", testGivingCustomEndpointAndEmptyCredential)
         ]
     }
 
@@ -144,5 +145,15 @@ class SignersV4Tests: XCTestCase {
         let signedURL = sign.signedURL(url: url, date: requestDate)
 
         XCTAssertEqual(signedURL.absoluteString, "https://s3-apnortheast1.amazon.com?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=key%2F20170101%2Fap-northeast-1%2Fs3%2Faws4_request&X-Amz-Date=20170101T000000Z&X-Amz-Expires=86400&X-Amz-SignedHeaders=host&X-Amz-Signature=c3c920a3b89cb39b01ef6f99228e4cfae5fc8a4ab5de9c5b4ad96e9b05ee0f61")
+    }
+    
+    func testGivingCustomEndpointAndEmptyCredential() {
+        let url = URL(string: "http://localhost:8000")!
+        
+        let emptyCred = Credential(accessKeyId: "", secretAccessKey: "")
+        let sign = Signers.V4(credential: emptyCred, region: .apnortheast1, service: "s3", endpoint: url.absoluteString)
+        
+        let headers = sign.signedHeaders(url: url, headers: [:], method: "PUT", bodyData: Data())
+        XCTAssertEqual(headers["Host"], "localhost:8000")
     }
 }


### PR DESCRIPTION
Hi, I'm back.
Today I tried to request dynamodb-local through custom endpoint like...
```
DynamoDB(endpoint: "http://localhost:8000")
```
But current AWSClient seems to lost the function of custom endpoint.
(`MetaDataService.getCredential()` is always called and attempt to connect `169.254.x.x` when the credential is empty.)
So I fixed it to connect the custom endpoint when it's given.