### PR TITLE
toSwiftVariableCase() shouldn't be adding `` to variable names in the runtime.

### DIFF
--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -421,7 +421,6 @@ extension AWSClient {
                     default:
                         body = Body(anyValue: payloadBody)
                     }
-                    headers.removeValue(forKey: payload.toSwiftVariableCase())
                 } else {
                     body = .empty
                 }
@@ -464,7 +463,6 @@ extension AWSClient {
                     default:
                         body = Body(anyValue: payloadBody)
                     }
-                    headers.removeValue(forKey: payload.toSwiftVariableCase())
                 } else {
                     body = .empty
                 }

--- a/Sources/AWSSDKSwiftCore/String.swift
+++ b/Sources/AWSSDKSwiftCore/String.swift
@@ -8,43 +8,6 @@
 
 import Foundation
 
-let swiftReservedWords: [String] = [
-    "protocol",
-    "return",
-    "operator",
-    "class",
-    "struct",
-    "break",
-    "continue",
-    "extension",
-    "self",
-    "public",
-    "private",
-    "internal",
-    "where",
-    "catch",
-    "try",
-    "default",
-    "case",
-    "static",
-    "switch",
-    "if",
-    "else",
-    "func",
-    "enum",
-    "true",
-    "false",
-    "nil",
-    "in",
-    "import",
-    "as",
-    "is",
-    "do",
-    "try",
-    "type",
-    "repeat"
-]
-
 extension String {
     public func lowerFirst() -> String {
         return String(self[startIndex]).lowercased() + self[index(after: startIndex)...]
@@ -61,26 +24,8 @@ extension String {
         return self.replacingOccurrences(of: "-", with: "_").camelCased()
     }
     
-    public func reservedwordEscaped() -> String {
-        if swiftReservedWords.contains(self.lowercased()) {
-            return "`\(self)`"
-        }
-        return self
-    }
-    
     public func toSwiftVariableCase() -> String {
-        return toSwiftLabelCase().reservedwordEscaped()
-    }
-    
-    public func toSwiftClassCase() -> String {
-        if self == "Type" {
-            return "`\(self)`"
-        }
-        
-        return self.replacingOccurrences(of: "-", with: "_")
-            .replacingOccurrences(of: ".", with: "")
-            .camelCased()
-            .upperFirst()
+        return toSwiftLabelCase()
     }
     
     public func camelCased(separator: String = "_") -> String {

--- a/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
@@ -285,6 +285,38 @@ class AWSClientTests: XCTestCase {
         }
     }
 
+    func testCreateAwsRequestWithKeywordInHeader() {
+        struct KeywordRequest: AWSShape {
+            static var _members: [AWSShapeMember] = [
+                AWSShapeMember(label: "repeat", location: .header(locationName: "repeat"), required: true, type: .string),
+            ]
+            let `repeat`: String
+        }
+        do {
+            let request = KeywordRequest(repeat: "Repeat")
+            let awsRequest = try s3Client.createAWSRequest(operation: "Keyword", path: "/", httpMethod: "POST", input: request)
+            XCTAssertEqual(awsRequest.httpHeaders["repeat"] as? String, "Repeat")
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
+    }
+    
+    func testCreateAwsRequestWithKeywordInQuery() {
+        struct KeywordRequest: AWSShape {
+            static var _members: [AWSShapeMember] = [
+                AWSShapeMember(label: "self", location: .querystring(locationName: "self"), required: true, type: .string),
+            ]
+            let `self`: String
+        }
+        do {
+            let request = KeywordRequest(self: "KeywordRequest")
+            let awsRequest = try s3Client.createAWSRequest(operation: "Keyword", path: "/", httpMethod: "POST", input: request)
+            XCTAssertEqual(awsRequest.url, URL(string:"https://s3.amazonaws.com/?self=KeywordRequest")!)
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
+    }
+    
     func testCreateNIORequest() {
         let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully()) }


### PR DESCRIPTION
It appears we have been adding `` around keywords when accessing their values using `Mirror`. This doesn't work. The code seems to be left over from the Code Generator where it is needed. This PR removes this. 

Added tests to verify this.