### PR TITLE
Added an option to inject the EventLoopGroup into the AWSClient.

### DIFF
--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -147,7 +147,7 @@ public class AWSClient {
 // invoker
 extension AWSClient {
     fileprivate func invoke(_ nioRequest: HTTPClient.Request) -> Future<HTTPClient.Response> {
-        let client = HTTPClient(eventLoopGroupProvider: .shared(self.eventLoopGroup))
+        let client = HTTPClient(eventLoopGroupProvider: .shared(eventLoopGroup))
         let futureResponse = client.connect(nioRequest)
 
         futureResponse.whenComplete { _ in
@@ -175,7 +175,7 @@ extension AWSClient {
     ///     Empty Future that completes when response is received
     public func send<Input: AWSShape>(operation operationName: String, path: String, httpMethod: String, input: Input) -> Future<Void> {
 
-        return signer.manageCredential(eventLoopGroup: self.eventLoopGroup).flatMapThrowing { _ in
+        return signer.manageCredential(eventLoopGroup: eventLoopGroup).flatMapThrowing { _ in
                 let awsRequest = try self.createAWSRequest(
                     operation: operationName,
                     path: path,
@@ -199,7 +199,7 @@ extension AWSClient {
     ///     Empty Future that completes when response is received
     public func send(operation operationName: String, path: String, httpMethod: String) -> Future<Void> {
 
-        return signer.manageCredential(eventLoopGroup: self.eventLoopGroup).flatMapThrowing { _ in
+        return signer.manageCredential(eventLoopGroup: eventLoopGroup).flatMapThrowing { _ in
                 let awsRequest = try self.createAWSRequest(
                     operation: operationName,
                     path: path,
@@ -222,7 +222,7 @@ extension AWSClient {
     ///     Future containing output object that completes when response is received
     public func send<Output: AWSShape>(operation operationName: String, path: String, httpMethod: String) -> Future<Output> {
 
-        return signer.manageCredential(eventLoopGroup: self.eventLoopGroup).flatMapThrowing { _ in
+        return signer.manageCredential(eventLoopGroup: eventLoopGroup).flatMapThrowing { _ in
                 let awsRequest = try self.createAWSRequest(
                     operation: operationName,
                     path: path,
@@ -246,7 +246,7 @@ extension AWSClient {
     ///     Future containing output object that completes when response is received
     public func send<Output: AWSShape, Input: AWSShape>(operation operationName: String, path: String, httpMethod: String, input: Input) -> Future<Output> {
 
-            return signer.manageCredential(eventLoopGroup: self.eventLoopGroup).flatMapThrowing { _ in
+            return signer.manageCredential(eventLoopGroup: eventLoopGroup).flatMapThrowing { _ in
                     let awsRequest = try self.createAWSRequest(
                         operation: operationName,
                         path: path,

--- a/Sources/AWSSDKSwiftCore/HTTPClient.swift
+++ b/Sources/AWSSDKSwiftCore/HTTPClient.swift
@@ -174,7 +174,7 @@ public final class HTTPClient {
         let response: EventLoopPromise<Response> = self.eventLoopGroup.next().makePromise()
 
         #if canImport(Network)
-            if #available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *) {
+            if #available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *), eventLoopGroup is NIOTSEventLoopGroup {
                 tsConnectionBootstrap(hostname: hostname, port: port, headerHostname: headerHostname, request: request, response: response)
             } else {
                 clientBootstrap(hostname: hostname, port: port, headerHostname: headerHostname, request: request, response: response)


### PR DESCRIPTION
PR for issue #137

### Notes:

In order to check if anything else was using `AWSClient.eventGroup` I deprecated `eventGroup`:

```swift
  @available(*, deprecated, message: "Consumers of this API shoud provide their own runtime at the initialization of an AWSClient with the EventLoopGroupProvider.use(eventLoopGroup) option.")
  public static let eventGroup: EventLoopGroup = _eventGroup
  private static let _eventGroup: EventLoopGroup = createEventLoopGroup()
```

This made me aware that `AWSClient.eventGroup` was also used in `Signers.V4` and `MetaDataService`. Therefore I had to dig deeper to change those APIs. I did so by dependency injection from `AWSClient`. Sadly those are breaking API changes (at least for Signers.V4 since this is a public class). It is to be discussed how many consumers use `Signers.V4` directly and how big of an impact this change is.

One could argue that we should avoid API Changes no matter what. On the other hand changing those APIs would allow us to reduce the impact of the shared `EventLoopGroup`.

I've also prepared the according changes for the `aws-sdk-swift` package. I will create a PR for this, as soon as this PR is accepted.
