### PR TITLE
Removed public from a bunch of credential/signer functions

### DIFF
--- a/Sources/AWSSDKSwiftCore/Credential/Credential.swift
+++ b/Sources/AWSSDKSwiftCore/Credential/Credential.swift
@@ -17,11 +17,11 @@ public protocol CredentialProvider {
 }
 
 extension CredentialProvider {
-    public func isEmpty() -> Bool {
+    func isEmpty() -> Bool {
         return self.accessKeyId.isEmpty || self.secretAccessKey.isEmpty
     }
 
-    public func nearExpiration() -> Bool {
+    func nearExpiration() -> Bool {
         if let expiration = self.expiration {
             // are we within 5 minutes of expiration?
             return Date().addingTimeInterval(5.0 * 60.0) > expiration
@@ -49,25 +49,25 @@ class IniConfigParser: SharedCredentialsConfigParser {
     }
 }
 
-public struct SharedCredential: CredentialProvider {
+struct SharedCredential: CredentialProvider {
 
     /// Errors occurring when initializing a SharedCredential
     ///
     /// - missingProfile: If the profile requested was not found
     /// - missingAccessKeyId: If the access key ID was not found
     /// - missingSecretAccessKey: If the secret access key was not found
-    public enum SharedCredentialError: Error, Equatable {
+    enum SharedCredentialError: Error, Equatable {
         case missingProfile(String)
         case missingAccessKeyId
         case missingSecretAccessKey
     }
 
-    public let accessKeyId: String
-    public let secretAccessKey: String
-    public let sessionToken: String?
-    public let expiration: Date? = nil
+    let accessKeyId: String
+    let secretAccessKey: String
+    let sessionToken: String?
+    let expiration: Date? = nil
 
-    public init(filename: String = "~/.aws/credentials",
+    init(filename: String = "~/.aws/credentials",
                 profile: String = "default") throws {
         try self.init(
             filename: filename,


### PR DESCRIPTION
Now that signer is accessible publicly I thought this would be sensible.
- Removed public from V4.manageCredential(). There is no need to provide credential details to user.
- Also made a number of the credential structs non-public as they don't need to be available to the user.
- Moved V4.manageCredential() and hexEncodedBodyHash() below the public functions in V4.swift