### PR TITLE
SwiftNIO dependency minor version bump

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
         .library(name: "AWSSDKSwiftCore", targets: ["AWSSDKSwiftCore"])
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", .upToNextMajor(from:"2.8.0")),
+        .package(url: "https://github.com/apple/swift-nio.git", .upToNextMajor(from:"2.11.0")),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", .upToNextMajor(from:"2.4.0")),
         .package(url: "https://github.com/apple/swift-nio-transport-services.git", .upToNextMajor(from:"1.0.0")),
         .package(url: "https://github.com/swift-aws/HypertextApplicationLanguage.git", .upToNextMinor(from: "1.1.0")),


### PR DESCRIPTION
Since we use the new `NIOAtomic` syntax introduced with SwiftNIO 2.11.0 we need to minor version bump our dependency.

PR that introduced new syntax: https://github.com/apple/swift-nio/pull/1263

cc: @weissi is such a move okay?