### PR TITLE
Fix '=' sign being percent encoded twice

### DIFF
--- a/Sources/AWSSDKSwiftCore/Signers/V4.swift
+++ b/Sources/AWSSDKSwiftCore/Signers/V4.swift
@@ -16,7 +16,7 @@ extension Signers {
         public let region: Region
 
         public let service: String
-        
+
         public let endpoint: String?
 
         let identifier = "aws4_request"
@@ -66,7 +66,7 @@ extension Signers {
             url.query?.components(separatedBy: "&").forEach {
                 var q = $0.components(separatedBy: "=")
                 if q.count == 2 {
-                    queries.append(URLQueryItem(name: q[0], value: q[1].addingPercentEncoding(withAllowedCharacters: .urlHostAllowed)))
+                    queries.append(URLQueryItem(name: q[0], value: V4.awsUriEncode(q[1].removingPercentEncoding!)))
                 } else {
                     queries.append(URLQueryItem(name: q[0], value: nil))
                 }


### PR DESCRIPTION
It is first encoded in AWSClient.createAWSRequest() when URLComponents.queryItems is set. Then in V4.signedURL() when building the query array for the signature it is percent encoded again. This gives
us %253D instead of %3D. Therefore the signature calculation is incorrect. I fixed this by undoing the encoding before re-encoding with V4.awsUriEncode().

This fixes S3.listObjectV2() when you are supplying a continuation token that contains an '=' sign.