### PR TITLE
Incorrect stringToSign created for API calls that include query parameters without assignation

### DIFF
--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -365,7 +365,11 @@ extension AWSClient {
         // add new queries to query item array. These need to be added to the queryItems list instead of the queryParams dictionary as added nil items to a dictionary doesn't add a value.
         if let pathQueryItems = parsedPath.queryItems {
             for item in pathQueryItems {
-                queryItems.append(URLQueryItem(name:item.name, value:item.value))
+                if let value = item.value {
+                    queryItems.append(URLQueryItem(name:item.name, value:value))
+                } else {
+                    queryItems.append(URLQueryItem(name:item.name, value:""))
+                }
             }
         }
 
@@ -407,7 +411,7 @@ extension AWSClient {
             if let value = dict[key] {
                 queryItems.append(URLQueryItem(name: key, value: String(describing: value)))
             } else {
-                queryItems.append(URLQueryItem(name: key, value: nil))
+                queryItems.append(URLQueryItem(name: key, value: ""))
             }
         }
         return queryItems.isEmpty ? nil : queryItems


### PR DESCRIPTION
If you have a path that includes a query parameter without an "=" sign the stringToSign that is built during the V4 signature construction is wrong. The code was outputting the query parameter without the "=" sign. AWS expects the "=" to be there. 

It seems that this only affects a number of S3 calls and a couple of calls in Cloudfront. I have checked both of systems and the code fixes the issue. This fixes https://github.com/swift-aws/aws-sdk-swift/issues/117