### PR TITLE
Provide a path for initialising a service without credentials

### DIFF
--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -98,7 +98,8 @@ public class AWSClient {
         } else if let scredential = try? SharedCredential() {
             credential = scredential
         } else {
-            credential = Credential(accessKeyId: "", secretAccessKey: "")
+            // create an expired credential
+            credential = Credential(accessKeyId: "", secretAccessKey: "", expiration: Date.init(timeIntervalSince1970: 0))
         }
 
         let region: Region

--- a/Sources/AWSSDKSwiftCore/MetaDataService.swift
+++ b/Sources/AWSSDKSwiftCore/MetaDataService.swift
@@ -6,6 +6,8 @@
 //
 //
 
+#if os(Linux)
+
 import Foundation
 import NIO
 import NIOHTTP1
@@ -219,3 +221,5 @@ extension MetaDataService.MetaData {
 
     }
 }
+
+#endif // os(Linux)

--- a/Sources/AWSSDKSwiftCore/Signers/V4.swift
+++ b/Sources/AWSSDKSwiftCore/Signers/V4.swift
@@ -49,11 +49,7 @@ extension Signers {
         public func manageCredential() -> Future<CredentialProvider> {
             if credential.nearExpiration() {
                 do {
-                    return try MetaDataService.getCredential()
-                        .flatMapError { _ in
-                            return AWSClient.eventGroup.next().makeSucceededFuture(Credential(accessKeyId: "", secretAccessKey: ""))
-                        }
-                        .map { credential in
+                    return try MetaDataService.getCredential().map { credential in
                             self.credential = credential
                             return credential
                     }

--- a/Sources/AWSSDKSwiftCore/Signers/V4.swift
+++ b/Sources/AWSSDKSwiftCore/Signers/V4.swift
@@ -47,6 +47,7 @@ extension Signers {
 
         /// If you did not provide credentials `manageCredential()` should be called and the future resolved prior to building signedURL or signedHeaders to ensure latest credentials are retreived and set
         public func manageCredential() -> Future<CredentialProvider> {
+#if os(Linux)
             if credential.nearExpiration() {
                 do {
                     return try MetaDataService.getCredential().map { credential in
@@ -57,7 +58,7 @@ extension Signers {
                     // should not be crash
                 }
             }
-
+#endif // os(Linux)
             return AWSClient.eventGroup.next().makeSucceededFuture(credential)
         }
 

--- a/Tests/AWSSDKSwiftCoreTests/MetaDataServiceTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/MetaDataServiceTests.swift
@@ -4,6 +4,7 @@
 //
 //  Created by Jonathan McAllister on 2017/12/29.
 //
+#if os(Linux)
 
 import Foundation
 import XCTest
@@ -81,3 +82,5 @@ class MetaDataServiceTests: XCTestCase {
     }
   }
 }
+
+#endif // os(Linux)

--- a/Tests/AWSSDKSwiftCoreTests/SignersV4Tests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/SignersV4Tests.swift
@@ -22,7 +22,6 @@ class SignersV4Tests: XCTestCase {
             ("testSignedHeadersForS3", testSignedHeadersForS3),
             ("testSignedGETQuery", testSignedGETQuery),
             ("testSignedHEADQuery", testSignedHEADQuery),
-            ("testGivingCustomEndpointAndEmptyCredential", testGivingCustomEndpointAndEmptyCredential)
         ]
     }
 
@@ -142,15 +141,5 @@ class SignersV4Tests: XCTestCase {
         let signedURL = sign.signedURL(url: url, method: "HEAD", date: requestDate)
 
         XCTAssertEqual(signedURL.absoluteString, "https://s3-apnortheast1.amazon.com?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=key%2F20170101%2Fap-northeast-1%2Fs3%2Faws4_request&X-Amz-Date=20170101T000000Z&X-Amz-Expires=86400&X-Amz-SignedHeaders=host&X-Amz-Signature=74bea6a033f90cc7a4f23f9f315b1d2c1865f55d1e51f062228301dffc68048b")
-    }
-
-    func testGivingCustomEndpointAndEmptyCredential() {
-        let url = URL(string: "http://localhost:8000")!
-
-        let emptyCred = Credential(accessKeyId: "", secretAccessKey: "")
-        let sign = Signers.V4(credential: emptyCred, region: .apnortheast1, signingName: "s3", endpoint: url.absoluteString)
-
-        let headers = sign.signedHeaders(url: url, headers: [:], method: "PUT", bodyData: Data())
-        XCTAssertEqual(headers["Host"], "localhost:8000")
     }
 }


### PR DESCRIPTION
CognitoIdentity and CognitoIdentityProvider can be used without authentication details. These changes allow for this to happen. 

- In AWSClient.init() If accessKeyId and secretAccessKey are nil create an expired credential.
- Metadata service is only used when credentials have expired
- Don't sign requests with empty credentials
- This means you can initialize AWSClient with accessKeyId: "", secretAccessKey: "" and avoid asking for EC2/ECS credentials and not sign requests
- CognitoIdentityProvider works without signed credentials
- Removed invalid signing test