### PR TITLE
If GET request has a header then sign request using headers

### DIFF
--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -334,6 +334,9 @@ extension AWSClient {
             case .restjson:
                 return try createNIORequestWithSignedHeader(awsRequest)
             default:
+                if awsRequest.httpHeaders.count > 0 {
+                    return try createNIORequestWithSignedHeader(awsRequest)
+                }
                 return try createNIORequestWithSignedURL(awsRequest)
             }
         default:


### PR DESCRIPTION
If a GET request has headers sign the request with an authorization header. If we don't do this AWS complains that the headers are not signed.

Fixes issue sending s3.getObjectAcl() request.