### PR TITLE
Add x-amz-security-token header before calling authorization()

### DIFF
--- a/Sources/AWSSDKSwiftCore/Signers/V4.swift
+++ b/Sources/AWSSDKSwiftCore/Signers/V4.swift
@@ -128,6 +128,10 @@ extension Signers {
                 headersForSign[header.key] = header.value
             }
 
+            if let token = credentialForSignature.sessionToken {
+                headersForSign["x-amz-security-token"] = token
+            }
+            
             headersForSign["Authorization"] = authorization(
                 url: url,
                 headers: headersForSign,
@@ -136,10 +140,6 @@ extension Signers {
                 bodyDigest: bodyDigest,
                 credentialForSignature: credentialForSignature
             )
-
-            if let token = credentialForSignature.sessionToken {
-                headersForSign["x-amz-security-token"] = token
-            }
 
             return headersForSign
         }


### PR DESCRIPTION
The "x-amz-security-token" header value was being added after the "Authorization" header value was calculated. This was then giving the error
```
accessDenied(message: Optional("RequestId: 4059FAA108A45F89, 
    HeadersNotSigned: x-amz-security-token, 
    Message: There were headers present in the request which were not signed, 
    HostId: p013uVEP7DHgqGkbCe/zsjuASVE0b9h9a7Gb37OfnuPmFnNeMZ5VnILzvi9orDLzHtfn1yNEzLA="))
```

This pull request moves the adding of the "x-amz-security-token" header value to before the authorization value calculation. This fixes https://github.com/swift-aws/aws-sdk-swift/issues/151 