### PR TITLE
Avoid warning on Xcode

### DIFF
--- a/Sources/AWSSDKSwiftCore/Signers/V4.swift
+++ b/Sources/AWSSDKSwiftCore/Signers/V4.swift
@@ -88,7 +88,7 @@ extension Signers {
             }
 
             url.query?.components(separatedBy: "&").forEach {
-                var q = $0.components(separatedBy: "=")
+                let q = $0.components(separatedBy: "=")
                 if q.count == 2 {
                     queries.append(URLQueryItem(name: q[0], value: V4.awsUriEncode(q[1].removingPercentEncoding!)))
                 } else {


### PR DESCRIPTION
Avoid warning on Xcode 11. This variable should be immutable.

<img width="1200" alt="Screen Shot 2019-06-22 at 21 43 50" src="https://user-images.githubusercontent.com/147051/59964098-fb653f80-9536-11e9-8245-013f90e7cfb5.png">
