### PR TITLE
Add additional methods for parsing timestamps

### DIFF
--- a/Tests/AWSSDKSwiftCoreTests/TimeStampTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/TimeStampTests.swift
@@ -15,7 +15,7 @@ class TimeStampTests: XCTestCase {
         let date: TimeStamp
     }
 
-    func testDecodeFromJSON() {
+    func testDecodeISOFromJSON() {
         do {
             let json = "{\"date\": \"2017-01-01T00:00:00.000Z\"}"
             if let json_data = json.data(using: .utf8) {
@@ -29,12 +29,35 @@ class TimeStampTests: XCTestCase {
         }
     }
     
-    func testDecodeFromXML() {
+    func testDecodeISOFromXML() {
         do {
             let xml = "<A><date>2017-01-01T00:01:00.000Z</date></A>"
             let xmlElement = try XML.Element(xmlString: xml)
             let a = try XMLDecoder().decode(A.self, from: xmlElement)
             XCTAssertEqual(a.date.stringValue, "2017-01-01T00:01:00.000Z")
+        } catch {
+            XCTFail("\(error)")
+        }
+    }
+    
+    func testDecodeHttpFormattedTimestamp() {
+        do {
+            let xml = "<A><date>Tue, 15 Nov 1994 12:45:26 GMT</date></A>"
+            let xmlElement = try XML.Element(xmlString: xml)
+            let a = try XMLDecoder().decode(A.self, from: xmlElement)
+            XCTAssertEqual(a.date.stringValue, "1994-11-15T12:45:26.000Z")
+        } catch {
+            XCTFail("\(error)")
+        }
+
+    }
+    
+    func testDecodeUnixEpochTimestamp() {
+        do {
+            let xml = "<A><date>1221382800</date></A>"
+            let xmlElement = try XML.Element(xmlString: xml)
+            let a = try XMLDecoder().decode(A.self, from: xmlElement)
+            XCTAssertEqual(a.date.stringValue, "2008-09-14T09:00:00.000Z")
         } catch {
             XCTFail("\(error)")
         }
@@ -53,8 +76,8 @@ class TimeStampTests: XCTestCase {
 
     static var allTests : [(String, (TimeStampTests) -> () throws -> Void)] {
         return [
-            ("testDecodeFromJSON", testDecodeFromJSON),
-            ("testDecodeFromXML", testDecodeFromXML),
+            ("testDecodeISOFromJSON", testDecodeISOFromJSON),
+            ("testDecodeISOFromXML", testDecodeISOFromXML),
             ("testEncodeToJSON", testEncodeToJSON),
         ]
     }


### PR DESCRIPTION
Added a HTTP date format DateFormatter (see https://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.3.1). Used by most dates found in response headers
Added parsing of UNIX epoch seconds (number of seconds since 1st Jan 1970).
Added tests for parsing both of these