### PR TITLE
Adjustments as discussed in PR #139

### DIFF
--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -71,7 +71,7 @@ public class AWSClient {
         return "\(service).\(signer.region.rawValue).amazonaws.com"
     }
 
-    public static let sharedEventLoopGroup: EventLoopGroup = createEventLoopGroup()
+    private static let sharedEventLoopGroup: EventLoopGroup = createEventLoopGroup()
 
     /// create an eventLoopGroup
     static func createEventLoopGroup() -> EventLoopGroup {
@@ -99,7 +99,8 @@ public class AWSClient {
     ///     - partitionEndpoint: Default endpoint to use
     ///     - middlewares: Array of middlewares to apply to requests and responses
     ///     - possibleErrorTypes: Array of possible error types that the client can throw
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region givenRegion: Region?, amzTarget: String? = nil, service: String, signingName: String? = nil, serviceProtocol: ServiceProtocol, apiVersion: String, endpoint: String? = nil, serviceEndpoints: [String: String] = [:], partitionEndpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], possibleErrorTypes: [AWSErrorType.Type]? = nil, eventLoopGroupProvider: EventLoopGroupProvider = .useAWSClientShared) {
+    ///     - eventLoopGroupProvider: EventLoopGroup to use. Use `useAWSClientShared` if the client shall manage its own EventLoopGroup.
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region givenRegion: Region?, amzTarget: String? = nil, service: String, signingName: String? = nil, serviceProtocol: ServiceProtocol, apiVersion: String, endpoint: String? = nil, serviceEndpoints: [String: String] = [:], partitionEndpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], possibleErrorTypes: [AWSErrorType.Type]? = nil, eventLoopGroupProvider: EventLoopGroupProvider) {
         let credential: CredentialProvider
         if let accessKey = accessKeyId, let secretKey = secretAccessKey {
             credential = Credential(accessKeyId: accessKey, secretAccessKey: secretKey, sessionToken: sessionToken)

--- a/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
@@ -75,9 +75,7 @@ class AWSClientTests: XCTestCase {
 
     func testGetCredential() {
         let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer {
-           XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully())
-        }
+        defer { XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully()) }
         
         let sesClient = AWSClient(
             accessKeyId: "key",
@@ -126,7 +124,8 @@ class AWSClientTests: XCTestCase {
         serviceProtocol: ServiceProtocol(type: .query),
         apiVersion: "2013-12-01",
         middlewares: [AWSLoggingMiddleware()],
-        possibleErrorTypes: [SESErrorType.self]
+        possibleErrorTypes: [SESErrorType.self],
+        eventLoopGroupProvider: .useAWSClientShared
     )
 
     let kinesisClient = AWSClient(
@@ -138,7 +137,8 @@ class AWSClientTests: XCTestCase {
         serviceProtocol: ServiceProtocol(type: .json, version: ServiceProtocol.Version(major: 1, minor: 1)),
         apiVersion: "2013-12-02",
         middlewares: [AWSLoggingMiddleware()],
-        possibleErrorTypes: [KinesisErrorType.self]
+        possibleErrorTypes: [KinesisErrorType.self],
+        eventLoopGroupProvider: .useAWSClientShared
     )
 
     let s3Client = AWSClient(
@@ -152,10 +152,14 @@ class AWSClientTests: XCTestCase {
         serviceEndpoints: ["us-west-2": "s3.us-west-2.amazonaws.com", "eu-west-1": "s3.eu-west-1.amazonaws.com", "us-east-1": "s3.amazonaws.com", "ap-northeast-1": "s3.ap-northeast-1.amazonaws.com", "s3-external-1": "s3-external-1.amazonaws.com", "ap-southeast-2": "s3.ap-southeast-2.amazonaws.com", "sa-east-1": "s3.sa-east-1.amazonaws.com", "ap-southeast-1": "s3.ap-southeast-1.amazonaws.com", "us-west-1": "s3.us-west-1.amazonaws.com"],
         partitionEndpoint: "us-east-1",
         middlewares: [AWSLoggingMiddleware()],
-        possibleErrorTypes: [S3ErrorType.self]
+        possibleErrorTypes: [S3ErrorType.self],
+        eventLoopGroupProvider: .useAWSClientShared
     )
 
     func testCreateAWSRequest() {
+        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully()) }
+      
         let input1 = C()
         let input2 = E()
         let input3 = F(fooParams: input2)
@@ -185,7 +189,8 @@ class AWSClientTests: XCTestCase {
             serviceProtocol: ServiceProtocol(type: .json, version: ServiceProtocol.Version(major: 1, minor: 1)),
             apiVersion: "2013-12-02",
             middlewares: [],
-            possibleErrorTypes: [KinesisErrorType.self]
+            possibleErrorTypes: [KinesisErrorType.self],
+            eventLoopGroupProvider: .shared(eventLoopGroup)
         )
 
         do {
@@ -281,6 +286,9 @@ class AWSClientTests: XCTestCase {
     }
 
     func testCreateNIORequest() {
+        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully()) }
+      
         let input2 = E()
 
         let kinesisClient = AWSClient(
@@ -292,7 +300,8 @@ class AWSClientTests: XCTestCase {
             serviceProtocol: ServiceProtocol(type: .json, version: ServiceProtocol.Version(major: 1, minor: 1)),
             apiVersion: "2013-12-02",
             middlewares: [],
-            possibleErrorTypes: [KinesisErrorType.self]
+            possibleErrorTypes: [KinesisErrorType.self],
+            eventLoopGroupProvider: .shared(eventLoopGroup)
         )
 
         do {


### PR DESCRIPTION
- `AWSClient`’s static shared instance of `eventLoopGroup` is now private.
- `AWSClient`’s initialiser does not have a default property for `EventLoopGroupProvider` anymore.