### PR TITLE
Default DictionaryEncoder/Decoder to use base64

### DIFF
--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -589,7 +589,6 @@ extension AWSClient {
             if let payloadPath = Output.payloadPath {
                 outputDict = [payloadPath : outputDict]
             }
-            decoder.dataDecodingStrategy = .base64
 
         case .xml(let node):
             var outputNode = node
@@ -620,6 +619,7 @@ extension AWSClient {
             if let payload = Output.payloadPath {
                 outputDict[payload] = data
             }
+            decoder.dataDecodingStrategy = .raw
 
         case .text(let text):
             if let payload = Output.payloadPath {

--- a/Sources/AWSSDKSwiftCore/Encoder/DictionaryEncoder.swift
+++ b/Sources/AWSSDKSwiftCore/Encoder/DictionaryEncoder.swift
@@ -189,8 +189,8 @@ open class DictionaryEncoder {
     /// The strategy to use in encoding dates. Defaults to `.deferredToDate`.
     open var dateEncodingStrategy: DateEncodingStrategy = .deferredToDate
     
-    /// The strategy to use in encoding binary data. Defaults to `.raw`.
-    open var dataEncodingStrategy: DataEncodingStrategy = .raw
+    /// The strategy to use in encoding binary data. Defaults to `.base64`.
+    open var dataEncodingStrategy: DataEncodingStrategy = .base64
     
     /// The strategy to use in encoding non-conforming numbers. Defaults to `.throw`.
     open var nonConformingFloatEncodingStrategy: NonConformingFloatEncodingStrategy = .throw
@@ -1129,8 +1129,8 @@ open class DictionaryDecoder {
     /// The strategy to use in decoding dates. Defaults to `.deferredToDate`.
     open var dateDecodingStrategy: DateDecodingStrategy = .deferredToDate
     
-    /// The strategy to use in decoding binary data. Defaults to `.raw`.
-    open var dataDecodingStrategy: DataDecodingStrategy = .raw
+    /// The strategy to use in decoding binary data. Defaults to `.base64`.
+    open var dataDecodingStrategy: DataDecodingStrategy = .base64
     
     /// The strategy to use in decoding non-conforming numbers. Defaults to `.throw`.
     open var nonConformingFloatDecodingStrategy: NonConformingFloatDecodingStrategy = .throw

--- a/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
@@ -26,6 +26,7 @@ class AWSClientTests: XCTestCase {
             ("testValidateJSONResponse", testValidateJSONResponse),
             ("testValidateJSONPayloadResponse", testValidateJSONPayloadResponse),
             ("testValidateJSONError", testValidateJSONError),
+            ("testDataInJsonPayload", testDataInJsonPayload)
         ]
     }
 
@@ -473,6 +474,30 @@ class AWSClientTests: XCTestCase {
             XCTAssertEqual(message, "Donald Where's Your Troosers?")
         } catch {
             XCTFail("Throwing the wrong error")
+        }
+    }
+    
+    func testDataInJsonPayload() {
+        struct DataContainer: AWSShape {
+            let data: Data
+        }
+        struct J: AWSShape {
+            public static let payloadPath: String? = "dataContainer"
+            public static var _members: [AWSShapeMember] = [
+                AWSShapeMember(label: "dataContainer", required: false, type: .structure),
+            ]
+            let dataContainer: DataContainer
+        }
+        let input = J(dataContainer: DataContainer(data: Data("test data".utf8)))
+        do {
+            _ = try kinesisClient.createAWSRequest(
+                operation: "PutRecord",
+                path: "/",
+                httpMethod: "POST",
+                input: input
+            )
+        } catch {
+            XCTFail(error.localizedDescription)
         }
     }
 }

--- a/Tests/AWSSDKSwiftCoreTests/DictionaryEncoderTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/DictionaryEncoderTests.swift
@@ -180,15 +180,15 @@ class DictionaryEncoderTests: XCTestCase {
         struct Test : Codable {
             let data : Data
         }
-        let dictionary: [String:Any] = ["data":"Hello, world".data(using:.utf8)!]
+        let dictionary: [String:Any] = ["data":"Hello, world".data(using:.utf8)!.base64EncodedString()]
         testDecodeEncode(type: Test.self, dictionary: dictionary)
         
         let decoder = DictionaryDecoder()
-        decoder.dataDecodingStrategy = .base64
+        decoder.dataDecodingStrategy = .raw
         let encoder = DictionaryEncoder()
-        encoder.dataEncodingStrategy = .base64
-        
-        let dictionary2: [String:Any] = ["data":"Hello, world".data(using:.utf8)!.base64EncodedString()]
+        encoder.dataEncodingStrategy = .raw
+
+        let dictionary2: [String:Any] = ["data":"Hello, world".data(using:.utf8)!]
         testDecodeEncode(type: Test.self, dictionary: dictionary2, decoder: decoder, encoder: encoder)
     }
     
@@ -343,7 +343,7 @@ class DictionaryEncoderTests: XCTestCase {
                     "double": Double.greatestFiniteMagnitude,
                     "float": Float.greatestFiniteMagnitude,
                     "string": "hello",
-                    "data": "hello".data(using: .utf8)!,
+                    "data": "hello".data(using: .utf8)!.base64EncodedString(),
                     "bool": true,
                     "optional": "hello"
                 ],
@@ -441,7 +441,7 @@ class DictionaryEncoderTests: XCTestCase {
             XCTAssertEqual(b!["double"] as? Double, 0.5)
             XCTAssertEqual(b!["float"] as? Float, 0.6)
             XCTAssertEqual(b!["string"] as? String, "string")
-            let data = b!["data"] as? Data
+            let data = Data(base64Encoded: b!["data"] as! String)
             XCTAssertNotNil(data)
             XCTAssertEqual(String(data: data!, encoding: .utf8), "hello")
             XCTAssertEqual(b!["optional"] as? String, "goodbye")


### PR DESCRIPTION
- Base64 is the standard decode/encode strategy for the json and xml encoders.
- The situation where we construct a dictionary with a `Foundation.Data` to be decoded later in `validate<Output: AWSShape>` https://github.com/swift-aws/aws-sdk-swift-core/blob/61ac3f1dea83a642154c1b02c1910363a9d0943b/Sources/AWSSDKSwiftCore/AWSClient.swift#L621 is a special case and shouldn't be considered the default.
- This should fix the situation where creating a dictionary to extract the payload from (in `CreateAWSRequest`). The serialization of this payload using `JSONSerialization.data(withJSONObject:)` would crash because it has been provided a dictionary containing a `Foundation.Data` object. Added test `testDataInJsonPayload` to demostrate this. Revert `DictionaryEncoder.dataEncodingStrategy` to `.raw` and the test will crash.  