### PR TITLE
NIOTSHTTPClient can only be initialised with a NIOTSEventLoopGroup

### DIFF
--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -176,8 +176,8 @@ extension AWSClient {
     /// create HTTPClient
     fileprivate static func createHTTPClient(eventLoopGroup: EventLoopGroup) -> AWSHTTPClient {
         #if canImport(Network)
-        if #available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *), eventLoopGroup is NIOTSEventLoopGroup {
-            return NIOTSHTTPClient(eventLoopGroupProvider: .shared(eventLoopGroup))
+        if #available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *), let nioTSEventLoopGroup = eventLoopGroup as? NIOTSEventLoopGroup {
+            return NIOTSHTTPClient(eventLoopGroup: nioTSEventLoopGroup)
         }
         #endif
         return AsyncHTTPClient.HTTPClient(eventLoopGroupProvider: .shared(eventLoopGroup))

--- a/Tests/AWSSDKSwiftCoreTests/HTTPClientTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/HTTPClientTests.swift
@@ -10,6 +10,7 @@ import AsyncHTTPClient
 import Foundation
 import NIO
 import NIOHTTP1
+import NIOTransportServices
 import XCTest
 @testable import AWSSDKSwiftCore
 
@@ -27,7 +28,7 @@ extension AWSHTTPResponse {
 @available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
 class NIOTSHTTPClientTests: XCTestCase {
 
-    let client = NIOTSHTTPClient()
+    let client = NIOTSHTTPClient(eventLoopGroup: NIOTSEventLoopGroup())
 
     deinit {
         try? client.syncShutdown()


### PR DESCRIPTION
Removed the eventLoopGroupProvider enum and ability for client to create its own EventLoopGroup.

Merging this change into async-http-client