### PR TITLE
Use AWSClient.eventLoopGroup in HTTPClient (merge into v3.x)

### DIFF
--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -61,7 +61,7 @@ public class AWSClient {
         return "\(service).\(signer.region.rawValue).amazonaws.com"
     }
 
-    public static let eventGroup: EventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+    public static let eventGroup: EventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
 
     /// Initialize an AWSClient struct
     /// - parameters:
@@ -119,17 +119,8 @@ public class AWSClient {
 // invoker
 extension AWSClient {
     fileprivate func invoke(_ nioRequest: HTTPClient.Request) -> Future<HTTPClient.Response> {
-        let client = HTTPClient(hostname: nioRequest.head.hostWithPort!, port: nioRequest.head.port ?? 443)
+        let client = HTTPClient(hostname: nioRequest.head.hostWithPort!, port: nioRequest.head.port ?? 443, eventGroup: AWSClient.eventGroup)
         let futureResponse = client.connect(nioRequest)
-
-        futureResponse.whenComplete {
-            client.close { error in
-                if let error = error {
-                    print("Error closing connection: \(error)")
-                }
-            }
-        }
-
         return futureResponse
     }
 }

--- a/Sources/AWSSDKSwiftCore/HTTPClient.swift
+++ b/Sources/AWSSDKSwiftCore/HTTPClient.swift
@@ -105,7 +105,7 @@ public final class HTTPClient {
     private let eventGroup: EventLoopGroup
 
     public init(url: URL,
-                eventGroup: EventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)) throws {
+                eventGroup: EventLoopGroup) throws {
         guard let scheme = url.scheme else {
             throw HTTPClient.HTTPError.malformedURL
         }
@@ -129,7 +129,7 @@ public final class HTTPClient {
 
     public init(hostname: String,
                 port: Int,
-                eventGroup: EventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)) {
+                eventGroup: EventLoopGroup) {
         self.headerHostname = hostname
         self.hostname = String(hostname.split(separator:":")[0])
         self.port = port
@@ -185,9 +185,5 @@ public final class HTTPClient {
                 response.fail(error: error)
         }
         return response.futureResult
-    }
-
-    public func close(_ callback: @escaping (Error?) -> Void) {
-        eventGroup.shutdownGracefully(callback)
     }
 }

--- a/Sources/AWSSDKSwiftCore/MetaDataService.swift
+++ b/Sources/AWSSDKSwiftCore/MetaDataService.swift
@@ -89,7 +89,7 @@ struct MetaDataService {
     }
 
     static func request(host: String, uri: String, timeout: TimeInterval) -> Future<HTTPClient.Response> {
-        let client = HTTPClient(hostname: host, port: 80)
+        let client = HTTPClient(hostname: host, port: 80, eventGroup: AWSClient.eventGroup)
         let head = HTTPRequestHead(
                      version: HTTPVersion(major: 1, minor: 1),
                      method: .GET,
@@ -97,15 +97,6 @@ struct MetaDataService {
                    )
         let request = HTTPClient.Request(head: head, body: Data())
         let futureResponse = client.connect(request)
-
-        futureResponse.whenComplete {
-            client.close { error in
-                if let error = error {
-                    print("Error closing connection: \(error)")
-                }
-            }
-        }
-
         return futureResponse
     }
 

--- a/Tests/AWSSDKSwiftCoreTests/HTTPClientTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/HTTPClientTests.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import NIO
 import NIOHTTP1
 import XCTest
 @testable import AWSSDKSwiftCore
@@ -22,10 +23,10 @@ class HTTPClientTests: XCTestCase {
               ("testConnectPost", testConnectPost)
           ]
       }
-
+    let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
     func testInitWithInvalidURL() {
       do {
-          _ = try HTTPClient(url: URL(string: "no_protocol.com")!)
+          _ = try HTTPClient(url: URL(string: "no_protocol.com")!, eventGroup: eventLoopGroup)
           XCTFail("Should throw malformedURL error")
       } catch {
         if case HTTPClient.HTTPError.malformedURL = error {}
@@ -37,13 +38,13 @@ class HTTPClientTests: XCTestCase {
 
     func testInitWithValidRL() {
       do {
-          _ = try HTTPClient(url: URL(string: "https://kinesis.us-west-2.amazonaws.com/")!)
+          _ = try HTTPClient(url: URL(string: "https://kinesis.us-west-2.amazonaws.com/")!, eventGroup: eventLoopGroup)
       } catch {
           XCTFail("Should not throw malformedURL error")
       }
 
       do {
-          _ = try HTTPClient(url: URL(string: "http://169.254.169.254/latest/meta-data/iam/security-credentials/")!)
+          _ = try HTTPClient(url: URL(string: "http://169.254.169.254/latest/meta-data/iam/security-credentials/")!, eventGroup: eventLoopGroup)
       } catch {
           XCTFail("Should not throw malformedURL error")
       }
@@ -51,12 +52,12 @@ class HTTPClientTests: XCTestCase {
 
     func testInitWithHostAndPort() {
         let url = URL(string: "https://kinesis.us-west-2.amazonaws.com/")!
-        _ = HTTPClient(hostname: url.host!, port: 443)
+        _ = HTTPClient(hostname: url.host!, port: 443, eventGroup: eventLoopGroup)
     }
 
     func testConnectSimpleGet() {
         let url = URL(string: "https://kinesis.us-west-2.amazonaws.com/")!
-        let client = HTTPClient(hostname: url.host!, port: 443)
+        let client = HTTPClient(hostname: url.host!, port: 443, eventGroup: eventLoopGroup)
         let head = HTTPRequestHead(
                      version: HTTPVersion(major: 1, minor: 1),
                      method: .GET,
@@ -69,7 +70,7 @@ class HTTPClientTests: XCTestCase {
         future.whenComplete { }
 
         do {
-            _ = try HTTPClient(url: URL(string: "http://169.254.169.254/latest/meta-data/iam/security-credentials/")!)
+            _ = try HTTPClient(url: URL(string: "http://169.254.169.254/latest/meta-data/iam/security-credentials/")!, eventGroup: eventLoopGroup)
         } catch {
             XCTFail("Should not throw malformedURL error")
         }
@@ -78,7 +79,7 @@ class HTTPClientTests: XCTestCase {
     func testConnectGet() {
 
         let url = URL(string: "https://kinesis.us-west-2.amazonaws.com/")!
-        let client = HTTPClient(hostname: url.host!, port: 443)
+        let client = HTTPClient(hostname: url.host!, port: 443, eventGroup: eventLoopGroup)
         let head = HTTPRequestHead(
                      version: HTTPVersion(major: 1, minor: 1),
                      method: .GET,
@@ -91,7 +92,7 @@ class HTTPClientTests: XCTestCase {
         future.whenComplete { }
 
         do {
-            _ = try HTTPClient(url: URL(string: "http://169.254.169.254/latest/meta-data/iam/security-credentials/")!)
+            _ = try HTTPClient(url: URL(string: "http://169.254.169.254/latest/meta-data/iam/security-credentials/")!, eventGroup: eventLoopGroup)
         } catch {
             XCTFail("Should not throw malformedURL error")
         }
@@ -99,7 +100,7 @@ class HTTPClientTests: XCTestCase {
 
     func testConnectPost() {
         let url = URL(string: "https://kinesis.us-west-2.amazonaws.com/")!
-        let client = HTTPClient(hostname: url.host!, port: 443)
+        let client = HTTPClient(hostname: url.host!, port: 443, eventGroup: eventLoopGroup)
         let head = HTTPRequestHead(
                      version: HTTPVersion(major: 1, minor: 1),
                      method: .GET,
@@ -112,7 +113,7 @@ class HTTPClientTests: XCTestCase {
         future.whenComplete { }
 
         do {
-            _ = try HTTPClient(url: URL(string: "http://169.254.169.254/latest/meta-data/iam/security-credentials/")!)
+            _ = try HTTPClient(url: URL(string: "http://169.254.169.254/latest/meta-data/iam/security-credentials/")!, eventGroup: eventLoopGroup)
         } catch {
             XCTFail("Should not throw malformedURL error")
         }


### PR DESCRIPTION
- HTTPClient has to be provided with an eventLoopGroup. It cannot create its own. Therefore does not need a close() function
- Use the static AWSClient.eventGroup in HTTPClient

This fixes the metadataservice hangs being experienced just now

We could extend this to be similar to the eventLoopGroupProvider changes in v4.x, but that would need considerable more changes on the aws-sdk-swift side as well