### PR TITLE
HTTPClient changes

### DIFF
--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -119,7 +119,7 @@ public class AWSClient {
 // invoker
 extension AWSClient {
     fileprivate func invoke(_ nioRequest: HTTPClient.Request) -> Future<HTTPClient.Response> {
-        let client = HTTPClient(hostname: nioRequest.head.hostWithPort!, port: nioRequest.head.port ?? 443)
+        let client = HTTPClient()
         let futureResponse = client.connect(nioRequest)
 
         futureResponse.whenComplete { _ in

--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -123,10 +123,10 @@ extension AWSClient {
         let futureResponse = client.connect(nioRequest)
 
         futureResponse.whenComplete { _ in
-            client.close { error in
-                if let error = error {
-                    print("Error closing connection: \(error)")
-                }
+            do {
+                try client.syncShutdown()
+            } catch {
+                print("Error closing connection: \(error)")
             }
         }
 

--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -61,7 +61,7 @@ public class AWSClient {
         return "\(service).\(signer.region.rawValue).amazonaws.com"
     }
 
-    public static let eventGroup: EventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+    public static let eventGroup: EventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
 
     /// Initialize an AWSClient struct
     /// - parameters:
@@ -119,7 +119,7 @@ public class AWSClient {
 // invoker
 extension AWSClient {
     fileprivate func invoke(_ nioRequest: HTTPClient.Request) -> Future<HTTPClient.Response> {
-        let client = HTTPClient()
+        let client = HTTPClient(eventLoopGroupProvider: .shared(AWSClient.eventGroup))
         let futureResponse = client.connect(nioRequest)
 
         futureResponse.whenComplete { _ in

--- a/Sources/AWSSDKSwiftCore/HTTPClient.swift
+++ b/Sources/AWSSDKSwiftCore/HTTPClient.swift
@@ -4,76 +4,17 @@
 //
 //  Created by Joseph Mehdi Smith on 4/21/18.
 //
-// Informed by the Swift NIO
-// [`testSimpleGet`](https://github.com/apple/swift-nio/blob/a4318d5e752f0e11638c0271f9c613e177c3bab8/Tests/NIOHTTP1Tests/HTTPServerClientTest.swift#L348)
-// and heavily built off Vapor's HTTP client library,
-// [`HTTPClient`](https://github.com/vapor/http/blob/2cb664097006e3fda625934079b51c90438947e1/Sources/HTTP/Responder/HTTPClient.swift)
+// Informed by Vapor's HTTP client
+// https://github.com/vapor/http/tree/master/Sources/HTTPKit/Client
+// and the swift-server's swift-nio-http-client
+// https://github.com/swift-server/swift-nio-http-client
+//
 
 import NIO
 import NIOHTTP1
 import NIOSSL
 import NIOFoundationCompat
 import Foundation
-
-private class HTTPClientResponseHandler: ChannelInboundHandler {
-    typealias InboundIn = HTTPClientResponsePart
-    typealias OutboundOut = HTTPClient.Response
-
-    private enum HTTPClientState {
-        /// Waiting to parse the next response.
-        case ready
-        /// Currently parsing the response's body.
-        case parsingBody(HTTPResponseHead, Data?)
-    }
-
-    private var receiveds: [HTTPClientResponsePart] = []
-    private var state: HTTPClientState = .ready
-    private var promise: EventLoopPromise<HTTPClient.Response>
-
-    public init(promise: EventLoopPromise<HTTPClient.Response>) {
-        self.promise = promise
-    }
-
-    func errorCaught(context: ChannelHandlerContext, error: Error) {
-        promise.fail(error)
-        context.fireErrorCaught(error)
-    }
-
-    public func channelRead(context: ChannelHandlerContext, data: NIOAny) {
-        switch unwrapInboundIn(data) {
-        case .head(let head):
-            switch state {
-            case .ready: state = .parsingBody(head, nil)
-            case .parsingBody: promise.fail(HTTPClient.HTTPError.malformedHead)
-            }
-        case .body(var body):
-            switch state {
-            case .ready: promise.fail(HTTPClient.HTTPError.malformedBody)
-            case .parsingBody(let head, let existingData):
-                let data: Data
-                if var existing = existingData {
-                    existing += body.readData(length: body.readableBytes) ?? Data()
-                    data = existing
-                } else {
-                    data = body.readData(length: body.readableBytes) ?? Data()
-                }
-                state = .parsingBody(head, data)
-            }
-        case .end(let tailHeaders):
-            assert(tailHeaders == nil, "Unexpected tail headers")
-            switch state {
-            case .ready: promise.fail(HTTPClient.HTTPError.malformedHead)
-            case .parsingBody(let head, let data):
-                let res = HTTPClient.Response(head: head, body: data ?? Data())
-                if context.channel.isActive {
-                    context.fireChannelRead(wrapOutboundOut(res))
-                }
-                promise.succeed(res)
-                state = .ready
-            }
-        }
-    }
-}
 
 /// HTTP Client class providing API for sending HTTP requests
 public final class HTTPClient {
@@ -136,50 +77,44 @@ public final class HTTPClient {
         self.eventGroup = eventGroup
     }
 
-    public func connect(_ request: Request) -> EventLoopFuture<Response> {
-        var head = request.head
-        let body = request.body
-
-        head.headers.replaceOrAdd(name: "Host", value: headerHostname)
-        head.headers.replaceOrAdd(name: "User-Agent", value: "AWS SDK Swift Core")
-        head.headers.replaceOrAdd(name: "Accept", value: "*/*")
-        head.headers.replaceOrAdd(name: "Content-Length", value: body.count.description)
-
-        // TODO implement Keep-alive
-        head.headers.replaceOrAdd(name: "Connection", value: "Close")
-
-        var preHandlers = [ChannelHandler]()
+    /// add SSL Handler to channel pipeline if the port is 443
+    func addSSLHandlerIfNeeded(_ pipeline : ChannelPipeline, hostname: String, port: Int) -> EventLoopFuture<Void> {
         if (port == 443) {
             do {
                 let tlsConfiguration = TLSConfiguration.forClient()
                 let sslContext = try NIOSSLContext(configuration: tlsConfiguration)
                 let tlsHandler = try NIOSSLClientHandler(context: sslContext, serverHostname: hostname)
-                preHandlers.append(tlsHandler)
+                return pipeline.addHandler(tlsHandler, position:.first)
             } catch {
-                print("Unable to setup TLS: \(error)")
+                return pipeline.eventLoop.makeFailedFuture(error)
             }
         }
+        return pipeline.eventLoop.makeSucceededFuture(())
+    }
+
+    /// send request to HTTP client, return a future holding the Response
+    public func connect(_ request: Request) -> EventLoopFuture<Response> {
         let response: EventLoopPromise<Response> = eventGroup.next().makePromise()
 
-        _ = ClientBootstrap(group: eventGroup)
+        _ = ClientBootstrap(group: self.eventGroup)
             .connectTimeout(TimeAmount.seconds(5))
-            .channelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
+            .channelOption(ChannelOptions.socket(SocketOptionLevel(IPPROTO_TCP), TCP_NODELAY), value: 1)
             .channelInitializer { channel in
-                let accumulation = HTTPClientResponseHandler(promise: response)
-                let results = preHandlers.map { channel.pipeline.addHandler($0) }
-                return EventLoopFuture<Void>.andAllSucceed(results, on: channel.eventLoop).flatMap { _ in
-                    channel.pipeline.addHTTPClientHandlers().flatMap { _ in
-                        channel.pipeline.addHandler(accumulation)
+                return channel.pipeline.addHTTPClientHandlers()
+                    .flatMap {
+                        return self.addSSLHandlerIfNeeded(channel.pipeline, hostname: self.hostname, port: self.port)
                     }
+                    .flatMap {
+                        let handlers : [ChannelHandler] = [
+                            HTTPClientRequestSerializer(hostname: self.headerHostname),
+                            HTTPClientResponseHandler(promise: response)
+                        ]
+                        return channel.pipeline.addHandlers(handlers)
                 }
             }
             .connect(host: hostname, port: port)
             .flatMap { channel -> EventLoopFuture<Void> in
-                channel.write(NIOAny(HTTPClientRequestPart.head(head)), promise: nil)
-                var buffer = ByteBufferAllocator().buffer(capacity: body.count)
-                buffer.writeBytes(body)
-                channel.write(NIOAny(HTTPClientRequestPart.body(.byteBuffer(buffer))), promise: nil)
-                return channel.writeAndFlush(NIOAny(HTTPClientRequestPart.end(nil)))
+                return channel.writeAndFlush(request)
             }
             .whenFailure { error in
                 response.fail(error)
@@ -189,5 +124,97 @@ public final class HTTPClient {
 
     public func close(_ callback: @escaping (Error?) -> Void) {
         eventGroup.shutdownGracefully(callback)
+    }
+
+    /// Channel Handler for serializing request header and data
+    private class HTTPClientRequestSerializer : ChannelOutboundHandler {
+        typealias OutboundIn = Request
+        typealias OutboundOut = HTTPClientRequestPart
+
+        private let hostname: String
+
+        init(hostname: String) {
+            self.hostname = hostname
+        }
+
+        func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
+            let request = unwrapOutboundIn(data)
+            var head = request.head
+
+            head.headers.replaceOrAdd(name: "Host", value: hostname)
+            head.headers.replaceOrAdd(name: "User-Agent", value: "AWS SDK Swift Core")
+            head.headers.replaceOrAdd(name: "Accept", value: "*/*")
+            head.headers.replaceOrAdd(name: "Content-Length", value: request.body.count.description)
+            // TODO implement keep-alive
+            head.headers.replaceOrAdd(name: "Connection", value: "Close")
+
+
+            context.write(wrapOutboundOut(.head(head)), promise: nil)
+            if request.body.count > 0 {
+                var buffer = ByteBufferAllocator().buffer(capacity: request.body.count)
+                buffer.writeBytes(request.body)
+                context.write(self.wrapOutboundOut(.body(.byteBuffer(buffer))), promise: nil)
+            }
+            context.write(self.wrapOutboundOut(.end(nil)), promise: promise)
+        }
+    }
+
+    /// Channel Handler for parsing response from server
+    private class HTTPClientResponseHandler: ChannelInboundHandler {
+        typealias InboundIn = HTTPClientResponsePart
+        typealias OutboundOut = Response
+
+        private enum ResponseState {
+            /// Waiting to parse the next response.
+            case ready
+            /// Currently parsing the response's body.
+            case parsingBody(HTTPResponseHead, Data?)
+        }
+
+        private var state: ResponseState = .ready
+        private let promise : EventLoopPromise<Response>
+
+        init(promise: EventLoopPromise<Response>) {
+            self.promise = promise
+        }
+
+        func errorCaught(context: ChannelHandlerContext, error: Error) {
+            context.fireErrorCaught(error)
+        }
+
+        func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+            switch unwrapInboundIn(data) {
+            case .head(let head):
+                switch state {
+                case .ready: state = .parsingBody(head, nil)
+                case .parsingBody: promise.fail(HTTPClient.HTTPError.malformedHead)
+                }
+            case .body(var body):
+                switch state {
+                case .ready: promise.fail(HTTPClient.HTTPError.malformedBody)
+                case .parsingBody(let head, let existingData):
+                    let data: Data
+                    if var existing = existingData {
+                        existing += body.readData(length: body.readableBytes) ?? Data()
+                        data = existing
+                    } else {
+                        data = body.readData(length: body.readableBytes) ?? Data()
+                    }
+                    state = .parsingBody(head, data)
+                }
+            case .end(let tailHeaders):
+                assert(tailHeaders == nil, "Unexpected tail headers")
+                switch state {
+                case .ready: promise.fail(HTTPClient.HTTPError.malformedHead)
+                case .parsingBody(let head, let data):
+                    let res = Response(head: head, body: data ?? Data())
+                    if context.channel.isActive {
+                        context.fireChannelRead(wrapOutboundOut(res))
+                    }
+                    promise.succeed(res)
+                    state = .ready
+                }
+            }
+        }
     }
 }

--- a/Sources/AWSSDKSwiftCore/MetaDataService.swift
+++ b/Sources/AWSSDKSwiftCore/MetaDataService.swift
@@ -55,8 +55,8 @@ struct MetaDataService {
 
         func uri() throws -> Future<String> {
             switch self {
-            case .ecsCredentials(let containerCredentialsUri):
-                return AWSClient.eventGroup.next().makeSucceededFuture(containerCredentialsUri)
+            case .ecsCredentials(_):
+                return AWSClient.eventGroup.next().makeSucceededFuture(self.baseURLString)
             case .instanceProfileCredentials:
                 // instance service expects absoluteString as uri...
                 return MetaDataService.request(host: host, uri: baseURLString, timeout: 2).flatMapThrowing{ response in

--- a/Sources/AWSSDKSwiftCore/MetaDataService.swift
+++ b/Sources/AWSSDKSwiftCore/MetaDataService.swift
@@ -89,7 +89,7 @@ struct MetaDataService {
     }
 
     static func request(host: String, uri: String, timeout: TimeInterval) -> Future<HTTPClient.Response> {
-        let client = HTTPClient(hostname: host, port: 80)
+        let client = HTTPClient()
         let head = HTTPRequestHead(
                      version: HTTPVersion(major: 1, minor: 1),
                      method: .GET,

--- a/Sources/AWSSDKSwiftCore/MetaDataService.swift
+++ b/Sources/AWSSDKSwiftCore/MetaDataService.swift
@@ -99,10 +99,10 @@ struct MetaDataService {
         let futureResponse = client.connect(request)
 
         futureResponse.whenComplete { _ in
-            client.close { error in
-                if let error = error {
-                    print("Error closing connection: \(error)")
-                }
+            do {
+                try client.syncShutdown()
+            } catch {
+                print("Error closing connection: \(error)")
             }
         }
 

--- a/Sources/AWSSDKSwiftCore/MetaDataService.swift
+++ b/Sources/AWSSDKSwiftCore/MetaDataService.swift
@@ -89,7 +89,7 @@ struct MetaDataService {
     }
 
     static func request(host: String, uri: String, timeout: TimeInterval) -> Future<HTTPClient.Response> {
-        let client = HTTPClient()
+        let client = HTTPClient(eventLoopGroupProvider: .shared(AWSClient.eventGroup))
         let head = HTTPRequestHead(
                      version: HTTPVersion(major: 1, minor: 1),
                      method: .GET,

--- a/Tests/AWSSDKSwiftCoreTests/HTTPClientTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/HTTPClientTests.swift
@@ -25,7 +25,7 @@ class HTTPClientTests: XCTestCase {
 
     func testInitWithInvalidURL() {
       do {
-        let client = try HTTPClient(url: URL(string:"no_protocol.com")!)
+        let client = HTTPClient()
         let head = HTTPRequestHead(version: HTTPVersion(major: 1, minor: 1), method: .GET, uri: "no_protocol.com")
         let request = HTTPClient.Request(head: head, body: Data())
         _ = try client.connect(request).wait()
@@ -39,8 +39,8 @@ class HTTPClientTests: XCTestCase {
     }
 
     func testInitWithValidRL() {
+        let client = HTTPClient()
         do {
-            let client = try HTTPClient(url: URL(string:"https://kinesis.us-west-2.amazonaws.com/")!)
             let head = HTTPRequestHead(version: HTTPVersion(major: 1, minor: 1), method: .GET, uri: "https://kinesis.us-west-2.amazonaws.com/")
             let request = HTTPClient.Request(head: head, body: Data())
             _ = try client.connect(request).wait()
@@ -49,7 +49,6 @@ class HTTPClientTests: XCTestCase {
         }
 
         do {
-            let client = try HTTPClient(url: URL(string:"http://169.254.169.254/latest/meta-data/iam/security-credentials/")!)
             let head = HTTPRequestHead(version: HTTPVersion(major: 1, minor: 1), method: .GET, uri: "http://169.254.169.254/latest/meta-data/iam/security-credentials/")
             let request = HTTPClient.Request(head: head, body: Data())
             _ = try client.connect(request).wait()
@@ -61,7 +60,7 @@ class HTTPClientTests: XCTestCase {
 
     func testConnectSimpleGet() {
         do {
-            let client = try HTTPClient(url: URL(string:"https://kinesis.us-west-2.amazonaws.com/")!)
+            let client = HTTPClient()
             let head = HTTPRequestHead(
                          version: HTTPVersion(major: 1, minor: 1),
                          method: .GET,
@@ -81,7 +80,7 @@ class HTTPClientTests: XCTestCase {
 
     func testConnectGet() {
         do {
-            let client = try HTTPClient(url: URL(string:"https://kinesis.us-west-2.amazonaws.com/")!)
+            let client = HTTPClient()
             let head = HTTPRequestHead(
                          version: HTTPVersion(major: 1, minor: 1),
                          method: .GET,
@@ -101,7 +100,7 @@ class HTTPClientTests: XCTestCase {
 
     func testConnectPost() {
         do {
-            let client = try HTTPClient(url: URL(string:"https://kinesis.us-west-2.amazonaws.com/")!)
+            let client = HTTPClient()
             let head = HTTPRequestHead(
                          version: HTTPVersion(major: 1, minor: 1),
                          method: .GET,

--- a/Tests/AWSSDKSwiftCoreTests/HTTPClientTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/HTTPClientTests.swift
@@ -25,8 +25,11 @@ class HTTPClientTests: XCTestCase {
 
     func testInitWithInvalidURL() {
       do {
-          _ = try HTTPClient(url: URL(string: "no_protocol.com")!)
-          XCTFail("Should throw malformedURL error")
+        let client = try HTTPClient(url: URL(string:"no_protocol.com")!)
+        let head = HTTPRequestHead(version: HTTPVersion(major: 1, minor: 1), method: .GET, uri: "no_protocol.com")
+        let request = HTTPClient.Request(head: head, body: Data())
+        _ = try client.connect(request).wait()
+        XCTFail("Should throw malformedURL error")
       } catch {
         if case HTTPClient.HTTPError.malformedURL = error {}
         else {
@@ -36,85 +39,83 @@ class HTTPClientTests: XCTestCase {
     }
 
     func testInitWithValidRL() {
-      do {
-          _ = try HTTPClient(url: URL(string: "https://kinesis.us-west-2.amazonaws.com/")!)
-      } catch {
-          XCTFail("Should not throw malformedURL error")
-      }
+        do {
+            let client = try HTTPClient(url: URL(string:"https://kinesis.us-west-2.amazonaws.com/")!)
+            let head = HTTPRequestHead(version: HTTPVersion(major: 1, minor: 1), method: .GET, uri: "https://kinesis.us-west-2.amazonaws.com/")
+            let request = HTTPClient.Request(head: head, body: Data())
+            _ = try client.connect(request).wait()
+        } catch {
+            XCTFail("Should not throw malformedURL error")
+        }
 
-      do {
-          _ = try HTTPClient(url: URL(string: "http://169.254.169.254/latest/meta-data/iam/security-credentials/")!)
-      } catch {
-          XCTFail("Should not throw malformedURL error")
-      }
-    }
-
-    func testInitWithHostAndPort() {
-        let url = URL(string: "https://kinesis.us-west-2.amazonaws.com/")!
-        _ = HTTPClient(hostname: url.host!, port: 443)
+        do {
+            let client = try HTTPClient(url: URL(string:"http://169.254.169.254/latest/meta-data/iam/security-credentials/")!)
+            let head = HTTPRequestHead(version: HTTPVersion(major: 1, minor: 1), method: .GET, uri: "http://169.254.169.254/latest/meta-data/iam/security-credentials/")
+            let request = HTTPClient.Request(head: head, body: Data())
+            _ = try client.connect(request).wait()
+        } catch HTTPClient.HTTPError.malformedURL{
+            XCTFail("Should not throw malformedURL error")
+        } catch {
+        }
     }
 
     func testConnectSimpleGet() {
-        let url = URL(string: "https://kinesis.us-west-2.amazonaws.com/")!
-        let client = HTTPClient(hostname: url.host!, port: 443)
-        let head = HTTPRequestHead(
-                     version: HTTPVersion(major: 1, minor: 1),
-                     method: .GET,
-                     uri: url.path
-                   )
-        let request = HTTPClient.Request(head: head, body: Data())
-        let future = client.connect(request)
-        future.whenSuccess { response in }
-        future.whenFailure { error in }
-        future.whenComplete { _ in }
-
         do {
-            _ = try HTTPClient(url: URL(string: "http://169.254.169.254/latest/meta-data/iam/security-credentials/")!)
+            let client = try HTTPClient(url: URL(string:"https://kinesis.us-west-2.amazonaws.com/")!)
+            let head = HTTPRequestHead(
+                         version: HTTPVersion(major: 1, minor: 1),
+                         method: .GET,
+                         uri: "https://kinesis.us-west-2.amazonaws.com/"
+                       )
+            let request = HTTPClient.Request(head: head, body: Data())
+            let future = client.connect(request)
+            future.whenSuccess { response in }
+            future.whenFailure { error in }
+            future.whenComplete { _ in }
+
+            _ = try future.wait()
         } catch {
-            XCTFail("Should not throw malformedURL error")
+            XCTFail(error.localizedDescription)
         }
     }
 
     func testConnectGet() {
-
-        let url = URL(string: "https://kinesis.us-west-2.amazonaws.com/")!
-        let client = HTTPClient(hostname: url.host!, port: 443)
-        let head = HTTPRequestHead(
-                     version: HTTPVersion(major: 1, minor: 1),
-                     method: .GET,
-                     uri: url.path
-                   )
-        let request = HTTPClient.Request(head: head, body: Data())
-        let future = client.connect(request)
-        future.whenSuccess { response in }
-        future.whenFailure { error in }
-        future.whenComplete { _ in }
-
         do {
-            _ = try HTTPClient(url: URL(string: "http://169.254.169.254/latest/meta-data/iam/security-credentials/")!)
+            let client = try HTTPClient(url: URL(string:"https://kinesis.us-west-2.amazonaws.com/")!)
+            let head = HTTPRequestHead(
+                         version: HTTPVersion(major: 1, minor: 1),
+                         method: .GET,
+                         uri: "https://kinesis.us-west-2.amazonaws.com/"
+                       )
+            let request = HTTPClient.Request(head: head, body: Data())
+            let future = client.connect(request)
+            future.whenSuccess { response in }
+            future.whenFailure { error in }
+            future.whenComplete { _ in }
+
+            _ = try future.wait()
         } catch {
-            XCTFail("Should not throw malformedURL error")
+            XCTFail(error.localizedDescription)
         }
     }
 
     func testConnectPost() {
-        let url = URL(string: "https://kinesis.us-west-2.amazonaws.com/")!
-        let client = HTTPClient(hostname: url.host!, port: 443)
-        let head = HTTPRequestHead(
-                     version: HTTPVersion(major: 1, minor: 1),
-                     method: .GET,
-                     uri: url.path
-                   )
-        let request = HTTPClient.Request(head: head, body: Data())
-        let future = client.connect(request)
-        future.whenSuccess { response in }
-        future.whenFailure { error in }
-        future.whenComplete { _ in }
-
         do {
-            _ = try HTTPClient(url: URL(string: "http://169.254.169.254/latest/meta-data/iam/security-credentials/")!)
+            let client = try HTTPClient(url: URL(string:"https://kinesis.us-west-2.amazonaws.com/")!)
+            let head = HTTPRequestHead(
+                         version: HTTPVersion(major: 1, minor: 1),
+                         method: .GET,
+                         uri: "https://kinesis.us-west-2.amazonaws.com/"
+                       )
+            let request = HTTPClient.Request(head: head, body: Data())
+            let future = client.connect(request)
+            future.whenSuccess { response in }
+            future.whenFailure { error in }
+            future.whenComplete { _ in }
+
+            _ = try future.wait()
         } catch {
-            XCTFail("Should not throw malformedURL error")
+            XCTFail(error.localizedDescription)
         }
     }
 

--- a/Tests/AWSSDKSwiftCoreTests/HTTPClientTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/HTTPClientTests.swift
@@ -13,19 +13,24 @@ import XCTest
 
 class HTTPClientTests: XCTestCase {
 
-      static var allTests : [(String, (HTTPClientTests) -> () throws -> Void)] {
-          return [
-              ("testInitWithInvalidURL", testInitWithInvalidURL),
-              ("testInitWithValidRL", testInitWithValidRL),
-              ("testConnectSimpleGet", testConnectSimpleGet),
-              ("testConnectGet", testConnectGet),
-              ("testConnectPost", testConnectPost)
-          ]
-      }
+    let client = HTTPClient()
+
+    deinit {
+        try? client.syncShutdown()
+    }
+    
+    static var allTests : [(String, (HTTPClientTests) -> () throws -> Void)] {
+        return [
+            ("testInitWithInvalidURL", testInitWithInvalidURL),
+            ("testInitWithValidRL", testInitWithValidRL),
+            ("testConnectSimpleGet", testConnectSimpleGet),
+            ("testConnectGet", testConnectGet),
+            ("testConnectPost", testConnectPost)
+        ]
+    }
 
     func testInitWithInvalidURL() {
       do {
-        let client = HTTPClient()
         let head = HTTPRequestHead(version: HTTPVersion(major: 1, minor: 1), method: .GET, uri: "no_protocol.com")
         let request = HTTPClient.Request(head: head, body: Data())
         _ = try client.connect(request).wait()
@@ -39,7 +44,6 @@ class HTTPClientTests: XCTestCase {
     }
 
     func testInitWithValidRL() {
-        let client = HTTPClient()
         do {
             let head = HTTPRequestHead(version: HTTPVersion(major: 1, minor: 1), method: .GET, uri: "https://kinesis.us-west-2.amazonaws.com/")
             let request = HTTPClient.Request(head: head, body: Data())
@@ -60,7 +64,6 @@ class HTTPClientTests: XCTestCase {
 
     func testConnectSimpleGet() {
         do {
-            let client = HTTPClient()
             let head = HTTPRequestHead(
                          version: HTTPVersion(major: 1, minor: 1),
                          method: .GET,
@@ -80,7 +83,6 @@ class HTTPClientTests: XCTestCase {
 
     func testConnectGet() {
         do {
-            let client = HTTPClient()
             let head = HTTPRequestHead(
                          version: HTTPVersion(major: 1, minor: 1),
                          method: .GET,
@@ -100,7 +102,6 @@ class HTTPClientTests: XCTestCase {
 
     func testConnectPost() {
         do {
-            let client = HTTPClient()
             let head = HTTPRequestHead(
                          version: HTTPVersion(major: 1, minor: 1),
                          method: .GET,

--- a/Tests/AWSSDKSwiftCoreTests/MetaDataServiceTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/MetaDataServiceTests.swift
@@ -44,7 +44,7 @@ class MetaDataServiceTests: XCTestCase {
 
        do {
            let uri = try MetaDataService.serviceProvider.uri().wait()
-           XCTAssertEqual(uri, "/v2/credentials/5275a487-9ff6-49b7-b50c-b64850f99999")
+           XCTAssertEqual(uri, "http://169.254.170.2/v2/credentials/5275a487-9ff6-49b7-b50c-b64850f99999")
        } catch {
            XCTFail("\(error)")
            return


### PR DESCRIPTION
- Moved the HTTP request setup into a HTTPClientRequestSerializer class and out of ClientBootstrap code. Similar to how other http clients are doing. Its looks much cleaner.
- HTTPClient.init() no longer needs the host details. Although we don't do this, could allow us to re-use the same HTTPClient for multiple calls.
- Implemented EventLoopGroupProvider enum and initialise HTTPClient with one.
- Use AWSClient.eventGroup in HTTPClient
