### PR TITLE
Fix crash on Linux 4.2 while handling XML

### DIFF
--- a/Sources/AWSSDKSwiftCore/Message/Body.swift
+++ b/Sources/AWSSDKSwiftCore/Message/Body.swift
@@ -14,7 +14,7 @@ public enum Body {
     case stream(InputStream) // currenty unsupported
     case multipart(Data) // currenty unsupported
     case json(Data)
-    case xml(XMLElement)
+    case xml(XMLNode)
     case empty
 }
 
@@ -83,10 +83,15 @@ extension Body {
             }
             
         case .xml(let node):
-            let xmlDocument = XMLDocument(rootElement: node)
-            xmlDocument.version = "1.0"
-            xmlDocument.characterEncoding = "UTF-8"
-            return xmlDocument.xmlData
+            if let document = node as? XMLDocument {
+                return document.xmlData
+            } else if let element = node as? XMLElement {
+                let xmlDocument = XMLDocument(rootElement: element)
+                xmlDocument.version = "1.0"
+                xmlDocument.characterEncoding = "UTF-8"
+                return xmlDocument.xmlData
+            }
+            return nil
             
         case .multipart(_):
             return nil


### PR DESCRIPTION
This fixes a crash most likely related to https://github.com/apple/swift-corelibs-foundation/pull/1887.
We need to ensure we hold a reference to the XMLDocument if we are processing XMLNodes inside it. I've done this by allowing Body to hold an XMLDocument.

The crash was occurring in S3Tests.testListObjects() on aws-sdk-swift. AWSClient.validateBody() would create a XMLDocument and return the rootElement(). Given the bug detailed above this would mean the XMLDocument and its contents were free to be deleted, even though we had a XMLElement referencing it.  