### PR TITLE
Fail response future when connection fails

### DIFF
--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -105,14 +105,16 @@ extension AWSClient {
         let client = HTTPClient(hostname: nioRequest.head.headers["Host"].first!, port: 443)
         let future = try client.connect(nioRequest)
 
-        //TODO(jmca) don't block
-        let response = try future.wait()
-
-        client.close { error in
-            if let error = error {
-                print("Error closing connection: \(error)")
+        future.whenComplete {
+            client.close { error in
+                if let error = error {
+                    print("Error closing connection: \(error)")
+                }
             }
         }
+
+        //TODO(jmca) don't block
+        let response = try future.wait()
 
         return response
     }

--- a/Sources/AWSSDKSwiftCore/HTTPClient.swift
+++ b/Sources/AWSSDKSwiftCore/HTTPClient.swift
@@ -166,6 +166,9 @@ public final class HTTPClient {
                 buffer.write(bytes: body)
                 channel.write(NIOAny(HTTPClientRequestPart.body(.byteBuffer(buffer))), promise: nil)
                 return channel.writeAndFlush(NIOAny(HTTPClientRequestPart.end(nil)))
+            }
+            .whenFailure { error in
+                response.fail(error: error)
         }
         return response.futureResult
     }


### PR DESCRIPTION
If there was no connection a noConnection error is thrown and the ClientBootstrap channel is never initialized. This means the response eventloopFuture is never connected up and the code will hang when you wait on it. 

To fix this I have added a thenIfErrorThrowing to catch the error and then set the response to fail inside there. 

Also added code to ensure the client.close() is always run