### PR TITLE
Add AWSClient.init() which takes a Credential parameter

### DIFF
--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -68,10 +68,10 @@ public struct AWSClient {
 
     public static let eventGroup: EventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, region givenRegion: Region?, amzTarget: String? = nil, service: String, serviceProtocol: ServiceProtocol, apiVersion: String, endpoint: String? = nil, serviceEndpoints: [String: String] = [:], partitionEndpoint: String? = nil, middlewares: [AWSRequestMiddleware] = [], possibleErrorTypes: [AWSErrorType.Type]? = nil) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region givenRegion: Region?, amzTarget: String? = nil, service: String, serviceProtocol: ServiceProtocol, apiVersion: String, endpoint: String? = nil, serviceEndpoints: [String: String] = [:], partitionEndpoint: String? = nil, middlewares: [AWSRequestMiddleware] = [], possibleErrorTypes: [AWSErrorType.Type]? = nil) {
         let credential: CredentialProvider
         if let accessKey = accessKeyId, let secretKey = secretAccessKey {
-            credential = Credential(accessKeyId: accessKey, secretAccessKey: secretKey)
+            credential = Credential(accessKeyId: accessKey, secretAccessKey: secretKey, sessionToken: sessionToken)
         } else if let ecredential = EnvironementCredential() {
             credential = ecredential
         } else if let scredential = try? SharedCredential() {


### PR DESCRIPTION
STS.AssumeRole() returns a credential structure, which contains a sessionToken. There is currently no way to initialize an AWS service with this sessionToken. 

This PR is the starting point of changing that. I have added a new AWSRequest.init() which takes a Credential structure as a parameter. The original initializer now creates a Credential structure and passes it onto the new initializer. Once this is in I can change the CodeGenerator to output code to create services taking a Credential structure. 