### PR TITLE
OpenSSL 1.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,6 +9,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio.git", from: "1.11.0"),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "1.3.2"),
+        .package(url: "https://github.com/apple/swift-nio-ssl-support.git", from: "1.0.0"),
         .package(url: "https://github.com/Yasumoto/HypertextApplicationLanguage.git", .upToNextMajor(from: "1.1.0")),
         .package(url: "https://github.com/PerfectlySoft/Perfect-INIParser.git", .upToNextMajor(from: "3.0.0")),
     ],
@@ -16,6 +17,7 @@ let package = Package(
         .target(
             name: "AWSSDKSwiftCore",
             dependencies: [
+                "CAWSSDKOpenSSL",
                 "HypertextApplicationLanguage",
                 "NIO",
                 "NIOHTTP1",
@@ -23,6 +25,7 @@ let package = Package(
                 "NIOFoundationCompat",
                 "INIParser"
             ]),
+        .target(name: "CAWSSDKOpenSSL"),
         .testTarget(name: "AWSSDKSwiftCoreTests", dependencies: ["AWSSDKSwiftCore"])
     ]
 )

--- a/Sources/AWSSDKSwiftCore/HMAC.swift
+++ b/Sources/AWSSDKSwiftCore/HMAC.swift
@@ -8,17 +8,18 @@
 
 import Foundation
 import CNIOOpenSSL
+import CAWSSDKOpenSSL
 
 func hmac(string: String, key: [UInt8]) -> [UInt8] {
-    var context = HMAC_CTX()
-    HMAC_Init_ex(&context, key, Int32(key.count), EVP_sha256(), nil)
+    let context = AWSSDK_HMAC_CTX_new()
+    HMAC_Init_ex(context, key, Int32(key.count), EVP_sha256(), nil)
 
     let bytes = Array(string.utf8)
-    HMAC_Update(&context, bytes, bytes.count)
+    HMAC_Update(context, bytes, bytes.count)
     var digest = [UInt8](repeating: 0, count: Int(EVP_MAX_MD_SIZE))
     var length: UInt32 = 0
-    HMAC_Final(&context, &digest, &length)
-    HMAC_CTX_cleanup(&context)
+    HMAC_Final(context, &digest, &length)
+    AWSSDK_HMAC_CTX_free(context)
 
     return Array(digest[0..<Int(length)])
 }

--- a/Sources/CAWSSDKOpenSSL/include/c_awssdk_openssl.h
+++ b/Sources/CAWSSDKOpenSSL/include/c_awssdk_openssl.h
@@ -1,0 +1,16 @@
+//
+//  c_awssdk_openssl.h
+//  AWSSDKSwiftCore
+//
+//  Created by Adam Fowler on 2019/08/08.
+//
+
+#ifndef C_AWSSDK_OPENSSL_H
+#define C_AWSSDK_OPENSSL_H
+
+#include <openssl/hmac.h>
+
+HMAC_CTX *AWSSDK_HMAC_CTX_new();
+void AWSSDK_HMAC_CTX_free(HMAC_CTX* ctx);
+
+#endif // C_AWSSDK_OPENSSL_H

--- a/Sources/CAWSSDKOpenSSL/shims.c
+++ b/Sources/CAWSSDKOpenSSL/shims.c
@@ -1,0 +1,34 @@
+//
+//  shims.c
+//  AWSSDKSwiftCore
+//
+//  Created by Adam Fowler on 2019/08/08.
+//
+
+// These are functions that shim over differences in different OpenSSL versions,
+// which are best handled by using the C preprocessor.
+#include "c_awssdk_openssl.h"
+#include <string.h>
+
+HMAC_CTX *AWSSDK_HMAC_CTX_new() {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x2070000fL)
+    HMAC_CTX *ctx = OPENSSL_malloc(sizeof(HMAC_CTX));
+    if (ctx != NULL) {
+        HMAC_CTX_init(ctx);
+    }
+    return ctx;
+#else
+    return HMAC_CTX_new();
+#endif
+}
+
+void AWSSDK_HMAC_CTX_free(HMAC_CTX* ctx) {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x2070000fL)
+    if (ctx != NULL) {
+        HMAC_CTX_cleanup(ctx);
+        OPENSSL_free(ctx);
+    }
+#else
+    HMAC_CTX_free(ctx);
+#endif
+}


### PR DESCRIPTION
Get aws-sdk-swift working with OpenSSL 1.1 without breaking earlier versions of OpenSSL.

Added CAWSSDKOpenSSL target to shim over differences in OpenSSL versions, specifically how HMAC contexts are created.

This is only needed for versions of the library that use nio 1.4 or less as nio2.0 includes BoringSSL with it.

@Yasumoto this is from the conversation on discord #aws this morning/yesterday