### PR TITLE
Remove the debugValidate and debugCreateAWSRequest

### DIFF
--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -312,7 +312,7 @@ extension AWSClient {
         }
     }
 
-    fileprivate func createAWSRequest(operation operationName: String, path: String, httpMethod: String) throws -> AWSRequest {
+    internal func createAWSRequest(operation operationName: String, path: String, httpMethod: String) throws -> AWSRequest {
 
         guard let url = URL(string: "\(endpoint)\(path)"), let _ = url.hostWithPort else {
             throw RequestError.invalidURL("\(endpoint)\(path) must specify url host and scheme")
@@ -329,7 +329,7 @@ extension AWSClient {
         ).applyMiddlewares(middlewares)
     }
 
-    fileprivate func createAWSRequest<Input: AWSShape>(operation operationName: String, path: String, httpMethod: String, input: Input) throws -> AWSRequest {
+    internal func createAWSRequest<Input: AWSShape>(operation operationName: String, path: String, httpMethod: String, input: Input) throws -> AWSRequest {
         var headers: [String: Any] = [:]
         var path = path
         var urlComponents = URLComponents()
@@ -525,21 +525,11 @@ extension AWSClient {
     }
 }
 
-// debug request creator
-#if DEBUG
-extension AWSClient {
-
-    func debugCreateAWSRequest<Input: AWSShape>(operation operationName: String, path: String, httpMethod: String, input: Input) throws -> AWSRequest {
-        return try createAWSRequest(operation: operationName, path: path, httpMethod: httpMethod, input: input)
-    }
-}
-#endif
-
 // response validator
 extension AWSClient {
 
     /// Validate the operation response and return a response shape
-    fileprivate func validate<Output: AWSShape>(operation operationName: String, response: HTTPClient.Response) throws -> Output {
+    internal func validate<Output: AWSShape>(operation operationName: String, response: HTTPClient.Response) throws -> Output {
         let raw: Bool
         if let payloadPath = Output.payloadPath, let member = Output.getMember(named: payloadPath), member.type == .blob {
             raw = true
@@ -632,7 +622,7 @@ extension AWSClient {
     }
 
     /// validate response without returning an output shape
-    private func validate(response: HTTPClient.Response) throws {
+    internal func validate(response: HTTPClient.Response) throws {
         let awsResponse = try AWSResponse(from: response, serviceProtocolType: serviceProtocol.type)
         try validateCode(response: awsResponse)
     }
@@ -767,21 +757,6 @@ extension AWSClient {
         return AWSError(message: message ?? "Unhandled Error. Response Code: \(response.status.code)", rawBody: rawBodyString ?? "")
     }
 }
-
-// debug request validator
-#if DEBUG
-extension AWSClient {
-
-    func debugValidate(response: HTTPClient.Response) throws {
-        try validate(response: response)
-    }
-
-    func debugValidate<Output: AWSShape>(operation operationName: String, response: HTTPClient.Response) throws -> Output {
-        return try validate(operation: operationName, response: response)
-    }
-}
-#endif
-
 
 extension AWSClient.RequestError: CustomStringConvertible {
     public var description: String {

--- a/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
@@ -154,7 +154,7 @@ class AWSClientTests: XCTestCase {
         let input3 = F(fooParams: input2)
 
         do {
-            let awsRequest = try sesClient.debugCreateAWSRequest(
+            let awsRequest = try sesClient.createAWSRequest(
                 operation: "SendEmail",
                 path: "/",
                 httpMethod: "POST",
@@ -182,7 +182,7 @@ class AWSClientTests: XCTestCase {
         )
 
         do {
-            let awsRequest = try kinesisClient.debugCreateAWSRequest(
+            let awsRequest = try kinesisClient.createAWSRequest(
                 operation: "PutRecord",
                 path: "/",
                 httpMethod: "POST",
@@ -214,7 +214,7 @@ class AWSClientTests: XCTestCase {
         }
 
         do {
-            let awsRequest = try s3Client.debugCreateAWSRequest(
+            let awsRequest = try s3Client.createAWSRequest(
                 operation: "ListObjectsV2",
                 path: "/Bucket?list-type=2",
                 httpMethod: "GET",
@@ -232,7 +232,7 @@ class AWSClientTests: XCTestCase {
         // encode for restxml
         //
         do {
-            let awsRequest = try s3Client.debugCreateAWSRequest(
+            let awsRequest = try s3Client.createAWSRequest(
                 operation: "payloadPath",
                 path: "/Bucket?list-type=2",
                 httpMethod: "POST",
@@ -255,7 +255,7 @@ class AWSClientTests: XCTestCase {
         // encode for json
         //
         do {
-            let awsRequest = try kinesisClient.debugCreateAWSRequest(
+            let awsRequest = try kinesisClient.createAWSRequest(
                 operation: "PutRecord",
                 path: "/",
                 httpMethod: "POST",
@@ -289,7 +289,7 @@ class AWSClientTests: XCTestCase {
         )
 
         do {
-            let awsRequest = try kinesisClient.debugCreateAWSRequest(
+            let awsRequest = try kinesisClient.createAWSRequest(
                 operation: "PutRecord",
                 path: "/",
                 httpMethod: "POST",
@@ -322,7 +322,7 @@ class AWSClientTests: XCTestCase {
             body: Data()
         )
         do {
-            try s3Client.debugValidate(response: response)
+            try s3Client.validate(response: response)
         } catch {
             XCTFail(error.localizedDescription)
         }
@@ -336,7 +336,7 @@ class AWSClientTests: XCTestCase {
         )
 
         do {
-            try s3Client.debugValidate(response: failResponse)
+            try s3Client.validate(response: failResponse)
             XCTFail("call to validateCode should throw an error")
         } catch {
             XCTAssertTrue(true)
@@ -355,7 +355,7 @@ class AWSClientTests: XCTestCase {
             body: "<Output><name>hello</name></Output>".data(using: .utf8)!
         )
         do {
-            let output : Output = try s3Client.debugValidate(operation: "Output", response: response)
+            let output : Output = try s3Client.validate(operation: "Output", response: response)
             XCTAssertEqual(output.name, "hello")
         } catch {
             XCTFail(error.localizedDescription)
@@ -375,7 +375,7 @@ class AWSClientTests: XCTestCase {
             body: "<name>hello</name>".data(using: .utf8)!
         )
         do {
-            let output : Output = try s3Client.debugValidate(operation: "Output", response: response)
+            let output : Output = try s3Client.validate(operation: "Output", response: response)
             XCTAssertEqual(output.name, "hello")
         } catch {
             XCTFail(error.localizedDescription)
@@ -391,7 +391,7 @@ class AWSClientTests: XCTestCase {
             body: "<Error><Code>NoSuchKey</Code><Message>It doesn't exist</Message></Error>".data(using: .utf8)!
         )
         do {
-            try s3Client.debugValidate(response: response)
+            try s3Client.validate(response: response)
             XCTFail("Should not get here")
         } catch S3ErrorType.noSuchKey(let message) {
             XCTAssertEqual(message, "Message: It doesn't exist")
@@ -412,7 +412,7 @@ class AWSClientTests: XCTestCase {
             body: "{\"name\":\"hello\"}".data(using: .utf8)!
         )
         do {
-            let output : Output = try kinesisClient.debugValidate(operation: "Output", response: response)
+            let output : Output = try kinesisClient.validate(operation: "Output", response: response)
             XCTAssertEqual(output.name, "hello")
         } catch {
             XCTFail(error.localizedDescription)
@@ -435,7 +435,7 @@ class AWSClientTests: XCTestCase {
             body: "{\"name\":\"hello\"}".data(using: .utf8)!
         )
         do {
-            let output : Output = try kinesisClient.debugValidate(operation: "Output", response: response)
+            let output : Output = try kinesisClient.validate(operation: "Output", response: response)
             XCTAssertEqual(output.output2.name, "hello")
         } catch {
             XCTFail(error.localizedDescription)
@@ -451,7 +451,7 @@ class AWSClientTests: XCTestCase {
             body: "{\"__type\":\"ResourceNotFoundException\", \"message\": \"Donald Where's Your Troosers?\"}".data(using: .utf8)!
         )
         do {
-            try kinesisClient.debugValidate(response: response)
+            try kinesisClient.validate(response: response)
             XCTFail("Should not get here")
         } catch KinesisErrorType.resourceNotFoundException(let message) {
             XCTAssertEqual(message, "Donald Where's Your Troosers?")


### PR DESCRIPTION
We still control the usage of these methods when protected with internal, and this removes extra code during debug vs. release builds

Let's fixup https://github.com/swift-aws/aws-sdk-swift-core/issues/43