### PR TITLE
Add public facing signURL() function to AWSClient

### DIFF
--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -30,7 +30,7 @@ public struct AWSClient {
         case invalidURL(String)
     }
 
-    public let signer: Signers.V4
+    let signer: Signers.V4
 
     let apiVersion: String
 
@@ -195,6 +195,9 @@ extension AWSClient {
                 }
     }
 
+    public func signURL(url: URL, httpMethod: String, expires: Int = 86400) -> URL {
+        return signer.signedURL(url: url, method: httpMethod, expires: expires)
+    }
 }
 
 // request creator


### PR DESCRIPTION
Clean up code path to generating signed URLs. See https://github.com/swift-aws/aws-sdk-swift/issues/73

```
let s3 = S3(.euwest1)
let url = "https://mybucket.s3.amazonaws.com/key/for/my/file"
let signedURL = s3.client.signURL(url: url, httpMethod: "GET")
```