### PR TITLE
Performance tests

### DIFF
--- a/Sources/AWSSDKSwiftCore/AWSShapes/TimeStamp.swift
+++ b/Sources/AWSSDKSwiftCore/AWSShapes/TimeStamp.swift
@@ -43,7 +43,9 @@ public struct TimeStamp {
     }
     
     /// date formatter for outputting dates
-    private static var defaultDateFormatter : DateFormatter {
+    private static let defaultDateFormatter : DateFormatter = createDefaultDateFormatter()
+
+    static func createDefaultDateFormatter() -> DateFormatter {
         let dateFormatter = DateFormatter()
         dateFormatter.locale = Locale(identifier: "en_US_POSIX")
         dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"

--- a/Tests/AWSSDKSwiftCoreTests/PerformanceTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/PerformanceTests.swift
@@ -1,0 +1,177 @@
+//
+//  AWSClient.swift
+//  AWSSDKSwift
+//
+//  Created by Jonathan McAllister on 2018/10/13.
+//
+//
+
+import Foundation
+import XCTest
+@testable import AWSSDKSwiftCore
+
+struct HeaderRequest: AWSShape {
+    static var _members: [AWSShapeMember] = [
+        AWSShapeMember(label: "Header1", location: .header(locationName: "Header1"), required: true, type: .string),
+        AWSShapeMember(label: "Header2", location: .header(locationName: "Header2"), required: true, type: .string),
+        AWSShapeMember(label: "Header3", location: .header(locationName: "Header3"), required: true, type: .string),
+        AWSShapeMember(label: "Header4", location: .header(locationName: "Header4"), required: true, type: .timestamp)
+    ]
+
+    let header1: String
+    let header2: String
+    let header3: String
+    let header4: TimeStamp
+}
+
+struct StandardRequest: AWSShape {
+    static var _members: [AWSShapeMember] = [
+        AWSShapeMember(label: "item1", location: .body(locationName: "item1"), required: true, type: .string),
+        AWSShapeMember(label: "item2", location: .body(locationName: "item2"), required: true, type: .integer),
+        AWSShapeMember(label: "item3", location: .body(locationName: "item3"), required: true, type: .double),
+        AWSShapeMember(label: "item4", location: .body(locationName: "item4"), required: true, type: .timestamp)
+    ]
+
+    let item1: String
+    let item2: Int
+    let item3: Double
+    let item4: Date
+}
+
+struct PayloadRequest: AWSShape {
+    public static let payloadPath: String? = "payload"
+    static var _members: [AWSShapeMember] = [
+        AWSShapeMember(label: "payload", location: .body(locationName: "payload"), required: true, type: .structure)
+    ]
+
+    let payload: StandardRequest
+}
+
+class PerformanceTests: XCTestCase {
+    
+    func testHeaderRequest() {
+        let client = AWSClient(
+            region: .useast1,
+            service:"Test",
+            serviceProtocol: ServiceProtocol(type: .restxml),
+            apiVersion: "1.0",
+            eventLoopGroupProvider: .useAWSClientShared
+        )
+        let date = Date()
+        let request = HeaderRequest(header1: "Header1", header2: "Header2", header3: "Header3", header4: TimeStamp(date))
+        measure {
+            do {
+                for _ in 0..<1000 {
+                    _ = try client.createAWSRequest(operation: "Test", path: "/", httpMethod: "POST", input: request)
+                }
+            } catch {
+                XCTFail(error.localizedDescription)
+            }
+        }
+    }
+    
+    func testXMLRequest() {
+        let client = AWSClient(
+            region: .useast1,
+            service:"Test",
+            serviceProtocol: ServiceProtocol(type: .restxml),
+            apiVersion: "1.0",
+            eventLoopGroupProvider: .useAWSClientShared
+        )
+        let date = Date()
+        let request = StandardRequest(item1: "item1", item2: 45, item3: 3.14, item4: date)
+        measure {
+            do {
+                for _ in 0..<1000 {
+                    _ = try client.createAWSRequest(operation: "Test", path: "/", httpMethod: "POST", input: request)
+                }
+            } catch {
+                XCTFail(error.localizedDescription)
+            }
+        }
+    }
+    
+    func testXMLPayloadRequest() {
+        let client = AWSClient(
+            region: .useast1,
+            service:"Test",
+            serviceProtocol: ServiceProtocol(type: .restxml),
+            apiVersion: "1.0",
+            eventLoopGroupProvider: .useAWSClientShared
+        )
+        let date = Date()
+        let request = PayloadRequest(payload: StandardRequest(item1: "item1", item2: 45, item3: 3.14, item4: date))
+        measure {
+            do {
+                for _ in 0..<1000 {
+                    _ = try client.createAWSRequest(operation: "Test", path: "/", httpMethod: "POST", input: request)
+                }
+            } catch {
+                XCTFail(error.localizedDescription)
+            }
+        }
+    }
+    
+    func testJSONRequest() {
+        let client = AWSClient(
+            region: .useast1,
+            service:"Test",
+            serviceProtocol: ServiceProtocol(type: .restjson),
+            apiVersion: "1.0",
+            eventLoopGroupProvider: .useAWSClientShared
+        )
+        let date = Date()
+        let request = StandardRequest(item1: "item1", item2: 45, item3: 3.14, item4: date)
+        measure {
+            do {
+                for _ in 0..<1000 {
+                    _ = try client.createAWSRequest(operation: "Test", path: "/", httpMethod: "POST", input: request)
+                }
+            } catch {
+                XCTFail(error.localizedDescription)
+            }
+        }
+    }
+    
+    func testJSONPayloadRequest() {
+        let client = AWSClient(
+            region: .useast1,
+            service:"Test",
+            serviceProtocol: ServiceProtocol(type: .restjson),
+            apiVersion: "1.0",
+            eventLoopGroupProvider: .useAWSClientShared
+        )
+        let date = Date()
+        let request = PayloadRequest(payload: StandardRequest(item1: "item1", item2: 45, item3: 3.14, item4: date))
+        measure {
+            do {
+                for _ in 0..<1000 {
+                    _ = try client.createAWSRequest(operation: "Test", path: "/", httpMethod: "POST", input: request)
+                }
+            } catch {
+                XCTFail(error.localizedDescription)
+            }
+        }
+    }
+    
+    func testQueryRequest() {
+        let client = AWSClient(
+            region: .useast1,
+            service:"Test",
+            serviceProtocol: ServiceProtocol(type: .query),
+            apiVersion: "1.0",
+            eventLoopGroupProvider: .useAWSClientShared
+        )
+        let date = Date()
+        let request = StandardRequest(item1: "item1", item2: 45, item3: 3.14, item4: date)
+        measure {
+            do {
+                for _ in 0..<1000 {
+                    _ = try client.createAWSRequest(operation: "Test", path: "/", httpMethod: "POST", input: request)
+                }
+            } catch {
+                XCTFail(error.localizedDescription)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Added tests to measure various sections of aws-sdk-swift-core. Tests are split into three sections, create aws request, sign request and validate response.

With these I found we were wasting time creating a date formatter every time we processed a timestamp. Also found the unnecessary adding of `` around keywords, which was really expensive and then also breaking requests with swift keywords #158