### PR TITLE
Add percent encoded characters for urlEncodedQueryParams

### DIFF
--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -442,13 +442,20 @@ extension AWSClient {
         )
     }
 
+    static let queryAllowedCharacters = CharacterSet(charactersIn:"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~:/")
     fileprivate func urlEncodeQueryParams(fromDictionary dict: [String:Any]) -> String? {
-        var components = URLComponents()
-        components.queryItems = urlQueryItems(fromDictionary: dict)
-        if components.queryItems != nil, let url = components.url {
-            return url.query
+        guard dict.count > 0 else {return nil}
+        var query = ""
+        let keys = Array(dict.keys).sorted()
+
+        for iterator in keys.enumerated() {
+            let value = dict[iterator.element]
+            query += iterator.element + "=" + (String(describing: value ?? "").addingPercentEncoding(withAllowedCharacters: AWSClient.queryAllowedCharacters) ?? "")
+            if iterator.offset < dict.count - 1 {
+                query += "&"
+            }
         }
-        return nil
+        return query
     }
 
     fileprivate func urlQueryItems(fromDictionary dict: [String:Any]) -> [URLQueryItem]? {


### PR DESCRIPTION
The query string returned by AWSClient.urlEncodedQueryParams() did not percent encode enough characters. In particular it didn't encode the + sign. The function used URLComponents() to generate it's query params text. This would percent encode some characters but not all. I couldn't send it already percent encoded text as that percent encode the '%' signs. So instead I wrote a version which didn't use the URLComponents at all.

This fixes https://github.com/swift-aws/aws-sdk-swift/issues/107