### PR TITLE
Deal with hostnames which include port in them

### DIFF
--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -122,13 +122,7 @@ extension AWSClient {
     }
 
     private func createHTTPClient(for nioRequest: Request) -> HTTPClient {
-        let client: HTTPClient
-        if let _ = self._endpoint {
-            client = HTTPClient(hostname: nioRequest.head.host!, port: nioRequest.head.port ?? 443)
-        } else {
-            client = HTTPClient(hostname: nioRequest.head.hostWithPort!, port: 443)
-        }
-        return client
+        return HTTPClient(hostname: nioRequest.head.hostWithPort!, port: nioRequest.head.port ?? 443)
     }
 }
 

--- a/Sources/AWSSDKSwiftCore/HTTPClient.swift
+++ b/Sources/AWSSDKSwiftCore/HTTPClient.swift
@@ -95,6 +95,7 @@ private class HTTPClientResponseHandler: ChannelInboundHandler {
 
 public final class HTTPClient {
     private let hostname: String
+    private let headerHostname: String
     private let port: Int
     private let eventGroup: EventLoopGroup
 
@@ -106,19 +107,26 @@ public final class HTTPClient {
         guard let hostname = url.host else {
             throw HTTPClientError.malformedURL
         }
-        var port: Int {
-            let isSecure = scheme == "https" || scheme == "wss"
-            return isSecure ? 443 : Int(url.port ?? 80)
-        }
+        
         self.hostname = hostname
-        self.port = port
+        
+        if let port = url.port {
+            self.port = port
+            self.headerHostname = "\(hostname):\(port)"
+        } else {
+            let isSecure = (scheme == "https")
+            self.port = isSecure == true ? 443 : 80
+            self.headerHostname = hostname
+        }
+
         self.eventGroup = eventGroup
     }
 
     public init(hostname: String,
                 port: Int,
                 eventGroup: EventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)) {
-        self.hostname = hostname
+        self.headerHostname = hostname
+        self.hostname = String(hostname.split(separator:":")[0])
         self.port = port
         self.eventGroup = eventGroup
     }
@@ -127,7 +135,7 @@ public final class HTTPClient {
         var head = request.head
         let body = request.body
 
-        head.headers.replaceOrAdd(name: "Host", value: hostname)
+        head.headers.replaceOrAdd(name: "Host", value: headerHostname)
         head.headers.replaceOrAdd(name: "User-Agent", value: "AWS SDK Swift Core")
         head.headers.replaceOrAdd(name: "Accept", value: "*/*")
         head.headers.replaceOrAdd(name: "Content-Length", value: body.count.description)

--- a/Sources/AWSSDKSwiftCore/HTTPClient.swift
+++ b/Sources/AWSSDKSwiftCore/HTTPClient.swift
@@ -115,7 +115,7 @@ public final class HTTPClient {
             self.headerHostname = "\(hostname):\(port)"
         } else {
             let isSecure = (scheme == "https")
-            self.port = isSecure == true ? 443 : 80
+            self.port = isSecure ? 443 : 80
             self.headerHostname = hostname
         }
 

--- a/Sources/AWSSDKSwiftCore/Message/AWSRequest.swift
+++ b/Sources/AWSSDKSwiftCore/Message/AWSRequest.swift
@@ -20,9 +20,6 @@ extension URL {
         guard var host = self.host else {
             return nil
         }
-        if host.contains("amazonaws.com") {
-            return host
-        }
         if let port = self.port {
             host+=":\(port)"
         }


### PR DESCRIPTION
If port is included in the hostname that is given to the HttpClient then
ensure that is included in the "Host" entry of the headers. 

This fixes https://github.com/swift-aws/aws-sdk-swift-core/issues/94
I have verified this code works with standard AWS requests and also that it works with fakes3 and dynamodb_local.