### PR TITLE
Encapsulate processed Response in AWSResponse struct

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/Yasumoto/HypertextApplicationLanguage.git",
         "state": {
           "branch": null,
-          "revision": "2302002502fe573494577cc6e8df686e385519f8",
-          "version": "1.1.0"
+          "revision": "aa2c9141d491682f17b2310aed17b9adfc006256",
+          "version": "1.1.1"
         }
       },
       {

--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -489,7 +489,14 @@ extension AWSClient {
 
     /// Validate the operation response and return a response shape
     fileprivate func validate<Output: AWSShape>(operation operationName: String, response: Response) throws -> Output {
-        var awsResponse = try AWSResponse(from: response, serviceProtocolType: serviceProtocol.type, raw: Output.payloadPath != nil)
+        let raw: Bool
+        if let payloadPath = Output.payloadPath, let member = Output.getMember(named: payloadPath), member.type == .blob {
+            raw = true
+        } else {
+            raw = false
+        }
+        
+        var awsResponse = try AWSResponse(from: response, serviceProtocolType: serviceProtocol.type, raw: raw)
         
         try validateCode(response: awsResponse)
 

--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -518,6 +518,10 @@ extension AWSClient {
         switch awsResponse.body {
         case .json(let data):
             outputDict = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] ?? [:]
+            // if payload path is set then the decode will expect the payload to decode to the relevant member variable
+            if let payloadPath = Output.payloadPath {
+                outputDict = [payloadPath : outputDict]
+            }
             decoder.dataDecodingStrategy = .base64
 
         case .xml(let node):

--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -509,11 +509,6 @@ extension AWSClient {
         
         let decoder = DictionaryDecoder()
 
-        var responseHeaders: [String: String] = [:]
-        for (key, value) in response.head.headers {
-            responseHeaders[key.description] = value
-        }
-
         var outputDict: [String: Any] = [:]
         switch awsResponse.body {
         case .json(let data):
@@ -630,7 +625,9 @@ extension AWSClient {
                         dictionary[rel] = representations.map({ $0.properties }).first ?? [:]
                     }
                 }
-                return AWSResponse(status: response.status, headers: response.headers, body: .json(try JSONSerialization.data(withJSONObject: dictionary, options: [])))
+                var response = response
+                response.body = .json(try JSONSerialization.data(withJSONObject: dictionary, options: []))
+                return response
             }
         default:
             break

--- a/Sources/AWSSDKSwiftCore/Message/AWSRequest.swift
+++ b/Sources/AWSSDKSwiftCore/Message/AWSRequest.swift
@@ -59,11 +59,11 @@ public struct AWSRequest {
     public let amzTarget: String?
     public let operation: String
     public let httpMethod: String
-    public var httpHeaders: [String: Any?] = [:]
+    public var httpHeaders: [String: Any] = [:]
     public var body: Body
     public let middlewares: [AWSServiceMiddleware]
 
-    public init(region: Region = .useast1, url: URL, serviceProtocol: ServiceProtocol, service: String, amzTarget: String? = nil, operation: String, httpMethod: String, httpHeaders: [String: Any?] = [:], body: Body = .empty, middlewares: [AWSServiceMiddleware] = []) {
+    public init(region: Region = .useast1, url: URL, serviceProtocol: ServiceProtocol, service: String, amzTarget: String? = nil, operation: String, httpMethod: String, httpHeaders: [String: Any] = [:], body: Body = .empty, middlewares: [AWSServiceMiddleware] = []) {
         self.region = region
         self.url = url
         self.serviceProtocol = serviceProtocol
@@ -88,7 +88,7 @@ public struct AWSRequest {
 
         var headers: [String:String] = [:]
         for (key, value) in awsRequest.httpHeaders {
-            guard let value = value else { continue }
+            //guard let value = value else { continue }
             headers[key] = "\(value)"
         }
 

--- a/Sources/AWSSDKSwiftCore/Message/AWSRequest.swift
+++ b/Sources/AWSSDKSwiftCore/Message/AWSRequest.swift
@@ -13,15 +13,15 @@ import NIOHTTP1
 
 public protocol AWSServiceMiddleware {
     func chain(request: AWSRequest) throws -> AWSRequest
-    func chain(responseBody: Body) throws -> Body
+    func chain(response: AWSResponse) throws -> AWSResponse
 }
 
 public extension AWSServiceMiddleware {
     func chain(request: AWSRequest) throws -> AWSRequest {
         return request
     }
-    func chain(responseBody: Body) throws -> Body {
-        return responseBody
+    func chain(response: AWSResponse) throws -> AWSResponse {
+        return response
     }
 }
 
@@ -125,7 +125,7 @@ public struct AWSRequest {
         let generatedHeaders = headers.map { ($0, $1) }
         head.headers = HTTPHeaders(generatedHeaders)
 
-        return Request(head: head, body: try awsRequest.body.asData() ?? Data())
+        return Request(head: head, body: awsRequest.body.asData() ?? Data())
     }
 
     fileprivate func nioHTTPMethod(from: String) -> HTTPMethod {
@@ -155,7 +155,7 @@ public struct AWSRequest {
 
         var request = URLRequest(url: awsRequest.url)
         request.httpMethod = awsRequest.httpMethod
-        request.httpBody = try awsRequest.body.asData()
+        request.httpBody = awsRequest.body.asData()
 
         if awsRequest.body.isJSON() {
             request.addValue("application/x-amz-json-1.1", forHTTPHeaderField: "Content-Type")

--- a/Sources/AWSSDKSwiftCore/Message/AWSResponse.swift
+++ b/Sources/AWSSDKSwiftCore/Message/AWSResponse.swift
@@ -1,0 +1,73 @@
+//
+//  AWSResponse.swift
+//  AWSSDKSwift
+//
+//  Created by Adam Fowler on 2019/08/25.
+//
+//
+
+import Foundation
+import NIO
+import NIOHTTP1
+import HypertextApplicationLanguage
+
+public struct AWSResponse {
+
+    public let status: HTTPResponseStatus
+    public let headers: [String: String]
+    public let body: Body
+
+    init(from response: Response, serviceProtocolType: ServiceProtocolType, raw: Bool = false) throws {
+        self.status = response.head.status
+        self.headers = AWSResponse.createHeaders(from: response)
+        self.body = try AWSResponse.createBody(from: response, serviceProtocolType: serviceProtocolType, raw: raw)
+    }
+
+    private static func createHeaders(from response: Response) -> [String: String] {
+        var responseHeaders: [String: String] = [:]
+        for (key, value) in response.head.headers {
+            responseHeaders[key.description] = value
+        }
+
+        return responseHeaders
+    }
+    
+    private static func createBody(from response: Response, serviceProtocolType: ServiceProtocolType, raw: Bool) throws -> Body {
+        var responseBody: Body = .empty
+        let data = response.body
+        
+        if data.isEmpty {
+            return .empty
+        }
+        
+        if raw {
+            return .buffer(data)
+        }
+        
+        switch serviceProtocolType {
+        case .json, .restjson:
+            responseBody = .json(data)
+            
+        case .restxml, .query:
+            let xmlDocument = try XML.Document(data: data)
+            if let element = xmlDocument.rootElement() {
+                responseBody = .xml(element)
+            }
+            
+        case .other(let proto):
+            switch proto.lowercased() {
+            case "ec2":
+                let xmlDocument = try XML.Document(data: data)
+                if let element = xmlDocument.rootElement() {
+                    responseBody = .xml(element)
+                }
+                
+            default:
+                responseBody = .buffer(data)
+            }
+        }
+        
+        return responseBody
+    }
+    
+}

--- a/Sources/AWSSDKSwiftCore/Message/AWSResponse.swift
+++ b/Sources/AWSSDKSwiftCore/Message/AWSResponse.swift
@@ -14,7 +14,7 @@ import HypertextApplicationLanguage
 public struct AWSResponse {
 
     public let status: HTTPResponseStatus
-    public var headers: [String: String]
+    public var headers: [String: Any]
     public var body: Body
 
     init(from response: Response, serviceProtocolType: ServiceProtocolType, raw: Bool = false) throws {

--- a/Sources/AWSSDKSwiftCore/Message/AWSResponse.swift
+++ b/Sources/AWSSDKSwiftCore/Message/AWSResponse.swift
@@ -23,6 +23,12 @@ public struct AWSResponse {
         self.body = try AWSResponse.createBody(from: response, serviceProtocolType: serviceProtocolType, raw: raw)
     }
 
+    init(status: HTTPResponseStatus, headers: [String: String], body: Body) {
+        self.status = status
+        self.headers = headers
+        self.body = body
+    }
+    
     private static func createHeaders(from response: Response) -> [String: String] {
         var responseHeaders: [String: String] = [:]
         for (key, value) in response.head.headers {

--- a/Sources/AWSSDKSwiftCore/Message/AWSResponse.swift
+++ b/Sources/AWSSDKSwiftCore/Message/AWSResponse.swift
@@ -14,8 +14,8 @@ import HypertextApplicationLanguage
 public struct AWSResponse {
 
     public let status: HTTPResponseStatus
-    public let headers: [String: String]
-    public let body: Body
+    public var headers: [String: String]
+    public var body: Body
 
     init(from response: Response, serviceProtocolType: ServiceProtocolType, raw: Bool = false) throws {
         self.status = response.head.status
@@ -23,12 +23,6 @@ public struct AWSResponse {
         self.body = try AWSResponse.createBody(from: response, serviceProtocolType: serviceProtocolType, raw: raw)
     }
 
-    init(status: HTTPResponseStatus, headers: [String: String], body: Body) {
-        self.status = status
-        self.headers = headers
-        self.body = body
-    }
-    
     private static func createHeaders(from response: Response) -> [String: String] {
         var responseHeaders: [String: String] = [:]
         for (key, value) in response.head.headers {

--- a/Sources/AWSSDKSwiftCore/Message/Body.swift
+++ b/Sources/AWSSDKSwiftCore/Message/Body.swift
@@ -67,7 +67,7 @@ extension Body {
         }
     }
 
-    public func asData() throws -> Data? {
+    public func asData() -> Data? {
         switch self {
         case .text(let text):
             return text.data(using: .utf8)

--- a/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
@@ -181,7 +181,7 @@ class AWSClientTests: XCTestCase {
             )
             XCTAssertEqual(awsRequest.url.absoluteString, "\(kinesisClient.endpoint)/")
 
-            if let bodyAsData = try awsRequest.body.asData(), let parsedBody = try JSONSerialization.jsonObject(with: bodyAsData, options: []) as? [String:Any] {
+            if let bodyAsData = awsRequest.body.asData(), let parsedBody = try JSONSerialization.jsonObject(with: bodyAsData, options: []) as? [String:Any] {
                 if let member = parsedBody["Member"] as? [String:Any] {
                     if let memberKey = member["memberKey"] {
                         XCTAssertEqual(String(describing: memberKey), "memberValue")
@@ -231,7 +231,7 @@ class AWSClientTests: XCTestCase {
             )
 
             XCTAssertNotNil(awsRequest.body)
-            if let xmlData = try awsRequest.body.asData() {
+            if let xmlData = awsRequest.body.asData() {
                 let document = try XML.Document(data:xmlData)
                 XCTAssertNotNil(document.rootElement())
                 let payload = try XMLDecoder().decode(E.self, from: document.rootElement()!)
@@ -253,7 +253,7 @@ class AWSClientTests: XCTestCase {
                 input: input3
             )
             XCTAssertNotNil(awsRequest.body)
-            if let jsonData = try awsRequest.body.asData() {
+            if let jsonData = awsRequest.body.asData() {
                 let jsonBody = try! JSONSerialization.jsonObject(with: jsonData, options: .allowFragments) as! [String:Any]
                 let fromJson = jsonBody["Member"]! as! [String: String]
                 XCTAssertEqual(fromJson["memberKey"], "memberValue")
@@ -312,9 +312,9 @@ class AWSClientTests: XCTestCase {
             ),
             body: Data()
         )
-
         do {
-            try s3Client.debugValidateCode(response: nioResponse)
+            let awsResponse = try AWSResponse(from: nioResponse, serviceProtocolType: .json)
+            try s3Client.debugValidateCode(response: awsResponse)
         } catch {
             XCTFail(error.localizedDescription)
         }
@@ -328,7 +328,8 @@ class AWSClientTests: XCTestCase {
         )
 
         do {
-            try s3Client.debugValidateCode(response: failNioResponse)
+            let awsResponse = try AWSResponse(from: failNioResponse, serviceProtocolType: .json)
+            try s3Client.debugValidateCode(response: awsResponse)
             XCTFail("call to validateCode should throw an error")
         } catch {
             XCTAssertTrue(true)


### PR DESCRIPTION
Store processed status code, body and headers in a single object. 
- Tidys up code
- Allows us to send a full response to AWSServiceMiddleware
- Also can start to think about processing HAL in a Future if we have a single processed response object to pass around