### PR TITLE
Set EC2 content type to application/json

### DIFF
--- a/Sources/AWSSDKSwiftCore/Message/AWSRequest.swift
+++ b/Sources/AWSSDKSwiftCore/Message/AWSRequest.swift
@@ -99,6 +99,10 @@ public struct AWSRequest {
             default:
                 break
             }
+        case .other(let service):
+            if service == "ec2" {
+                headers["Content-Type"] = "application/json"
+            }
         default:
             break
         }


### PR DESCRIPTION
Even though EC2 outputs a querystring. The content-type should be set to application/json