### PR TITLE
Paginated results

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,4 @@ RUN apt-get -qq update && apt-get install -y \
 
 WORKDIR /aws-sdk-swift-core
 COPY . .
-RUN swift test
+RUN swift test -Xswiftc -DDEBUG

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
                 "NIOFoundationCompat",
                 "INIParser"
             ]),
-        .testTarget(name: "AWSSDKSwiftCoreTests", dependencies: ["AWSSDKSwiftCore"])
+        .testTarget(name: "AWSSDKSwiftCoreTests", dependencies: ["AWSSDKSwiftCore", "NIOTestUtils"])
     ]
 )
 

--- a/Sources/AWSSDKSwiftCore/AWSClient+Paginate.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient+Paginate.swift
@@ -9,8 +9,12 @@ import NIO
 
 /// protocol for all AWSShapes that can be paginated.
 /// Adds an initialiser that does a copy but inserts a new pagination token
-public protocol AWSPaginateable: AWSShape {
+public protocol AWSPaginateStringToken: AWSShape {
     init(_ original: Self, token: String)
+}
+
+public protocol AWSPaginateIntToken: AWSShape {
+    init(_ original: Self, token: Int)
 }
 
 public extension AWSClient {
@@ -23,7 +27,7 @@ public extension AWSClient {
     ///   - command: Command to be paginated
     ///   - resultKey: The name of the objects to be paginated in the response object
     ///   - tokenKey: The name of token in the response object to continue pagination
-    func paginate<Input: AWSPaginateable, Output: AWSShape, PaginateOutput>(input: Input, command: @escaping (Input)->EventLoopFuture<Output>, resultKey: String, tokenKey: String) -> EventLoopFuture<[PaginateOutput]> {
+    func paginate<Input: AWSPaginateStringToken, Output: AWSShape, PaginateOutput>(input: Input, command: @escaping (Input)->EventLoopFuture<Output>, resultKey: String, tokenKey: String) -> EventLoopFuture<[PaginateOutput]> {
         var list : [PaginateOutput] = []
         
         func paginatePart(input: Input) -> EventLoopFuture<[PaginateOutput]> {
@@ -35,6 +39,37 @@ public extension AWSClient {
 
                 // get next block token and construct a new input with this token
                 guard let token = mirror.getAttribute(forKey: tokenKey) as? String else { return self.eventLoopGroup.next().makeSucceededFuture(list) }
+                let input = Input.init(input, token: token)
+
+                return paginatePart(input: input)
+            }
+            return objects
+        }
+        return paginatePart(input: input)
+    }
+
+
+    /// If an AWS command is returning an arbituary sized array sometimes it adds support for paginating this array
+    /// ie it will return the array in blocks of a defined size, each block also includes a token which can be used to access
+    /// the next block. This function returns a future that will contain the full contents of the array.
+    ///
+    /// - Parameters:
+    ///   - input: Input for request
+    ///   - command: Command to be paginated
+    ///   - resultKey: The name of the objects to be paginated in the response object
+    ///   - tokenKey: The name of token in the response object to continue pagination
+    func paginate<Input: AWSPaginateIntToken, Output: AWSShape, PaginateOutput>(input: Input, command: @escaping (Input)->EventLoopFuture<Output>, resultKey: String, tokenKey: String) -> EventLoopFuture<[PaginateOutput]> {
+        var list : [PaginateOutput] = []
+        
+        func paginatePart(input: Input) -> EventLoopFuture<[PaginateOutput]> {
+            let objects = command(input).flatMap { (response: Output) -> EventLoopFuture<[PaginateOutput]> in
+                // extract results from response and add to list
+                let mirror = Mirror(reflecting: response)
+                guard let results = mirror.getAttribute(forKey: resultKey) as? [PaginateOutput] else { return self.eventLoopGroup.next().makeSucceededFuture(list) }
+                list.append(contentsOf: results)
+
+                // get next block token and construct a new input with this token
+                guard let token = mirror.getAttribute(forKey: tokenKey) as? Int else { return self.eventLoopGroup.next().makeSucceededFuture(list) }
                 let input = Input.init(input, token: token)
 
                 return paginatePart(input: input)

--- a/Sources/AWSSDKSwiftCore/AWSClient+Paginate.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient+Paginate.swift
@@ -20,6 +20,7 @@ public protocol AWSPaginateIntToken: AWSShape {
 }
 
 public extension AWSClient {
+    
     /// If an AWS command is returning an arbituary sized array sometimes it adds support for paginating this array
     /// ie it will return the array in blocks of a defined size, each block also includes a token which can be used to access
     /// the next block. This function loads each block and calls a closure with each block as parameter.
@@ -30,12 +31,11 @@ public extension AWSClient {
     ///   - resultKey: The keypath to the list of objects to be paginated
     ///   - tokenKey: The name of token in the response object to continue pagination
     ///   - onPage: closure called with each block of entries
-    func paginate<Input: AWSPaginateStringToken, Output: AWSShape, Result>(
+    func paginate<Input: AWSPaginateStringToken, Output: AWSShape>(
         input: Input,
         command: @escaping (Input)->EventLoopFuture<Output>,
-        resultKey: PartialKeyPath<Output>,
         tokenKey: KeyPath<Output, String?>,
-        onPage: @escaping ([Result], EventLoop)->EventLoopFuture<Bool>
+        onPage: @escaping (Output, EventLoop)->EventLoopFuture<Bool>
     ) -> EventLoopFuture<Void> {
         let eventLoop = self.eventLoopGroup.next()
         let promise = eventLoop.makePromise(of: Void.self)
@@ -43,181 +43,7 @@ public extension AWSClient {
         func paginatePart(input: Input) {
             let responseFuture = command(input)
             responseFuture.whenSuccess { (response: Output)->Void in
-                // extract results from response and add to list
-                let results = response[keyPath: resultKey] as? [Result] ?? []
-
-                let onPageFuture = onPage(results, eventLoop)
-                onPageFuture.whenSuccess { rt in
-                    guard rt == true else { return promise.succeed(Void()) }
-                    // get next block token and construct a new input with this token
-                    guard let token = response[keyPath: tokenKey] else { return promise.succeed(Void()) }
-
-                    let input = Input.init(input, token: token)
-                    paginatePart(input: input)
-                }
-                onPageFuture.whenFailure { error in
-                    promise.fail(error)
-                }
-            }
-            responseFuture.whenFailure { error in
-                promise.fail(error)
-            }
-        }
-
-        paginatePart(input: input)
-        
-        return promise.futureResult
-    }
-
-    /// If an AWS command is returning an arbituary sized array sometimes it adds support for paginating this array
-    /// ie it will return the array in blocks of a defined size, each block also includes a token which can be used to access
-    /// the next block. This function loads each block and calls a closure with each block as parameter.
-    ///
-    /// This version returns two arrays
-    ///
-    /// - Parameters:
-    ///   - input: Input for request
-    ///   - command: Command to be paginated
-    ///   - resultKey1: The keypath to the first list of objects to be paginated
-    ///   - resultKey2: The keypath to the second list of objects to be paginated
-    ///   - tokenKey: The name of token in the response object to continue pagination
-    ///   - onPage: closure called with each block of entries
-    func paginate<Input: AWSPaginateStringToken, Output: AWSShape, Result1, Result2>(
-        input: Input,
-        command: @escaping (Input)->EventLoopFuture<Output>,
-        resultKey1: PartialKeyPath<Output>,
-        resultKey2: PartialKeyPath<Output>,
-        tokenKey: KeyPath<Output, String?>,
-        onPage: @escaping ([Result1], [Result2], EventLoop)->EventLoopFuture<Bool>
-    ) -> EventLoopFuture<Void> {
-        let eventLoop = self.eventLoopGroup.next()
-        let promise = eventLoop.makePromise(of: Void.self)
-
-        func paginatePart(input: Input) {
-            let responseFuture = command(input)
-            responseFuture.whenSuccess { (response: Output)->Void in
-                // extract results from response and add to list
-                let results1 = response[keyPath: resultKey1] as? [Result1] ?? []
-                let results2 = response[keyPath: resultKey2] as? [Result2] ?? []
-
-                let onPageFuture = onPage(results1, results2, eventLoop)
-                onPageFuture.whenSuccess { rt in
-                    guard rt == true else { return promise.succeed(Void()) }
-                    // get next block token and construct a new input with this token
-                    guard let token = response[keyPath: tokenKey] else { return promise.succeed(Void()) }
-
-                    let input = Input.init(input, token: token)
-                    paginatePart(input: input)
-                }
-                onPageFuture.whenFailure { error in
-                    promise.fail(error)
-                }
-            }
-            responseFuture.whenFailure { error in
-                promise.fail(error)
-            }
-        }
-
-        paginatePart(input: input)
-        
-        return promise.futureResult
-    }
-
-    /// If an AWS command is returning an arbituary sized array sometimes it adds support for paginating this array
-    /// ie it will return the array in blocks of a defined size, each block also includes a token which can be used to access
-    /// the next block. This function loads each block and calls a closure with each block as parameter.
-    ///
-    /// This version returns three arrays
-    ///
-    /// - Parameters:
-    ///   - input: Input for request
-    ///   - command: Command to be paginated
-    ///   - resultKey1: The keypath to the first list of objects to be paginated
-    ///   - resultKey2: The keypath to the second list of objects to be paginated
-    ///   - resultKey3: The keypath to the third list of objects to be paginated
-    ///   - tokenKey: The name of token in the response object to continue pagination
-    ///   - onPage: closure called with each block of entries
-    func paginate<Input: AWSPaginateStringToken, Output: AWSShape, Result1, Result2, Result3>(
-        input: Input,
-        command: @escaping (Input)->EventLoopFuture<Output>,
-        resultKey1: PartialKeyPath<Output>,
-        resultKey2: PartialKeyPath<Output>,
-        resultKey3: PartialKeyPath<Output>,
-        tokenKey: KeyPath<Output, String?>,
-        onPage: @escaping ([Result1], [Result2], [Result3], EventLoop)->EventLoopFuture<Bool>
-    ) -> EventLoopFuture<Void> {
-        let eventLoop = self.eventLoopGroup.next()
-        let promise = eventLoop.makePromise(of: Void.self)
-
-        func paginatePart(input: Input) {
-            let responseFuture = command(input)
-            responseFuture.whenSuccess { (response: Output)->Void in
-                // extract results from response and add to list
-                let results1 = response[keyPath: resultKey1] as? [Result1] ?? []
-                let results2 = response[keyPath: resultKey2] as? [Result2] ?? []
-                let results3 = response[keyPath: resultKey3] as? [Result3] ?? []
-
-                let onPageFuture = onPage(results1, results2, results3, eventLoop)
-                onPageFuture.whenSuccess { rt in
-                    guard rt == true else { return promise.succeed(Void()) }
-                    // get next block token and construct a new input with this token
-                    guard let token = response[keyPath: tokenKey] else { return promise.succeed(Void()) }
-
-                    let input = Input.init(input, token: token)
-                    paginatePart(input: input)
-                }
-                onPageFuture.whenFailure { error in
-                    promise.fail(error)
-                }
-            }
-            responseFuture.whenFailure { error in
-                promise.fail(error)
-            }
-        }
-
-        paginatePart(input: input)
-        
-        return promise.futureResult
-    }
-
-    /// If an AWS command is returning an arbituary sized array sometimes it adds support for paginating this array
-    /// ie it will return the array in blocks of a defined size, each block also includes a token which can be used to access
-    /// the next block. This function loads each block and calls a closure with each block as parameter.
-    ///
-    /// This version returns four arrays
-    ///
-    /// - Parameters:
-    ///   - input: Input for request
-    ///   - command: Command to be paginated
-    ///   - resultKey1: The keypath to the first list of objects to be paginated
-    ///   - resultKey2: The keypath to the second list of objects to be paginated
-    ///   - resultKey3: The keypath to the third list of objects to be paginated
-    ///   - resultKey4: The keypath to the fourth list of objects to be paginated
-    ///   - tokenKey: The name of token in the response object to continue pagination
-    ///   - onPage: closure called with each block of entries
-    func paginate<Input: AWSPaginateStringToken, Output: AWSShape, Result1, Result2, Result3, Result4>(
-        input: Input,
-        command: @escaping (Input)->EventLoopFuture<Output>,
-        resultKey1: PartialKeyPath<Output>,
-        resultKey2: PartialKeyPath<Output>,
-        resultKey3: PartialKeyPath<Output>,
-        resultKey4: PartialKeyPath<Output>,
-        tokenKey: KeyPath<Output, String?>,
-        onPage: @escaping ([Result1], [Result2], [Result3], [Result4], EventLoop)->EventLoopFuture<Bool>
-    ) -> EventLoopFuture<Void> {
-        let eventLoop = self.eventLoopGroup.next()
-        let promise = eventLoop.makePromise(of: Void.self)
-
-        func paginatePart(input: Input) {
-            let responseFuture = command(input)
-            responseFuture.whenSuccess { (response: Output)->Void in
-                // extract results from response and add to list
-                let results1 = response[keyPath: resultKey1] as? [Result1] ?? []
-                let results2 = response[keyPath: resultKey2] as? [Result2] ?? []
-                let results3 = response[keyPath: resultKey3] as? [Result3] ?? []
-                let results4 = response[keyPath: resultKey4] as? [Result4] ?? []
-
-                let onPageFuture = onPage(results1, results2, results3, results4, eventLoop)
+                let onPageFuture = onPage(response, eventLoop)
                 onPageFuture.whenSuccess { rt in
                     guard rt == true else { return promise.succeed(Void()) }
                     // get next block token and construct a new input with this token
@@ -252,12 +78,11 @@ public extension AWSClient {
     ///   - resultKey: The keypath to the list of objects to be paginated
     ///   - tokenKey: The name of token in the response object to continue pagination
     ///   - onPage: closure called with each block of entries
-    func paginate<Input: AWSPaginateIntToken, Output: AWSShape, Result>(
+    func paginate<Input: AWSPaginateIntToken, Output: AWSShape>(
         input: Input,
         command: @escaping (Input)->EventLoopFuture<Output>,
-        resultKey: PartialKeyPath<Output>,
         tokenKey: KeyPath<Output, Int?>,
-        onPage: @escaping ([Result], EventLoop)->EventLoopFuture<Bool>
+        onPage: @escaping (Output, EventLoop)->EventLoopFuture<Bool>
     ) -> EventLoopFuture<Void> {
         let eventLoop = self.eventLoopGroup.next()
         let promise = eventLoop.makePromise(of: Void.self)
@@ -265,10 +90,7 @@ public extension AWSClient {
         func paginatePart(input: Input) {
             let responseFuture = command(input)
             responseFuture.whenSuccess { (response: Output)->Void in
-                // extract results from response and add to list
-                let results = response[keyPath: resultKey] as? [Result] ?? []
-
-                let onPageFuture = onPage(results, eventLoop)
+                let onPageFuture = onPage(response, eventLoop)
                 onPageFuture.whenSuccess { rt in
                     guard rt == true else { return promise.succeed(Void()) }
                     // get next block token and construct a new input with this token

--- a/Sources/AWSSDKSwiftCore/AWSClient+Paginate.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient+Paginate.swift
@@ -10,13 +10,13 @@ import NIO
 /// protocol for all AWSShapes that can be paginated.
 /// Adds an initialiser that does a copy but inserts a new string based pagination token
 public protocol AWSPaginateStringToken: AWSShape {
-    init(_ original: Self, token: String)
+    func usingPaginationToken(_ token: String) -> Self
 }
 
 /// protocol for all AWSShapes that can be paginated.
 /// Adds an initialiser that does a copy but inserts a new integer based pagination token
 public protocol AWSPaginateIntToken: AWSShape {
-    init(_ original: Self, token: Int)
+    func usingPaginationToken(_ token: Int) -> Self
 }
 
 public extension AWSClient {
@@ -49,7 +49,7 @@ public extension AWSClient {
                     // get next block token and construct a new input with this token
                     guard let token = response[keyPath: tokenKey] else { return promise.succeed(Void()) }
 
-                    let input = Input.init(input, token: token)
+                    let input = input.usingPaginationToken(token)
                     paginatePart(input: input)
                 }
                 onPageFuture.whenFailure { error in
@@ -96,7 +96,7 @@ public extension AWSClient {
                     // get next block token and construct a new input with this token
                     guard let token = response[keyPath: tokenKey] else { return promise.succeed(Void()) }
 
-                    let input = Input.init(input, token: token)
+                    let input = input.usingPaginationToken(token)
                     paginatePart(input: input)
                 }
                 onPageFuture.whenFailure { error in

--- a/Sources/AWSSDKSwiftCore/AWSClient+Paginate.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient+Paginate.swift
@@ -9,11 +9,11 @@ import NIO
 
 /// protocol for all AWSShapes that can be paginated.
 /// Adds an initialiser that does a copy but inserts a new pagination token
-protocol AWSPaginateable: AWSShape {
+public protocol AWSPaginateable: AWSShape {
     init(_ original: Self, token: String)
 }
 
-extension AWSClient {
+public extension AWSClient {
     /// If an AWS command is returning an arbituary sized array sometimes it adds support for paginating this array
     /// ie it will return the array in blocks of a defined size, each block also includes a token which can be used to access
     /// the next block. This function returns a future that will contain the full contents of the array.
@@ -23,19 +23,20 @@ extension AWSClient {
     ///   - command: Command to be paginated
     ///   - resultKey: The name of the objects to be paginated in the response object
     ///   - tokenKey: The name of token in the response object to continue pagination
-    func paginate<Input: AWSPaginateable, Output: AWSShape, PaginateOutput: AWSShape>(input: Input, command: @escaping (Input)->EventLoopFuture<Output>, resultKey: String, tokenKey: String) -> EventLoopFuture<[PaginateOutput]> {
+    func paginate<Input: AWSPaginateable, Output: AWSShape, PaginateOutput>(input: Input, command: @escaping (Input)->EventLoopFuture<Output>, resultKey: String, tokenKey: String) -> EventLoopFuture<[PaginateOutput]> {
         var list : [PaginateOutput] = []
         
         func paginatePart(input: Input) -> EventLoopFuture<[PaginateOutput]> {
             let objects = command(input).flatMap { (response: Output) -> EventLoopFuture<[PaginateOutput]> in
+                // extract results from response and add to list
                 let mirror = Mirror(reflecting: response)
                 guard let results = mirror.getAttribute(forKey: resultKey) as? [PaginateOutput] else { return self.eventLoopGroup.next().makeSucceededFuture(list) }
-
                 list.append(contentsOf: results)
 
+                // get next block token and construct a new input with this token
                 guard let token = mirror.getAttribute(forKey: tokenKey) as? String else { return self.eventLoopGroup.next().makeSucceededFuture(list) }
-
                 let input = Input.init(input, token: token)
+
                 return paginatePart(input: input)
             }
             return objects

--- a/Sources/AWSSDKSwiftCore/AWSClient+Paginate.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient+Paginate.swift
@@ -8,11 +8,13 @@
 import NIO
 
 /// protocol for all AWSShapes that can be paginated.
-/// Adds an initialiser that does a copy but inserts a new pagination token
+/// Adds an initialiser that does a copy but inserts a new string based pagination token
 public protocol AWSPaginateStringToken: AWSShape {
     init(_ original: Self, token: String)
 }
 
+/// protocol for all AWSShapes that can be paginated.
+/// Adds an initialiser that does a copy but inserts a new integer based pagination token
 public protocol AWSPaginateIntToken: AWSShape {
     init(_ original: Self, token: Int)
 }
@@ -20,14 +22,21 @@ public protocol AWSPaginateIntToken: AWSShape {
 public extension AWSClient {
     /// If an AWS command is returning an arbituary sized array sometimes it adds support for paginating this array
     /// ie it will return the array in blocks of a defined size, each block also includes a token which can be used to access
-    /// the next block. This function returns a future that will contain the full contents of the array.
+    /// the next block. This function loads each block and calls a closure with each block as parameter.
     ///
     /// - Parameters:
     ///   - input: Input for request
     ///   - command: Command to be paginated
-    ///   - resultKey: The name of the objects to be paginated in the response object
+    ///   - resultKey: The keypath to the list of objects to be paginated
     ///   - tokenKey: The name of token in the response object to continue pagination
-    func paginate<Input: AWSPaginateStringToken, Output: AWSShape, Result>(input: Input, command: @escaping (Input)->EventLoopFuture<Output>, resultKey: PartialKeyPath<Output>, tokenKey: KeyPath<Output, String?>, onPage: @escaping ([Result], EventLoop)->EventLoopFuture<Bool>) -> EventLoopFuture<Void> {
+    ///   - onPage: closure called with each block of entries
+    func paginate<Input: AWSPaginateStringToken, Output: AWSShape, Result>(
+        input: Input,
+        command: @escaping (Input)->EventLoopFuture<Output>,
+        resultKey: PartialKeyPath<Output>,
+        tokenKey: KeyPath<Output, String?>,
+        onPage: @escaping ([Result], EventLoop)->EventLoopFuture<Bool>
+    ) -> EventLoopFuture<Void> {
         
         func paginatePart(input: Input) -> EventLoopFuture<Void> {
             let future = command(input).flatMap { (response: Output) -> EventLoopFuture<Void> in
@@ -49,17 +58,25 @@ public extension AWSClient {
 
     /// If an AWS command is returning an arbituary sized array sometimes it adds support for paginating this array
     /// ie it will return the array in blocks of a defined size, each block also includes a token which can be used to access
-    /// the next block. This function returns a future that will contain the full contents of the array.
+    /// the next block. This function loads each block and calls a closure with each block as parameter.
     ///
     /// This version returns two arrays
     ///
     /// - Parameters:
     ///   - input: Input for request
     ///   - command: Command to be paginated
-    ///   - resultKey1: The name of the first set of objects to be paginated in the response object
-    ///   - resultKey2: The name of the second set of objects to be paginated in the response object
+    ///   - resultKey1: The keypath to the first list of objects to be paginated
+    ///   - resultKey2: The keypath to the second list of objects to be paginated
     ///   - tokenKey: The name of token in the response object to continue pagination
-    func paginate<Input: AWSPaginateStringToken, Output: AWSShape, Result1, Result2>(input: Input, command: @escaping (Input)->EventLoopFuture<Output>, resultKey1: PartialKeyPath<Output>, resultKey2: PartialKeyPath<Output>, tokenKey: KeyPath<Output, String?>, onPage: @escaping ([Result1], [Result2], EventLoop)->EventLoopFuture<Bool>) -> EventLoopFuture<Void> {
+    ///   - onPage: closure called with each block of entries
+    func paginate<Input: AWSPaginateStringToken, Output: AWSShape, Result1, Result2>(
+        input: Input,
+        command: @escaping (Input)->EventLoopFuture<Output>,
+        resultKey1: PartialKeyPath<Output>,
+        resultKey2: PartialKeyPath<Output>,
+        tokenKey: KeyPath<Output, String?>,
+        onPage: @escaping ([Result1], [Result2], EventLoop)->EventLoopFuture<Bool>
+    ) -> EventLoopFuture<Void> {
 
         func paginatePart(input: Input) -> EventLoopFuture<Void> {
             let objects = command(input).flatMap { (response: Output) -> EventLoopFuture<Void> in
@@ -82,18 +99,27 @@ public extension AWSClient {
 
     /// If an AWS command is returning an arbituary sized array sometimes it adds support for paginating this array
     /// ie it will return the array in blocks of a defined size, each block also includes a token which can be used to access
-    /// the next block. This function returns a future that will contain the full contents of the array.
+    /// the next block. This function loads each block and calls a closure with each block as parameter.
     ///
     /// This version returns three arrays
     ///
     /// - Parameters:
     ///   - input: Input for request
     ///   - command: Command to be paginated
-    ///   - resultKey1: The name of the first set of objects to be paginated in the response object
-    ///   - resultKey2: The name of the second set of objects to be paginated in the response object
-    ///   - resultKey3: The name of the second set of objects to be paginated in the response object
+    ///   - resultKey1: The keypath to the first list of objects to be paginated
+    ///   - resultKey2: The keypath to the second list of objects to be paginated
+    ///   - resultKey3: The keypath to the third list of objects to be paginated
     ///   - tokenKey: The name of token in the response object to continue pagination
-    func paginate<Input: AWSPaginateStringToken, Output: AWSShape, Result1, Result2, Result3>(input: Input, command: @escaping (Input)->EventLoopFuture<Output>, resultKey1: PartialKeyPath<Output>, resultKey2: PartialKeyPath<Output>, resultKey3: PartialKeyPath<Output>, tokenKey: KeyPath<Output, String?>, onPage: @escaping ([Result1], [Result2], [Result3], EventLoop)->EventLoopFuture<Bool>) -> EventLoopFuture<Void> {
+    ///   - onPage: closure called with each block of entries
+    func paginate<Input: AWSPaginateStringToken, Output: AWSShape, Result1, Result2, Result3>(
+        input: Input,
+        command: @escaping (Input)->EventLoopFuture<Output>,
+        resultKey1: PartialKeyPath<Output>,
+        resultKey2: PartialKeyPath<Output>,
+        resultKey3: PartialKeyPath<Output>,
+        tokenKey: KeyPath<Output, String?>,
+        onPage: @escaping ([Result1], [Result2], [Result3], EventLoop)->EventLoopFuture<Bool>
+    ) -> EventLoopFuture<Void> {
 
         func paginatePart(input: Input) -> EventLoopFuture<Void> {
             let objects = command(input).flatMap { (response: Output) -> EventLoopFuture<Void> in
@@ -117,18 +143,29 @@ public extension AWSClient {
 
     /// If an AWS command is returning an arbituary sized array sometimes it adds support for paginating this array
     /// ie it will return the array in blocks of a defined size, each block also includes a token which can be used to access
-    /// the next block. This function returns a future that will contain the full contents of the array.
+    /// the next block. This function loads each block and calls a closure with each block as parameter.
     ///
     /// This version returns four arrays
     ///
     /// - Parameters:
     ///   - input: Input for request
     ///   - command: Command to be paginated
-    ///   - resultKey1: The name of the first set of objects to be paginated in the response object
-    ///   - resultKey2: The name of the second set of objects to be paginated in the response object
-    ///   - resultKey3: The name of the second set of objects to be paginated in the response object
+    ///   - resultKey1: The keypath to the first list of objects to be paginated
+    ///   - resultKey2: The keypath to the second list of objects to be paginated
+    ///   - resultKey3: The keypath to the third list of objects to be paginated
+    ///   - resultKey4: The keypath to the fourth list of objects to be paginated
     ///   - tokenKey: The name of token in the response object to continue pagination
-    func paginate<Input: AWSPaginateStringToken, Output: AWSShape, Result1, Result2, Result3, Result4>(input: Input, command: @escaping (Input)->EventLoopFuture<Output>, resultKey1: PartialKeyPath<Output>, resultKey2: PartialKeyPath<Output>, resultKey3: PartialKeyPath<Output>, resultKey4: PartialKeyPath<Output>, tokenKey: KeyPath<Output, String?>, onPage: @escaping ([Result1], [Result2], [Result3], [Result4], EventLoop)->EventLoopFuture<Bool>) -> EventLoopFuture<Void> {
+    ///   - onPage: closure called with each block of entries
+    func paginate<Input: AWSPaginateStringToken, Output: AWSShape, Result1, Result2, Result3, Result4>(
+        input: Input,
+        command: @escaping (Input)->EventLoopFuture<Output>,
+        resultKey1: PartialKeyPath<Output>,
+        resultKey2: PartialKeyPath<Output>,
+        resultKey3: PartialKeyPath<Output>,
+        resultKey4: PartialKeyPath<Output>,
+        tokenKey: KeyPath<Output, String?>,
+        onPage: @escaping ([Result1], [Result2], [Result3], [Result4], EventLoop)->EventLoopFuture<Bool>
+    ) -> EventLoopFuture<Void> {
 
         func paginatePart(input: Input) -> EventLoopFuture<Void> {
             let objects = command(input).flatMap { (response: Output) -> EventLoopFuture<Void> in
@@ -153,16 +190,23 @@ public extension AWSClient {
 
     /// If an AWS command is returning an arbituary sized array sometimes it adds support for paginating this array
     /// ie it will return the array in blocks of a defined size, each block also includes a token which can be used to access
-    /// the next block. This function returns a future that will contain the full contents of the array.
+    /// the next block. This function loads each block and calls a closure with each block as parameter.
     ///
     /// This version uses an Int instead of a String for the token
     ///
     /// - Parameters:
     ///   - input: Input for request
     ///   - command: Command to be paginated
-    ///   - resultKey: The name of the objects to be paginated in the response object
+    ///   - resultKey: The keypath to the list of objects to be paginated
     ///   - tokenKey: The name of token in the response object to continue pagination
-    func paginate<Input: AWSPaginateIntToken, Output: AWSShape, Result>(input: Input, command: @escaping (Input)->EventLoopFuture<Output>, resultKey: PartialKeyPath<Output>, tokenKey: KeyPath<Output, Int?>, onPage: @escaping ([Result], EventLoop)->EventLoopFuture<Bool>) -> EventLoopFuture<Void> {
+    ///   - onPage: closure called with each block of entries
+    func paginate<Input: AWSPaginateIntToken, Output: AWSShape, Result>(
+        input: Input,
+        command: @escaping (Input)->EventLoopFuture<Output>,
+        resultKey: PartialKeyPath<Output>,
+        tokenKey: KeyPath<Output, Int?>,
+        onPage: @escaping ([Result], EventLoop)->EventLoopFuture<Bool>
+    ) -> EventLoopFuture<Void> {
         
         func paginatePart(input: Input) -> EventLoopFuture<Void> {
             let future = command(input).flatMap { (response: Output) -> EventLoopFuture<Void> in

--- a/Sources/AWSSDKSwiftCore/AWSClient+Paginate.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient+Paginate.swift
@@ -21,17 +21,17 @@ extension AWSClient {
     /// - Parameters:
     ///   - input: Input for request
     ///   - command: Command to be paginated
-    ///   - contentsKey: The name of the objects to be paginated in the response object
+    ///   - resultKey: The name of the objects to be paginated in the response object
     ///   - tokenKey: The name of token in the response object to continue pagination
-    func paginate<Input: AWSPaginateable, Output: AWSShape, PaginateOutput: AWSShape>(input: Input, command: @escaping (Input)->EventLoopFuture<Output>, contentsKey: String, tokenKey: String) -> EventLoopFuture<[PaginateOutput]> {
+    func paginate<Input: AWSPaginateable, Output: AWSShape, PaginateOutput: AWSShape>(input: Input, command: @escaping (Input)->EventLoopFuture<Output>, resultKey: String, tokenKey: String) -> EventLoopFuture<[PaginateOutput]> {
         var list : [PaginateOutput] = []
         
         func paginatePart(input: Input) -> EventLoopFuture<[PaginateOutput]> {
             let objects = command(input).flatMap { (response: Output) -> EventLoopFuture<[PaginateOutput]> in
                 let mirror = Mirror(reflecting: response)
-                guard let contents = mirror.getAttribute(forKey: contentsKey) as? [PaginateOutput] else { return self.eventLoopGroup.next().makeSucceededFuture(list) }
+                guard let results = mirror.getAttribute(forKey: resultKey) as? [PaginateOutput] else { return self.eventLoopGroup.next().makeSucceededFuture(list) }
 
-                list.append(contentsOf: contents)
+                list.append(contentsOf: results)
 
                 guard let token = mirror.getAttribute(forKey: tokenKey) as? String else { return self.eventLoopGroup.next().makeSucceededFuture(list) }
 

--- a/Sources/AWSSDKSwiftCore/AWSClient+Paginate.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient+Paginate.swift
@@ -23,7 +23,7 @@ extension AWSClient {
     ///   - command: Command to be paginated
     ///   - contentsKey: The name of the objects to be paginated in the response object
     ///   - tokenKey: The name of token in the response object to continue pagination
-    func paginate<Input: AWSPaginateable, Output: AWSShape, PaginateOutput: AWSShape>(input: Input, command: @escaping (Input)->EventLoopFuture<FullOutput>, contentsKey: String, tokenKey: String) -> EventLoopFuture<[PaginateOutput]> {
+    func paginate<Input: AWSPaginateable, Output: AWSShape, PaginateOutput: AWSShape>(input: Input, command: @escaping (Input)->EventLoopFuture<Output>, contentsKey: String, tokenKey: String) -> EventLoopFuture<[PaginateOutput]> {
         var list : [PaginateOutput] = []
         
         func paginatePart(input: Input) -> EventLoopFuture<[PaginateOutput]> {

--- a/Sources/AWSSDKSwiftCore/AWSClient+Paginate.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient+Paginate.swift
@@ -1,0 +1,37 @@
+//
+//  AWSClient+Paginate.swift
+//  AWSSDKSwift
+//
+//  Created by Adam Fowler on 2020/01/19.
+//
+//
+import NIO
+
+/// protocol for all AWSShapes that can be paginated.
+/// Adds an initialiser that does a copy but inserts a new pagination token
+protocol AWSPaginateable: AWSShape {
+    init(_ original: Self, token: String)
+}
+
+extension AWSClient {
+    func paginate<Input: AWSPaginateable, Output: AWSShape, PaginateOutput: AWSShape>(input: Input, command: @escaping (Input)->EventLoopFuture<FullOutput>, contentsKey: String, tokenKey: String) -> Future<[PaginateOutput]> {
+        var list : [PaginateOutput] = []
+        
+        func paginatePart(input: Input) -> Future<[PaginateOutput]> {
+            let objects = command(input).flatMap { (response: Output) -> Future<[PaginateOutput]> in
+                let mirror = Mirror(reflecting: response)
+                guard let contents = mirror.getAttribute(forKey: contentsKey) as? [PaginateOutput] else { return self.eventLoopGroup.next().makeSucceededFuture(list) }
+
+                list.append(contentsOf: contents)
+
+                guard let token = mirror.getAttribute(forKey: tokenKey) as? String else { return self.eventLoopGroup.next().makeSucceededFuture(list) }
+
+                let input = Input.init(input, token: token)
+                return paginatePart(input: input)
+            }
+            return objects
+        }
+        return paginatePart(input: input)
+    }
+}
+

--- a/Sources/AWSSDKSwiftCore/AWSClient+Paginate.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient+Paginate.swift
@@ -92,13 +92,13 @@ public extension AWSClient {
     ///   - command: Command to be paginated
     ///   - resultKey: The name of the objects to be paginated in the response object
     ///   - tokenKey: The name of token in the response object to continue pagination
-    func paginate<Input: AWSPaginateIntToken, Output: AWSShape, Result>(input: Input, command: @escaping (Input)->EventLoopFuture<Output>, resultKey: KeyPath<Output, [Result]?>, tokenKey: KeyPath<Output, Int?>) -> EventLoopFuture<[Result]> {
+    func paginate<Input: AWSPaginateIntToken, Output: AWSShape, Result>(input: Input, command: @escaping (Input)->EventLoopFuture<Output>, resultKey: PartialKeyPath<Output>, tokenKey: KeyPath<Output, Int?>) -> EventLoopFuture<[Result]> {
         var list: [Result] = []
         
         func paginatePart(input: Input) -> EventLoopFuture<[Result]> {
             let objects = command(input).flatMap { (response: Output) -> EventLoopFuture<[Result]> in
                 // extract results from response and add to list
-                if let results = response[keyPath: resultKey] {
+                if let results = response[keyPath: resultKey] as? [Result] {
                     list.append(contentsOf: results)
                 }
                 // get next block token and construct a new input with this token

--- a/Sources/AWSSDKSwiftCore/AWSClient+Paginate.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient+Paginate.swift
@@ -42,19 +42,16 @@ public extension AWSClient {
 
         func paginatePart(input: Input) {
             let responseFuture = command(input)
-            responseFuture.whenSuccess { (response: Output)->Void in
-                let onPageFuture = onPage(response, eventLoop)
-                onPageFuture.whenSuccess { rt in
-                    guard rt == true else { return promise.succeed(Void()) }
-                    // get next block token and construct a new input with this token
-                    guard let token = response[keyPath: tokenKey] else { return promise.succeed(Void()) }
+                .flatMap { response in
+                    return onPage(response, eventLoop)
+                        .map { (rt)->Void in
+                            guard rt == true else { return promise.succeed(Void()) }
+                            // get next block token and construct a new input with this token
+                            guard let token = response[keyPath: tokenKey] else { return promise.succeed(Void()) }
 
-                    let input = input.usingPaginationToken(token)
-                    paginatePart(input: input)
-                }
-                onPageFuture.whenFailure { error in
-                    promise.fail(error)
-                }
+                            let input = input.usingPaginationToken(token)
+                            paginatePart(input: input)
+                    }
             }
             responseFuture.whenFailure { error in
                 promise.fail(error)
@@ -89,19 +86,16 @@ public extension AWSClient {
 
         func paginatePart(input: Input) {
             let responseFuture = command(input)
-            responseFuture.whenSuccess { (response: Output)->Void in
-                let onPageFuture = onPage(response, eventLoop)
-                onPageFuture.whenSuccess { rt in
-                    guard rt == true else { return promise.succeed(Void()) }
-                    // get next block token and construct a new input with this token
-                    guard let token = response[keyPath: tokenKey] else { return promise.succeed(Void()) }
+                .flatMap { response in
+                    return onPage(response, eventLoop)
+                        .map { (rt)->Void in
+                            guard rt == true else { return promise.succeed(Void()) }
+                            // get next block token and construct a new input with this token
+                            guard let token = response[keyPath: tokenKey] else { return promise.succeed(Void()) }
 
-                    let input = input.usingPaginationToken(token)
-                    paginatePart(input: input)
-                }
-                onPageFuture.whenFailure { error in
-                    promise.fail(error)
-                }
+                            let input = input.usingPaginationToken(token)
+                            paginatePart(input: input)
+                    }
             }
             responseFuture.whenFailure { error in
                 promise.fail(error)

--- a/Sources/AWSSDKSwiftCore/AWSClient+Paginate.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient+Paginate.swift
@@ -51,29 +51,30 @@ public extension AWSClient {
     /// ie it will return the array in blocks of a defined size, each block also includes a token which can be used to access
     /// the next block. This function returns a future that will contain the full contents of the array.
     ///
+    /// This version returns two arrays
+    ///
     /// - Parameters:
     ///   - input: Input for request
     ///   - command: Command to be paginated
     ///   - resultKey1: The name of the first set of objects to be paginated in the response object
     ///   - resultKey2: The name of the second set of objects to be paginated in the response object
     ///   - tokenKey: The name of token in the response object to continue pagination
-    /*func paginate<Input: AWSPaginateStringToken, Output: AWSShape, Result1, Result2>(input: Input, command: @escaping (Input)->EventLoopFuture<Output>, resultKey1: String, resultKey2: String, tokenKey: String) -> EventLoopFuture<([Result1],[Result2])> {
+    func paginate<Input: AWSPaginateStringToken, Output: AWSShape, Result1, Result2>(input: Input, command: @escaping (Input)->EventLoopFuture<Output>, resultKey1: PartialKeyPath<Output>, resultKey2: PartialKeyPath<Output>, tokenKey: KeyPath<Output, String?>) -> EventLoopFuture<([Result1],[Result2])> {
         var list1: [Result1] = []
         var list2: [Result2] = []
         
         func paginatePart(input: Input) -> EventLoopFuture<([Result1],[Result2])> {
             let objects = command(input).flatMap { (response: Output) -> EventLoopFuture<([Result1],[Result2])> in
                 // extract results from response and add to list
-                let mirror = Mirror(reflecting: response)
-                if let results = mirror.getAttribute(forKey: resultKey1) as? [Result1] {
+                if let results = response[keyPath: resultKey1] as? [Result1] {
                     list1.append(contentsOf: results)
                 }
-                if let results = mirror.getAttribute(forKey: resultKey2) as? [Result2] {
+                if let results = response[keyPath: resultKey2] as? [Result2] {
                     list2.append(contentsOf: results)
                 }
 
                 // get next block token and construct a new input with this token
-                guard let token = mirror.getAttribute(forKey: tokenKey) as? String else { return self.eventLoopGroup.next().makeSucceededFuture((list1, list2)) }
+                guard let token = response[keyPath: tokenKey] else { return self.eventLoopGroup.next().makeSucceededFuture((list1, list2)) }
                 let input = Input.init(input, token: token)
 
                 return paginatePart(input: input)
@@ -81,11 +82,101 @@ public extension AWSClient {
             return objects
         }
         return paginatePart(input: input)
-    }*/
+    }
 
     /// If an AWS command is returning an arbituary sized array sometimes it adds support for paginating this array
     /// ie it will return the array in blocks of a defined size, each block also includes a token which can be used to access
     /// the next block. This function returns a future that will contain the full contents of the array.
+    ///
+    /// This version returns three arrays
+    ///
+    /// - Parameters:
+    ///   - input: Input for request
+    ///   - command: Command to be paginated
+    ///   - resultKey1: The name of the first set of objects to be paginated in the response object
+    ///   - resultKey2: The name of the second set of objects to be paginated in the response object
+    ///   - resultKey3: The name of the second set of objects to be paginated in the response object
+    ///   - tokenKey: The name of token in the response object to continue pagination
+    func paginate<Input: AWSPaginateStringToken, Output: AWSShape, Result1, Result2, Result3>(input: Input, command: @escaping (Input)->EventLoopFuture<Output>, resultKey1: PartialKeyPath<Output>, resultKey2: PartialKeyPath<Output>, resultKey3: PartialKeyPath<Output>, tokenKey: KeyPath<Output, String?>) -> EventLoopFuture<([Result1],[Result2],[Result3])> {
+        var list1: [Result1] = []
+        var list2: [Result2] = []
+        var list3: [Result3] = []
+
+        func paginatePart(input: Input) -> EventLoopFuture<([Result1],[Result2],[Result3])> {
+            let objects = command(input).flatMap { (response: Output) -> EventLoopFuture<([Result1],[Result2],[Result3])> in
+                // extract results from response and add to list
+                if let results = response[keyPath: resultKey1] as? [Result1] {
+                    list1.append(contentsOf: results)
+                }
+                if let results = response[keyPath: resultKey2] as? [Result2] {
+                    list2.append(contentsOf: results)
+                }
+                if let results = response[keyPath: resultKey3] as? [Result3] {
+                    list3.append(contentsOf: results)
+                }
+
+                // get next block token and construct a new input with this token
+                guard let token = response[keyPath: tokenKey] else { return self.eventLoopGroup.next().makeSucceededFuture((list1, list2, list3)) }
+                let input = Input.init(input, token: token)
+
+                return paginatePart(input: input)
+            }
+            return objects
+        }
+        return paginatePart(input: input)
+    }
+
+    /// If an AWS command is returning an arbituary sized array sometimes it adds support for paginating this array
+    /// ie it will return the array in blocks of a defined size, each block also includes a token which can be used to access
+    /// the next block. This function returns a future that will contain the full contents of the array.
+    ///
+    /// This version returns four arrays
+    ///
+    /// - Parameters:
+    ///   - input: Input for request
+    ///   - command: Command to be paginated
+    ///   - resultKey1: The name of the first set of objects to be paginated in the response object
+    ///   - resultKey2: The name of the second set of objects to be paginated in the response object
+    ///   - resultKey3: The name of the second set of objects to be paginated in the response object
+    ///   - tokenKey: The name of token in the response object to continue pagination
+    func paginate<Input: AWSPaginateStringToken, Output: AWSShape, Result1, Result2, Result3, Result4>(input: Input, command: @escaping (Input)->EventLoopFuture<Output>, resultKey1: PartialKeyPath<Output>, resultKey2: PartialKeyPath<Output>, resultKey3: PartialKeyPath<Output>, resultKey4: PartialKeyPath<Output>, tokenKey: KeyPath<Output, String?>) -> EventLoopFuture<([Result1],[Result2],[Result3],[Result4])> {
+        var list1: [Result1] = []
+        var list2: [Result2] = []
+        var list3: [Result3] = []
+        var list4: [Result4] = []
+
+        func paginatePart(input: Input) -> EventLoopFuture<([Result1],[Result2],[Result3],[Result4])> {
+            let objects = command(input).flatMap { (response: Output) -> EventLoopFuture<([Result1],[Result2],[Result3],[Result4])> in
+                // extract results from response and add to list
+                if let results = response[keyPath: resultKey1] as? [Result1] {
+                    list1.append(contentsOf: results)
+                }
+                if let results = response[keyPath: resultKey2] as? [Result2] {
+                    list2.append(contentsOf: results)
+                }
+                if let results = response[keyPath: resultKey3] as? [Result3] {
+                    list3.append(contentsOf: results)
+                }
+                if let results = response[keyPath: resultKey4] as? [Result4] {
+                    list4.append(contentsOf: results)
+                }
+
+                // get next block token and construct a new input with this token
+                guard let token = response[keyPath: tokenKey] else { return self.eventLoopGroup.next().makeSucceededFuture((list1, list2, list3, list4)) }
+                let input = Input.init(input, token: token)
+
+                return paginatePart(input: input)
+            }
+            return objects
+        }
+        return paginatePart(input: input)
+    }
+
+    /// If an AWS command is returning an arbituary sized array sometimes it adds support for paginating this array
+    /// ie it will return the array in blocks of a defined size, each block also includes a token which can be used to access
+    /// the next block. This function returns a future that will contain the full contents of the array.
+    ///
+    /// This version uses an Int instead of a String for the token
     ///
     /// - Parameters:
     ///   - input: Input for request

--- a/Sources/AWSSDKSwiftCore/AWSClient+Paginate.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient+Paginate.swift
@@ -27,18 +27,37 @@ public extension AWSClient {
     ///   - command: Command to be paginated
     ///   - resultKey: The name of the objects to be paginated in the response object
     ///   - tokenKey: The name of token in the response object to continue pagination
-    func paginate<Input: AWSPaginateStringToken, Output: AWSShape, PaginateOutput>(input: Input, command: @escaping (Input)->EventLoopFuture<Output>, resultKey: String, tokenKey: String) -> EventLoopFuture<[PaginateOutput]> {
-        var list : [PaginateOutput] = []
+    func paginate<Input: AWSPaginateStringToken, Output: AWSShape, Result>(input: Input, command: @escaping (Input)->EventLoopFuture<Output>, resultKey: KeyPath<Output, [Result]?>, tokenKey: KeyPath<Output, String?>) -> EventLoopFuture<[Result]> {
+        var list: [Result] = []
         
-        func paginatePart(input: Input) -> EventLoopFuture<[PaginateOutput]> {
-            let objects = command(input).flatMap { (response: Output) -> EventLoopFuture<[PaginateOutput]> in
+        func paginatePart(input: Input) -> EventLoopFuture<[Result]> {
+            let objects = command(input).flatMap { (response: Output) -> EventLoopFuture<[Result]> in
                 // extract results from response and add to list
-                let mirror = Mirror(reflecting: response)
-                guard let results = mirror.getAttribute(forKey: resultKey) as? [PaginateOutput] else { return self.eventLoopGroup.next().makeSucceededFuture(list) }
-                list.append(contentsOf: results)
-
+                if let results = response[keyPath: resultKey] {
+                    list.append(contentsOf: results)
+                }
                 // get next block token and construct a new input with this token
-                guard let token = mirror.getAttribute(forKey: tokenKey) as? String else { return self.eventLoopGroup.next().makeSucceededFuture(list) }
+                guard let token = response[keyPath: tokenKey] else { return self.eventLoopGroup.next().makeSucceededFuture(list) }
+                let input = Input.init(input, token: token)
+
+                return paginatePart(input: input)
+            }
+            return objects
+        }
+        return paginatePart(input: input)
+    }
+
+    func paginate<Input: AWSPaginateStringToken, Output: AWSShape, Result>(input: Input, command: @escaping (Input)->EventLoopFuture<Output>, resultKey: KeyPath<Output, [Result]>, tokenKey: KeyPath<Output, String?>) -> EventLoopFuture<[Result]> {
+        var list: [Result] = []
+        
+        func paginatePart(input: Input) -> EventLoopFuture<[Result]> {
+            let objects = command(input).flatMap { (response: Output) -> EventLoopFuture<[Result]> in
+                // extract results from response and add to list
+                let results = response[keyPath: resultKey]
+                list.append(contentsOf: results)
+                
+                // get next block token and construct a new input with this token
+                guard let token = response[keyPath: tokenKey] else { return self.eventLoopGroup.next().makeSucceededFuture(list) }
                 let input = Input.init(input, token: token)
 
                 return paginatePart(input: input)
@@ -56,20 +75,55 @@ public extension AWSClient {
     /// - Parameters:
     ///   - input: Input for request
     ///   - command: Command to be paginated
-    ///   - resultKey: The name of the objects to be paginated in the response object
+    ///   - resultKey1: The name of the first set of objects to be paginated in the response object
+    ///   - resultKey2: The name of the second set of objects to be paginated in the response object
     ///   - tokenKey: The name of token in the response object to continue pagination
-    func paginate<Input: AWSPaginateIntToken, Output: AWSShape, PaginateOutput>(input: Input, command: @escaping (Input)->EventLoopFuture<Output>, resultKey: String, tokenKey: String) -> EventLoopFuture<[PaginateOutput]> {
-        var list : [PaginateOutput] = []
+    /*func paginate<Input: AWSPaginateStringToken, Output: AWSShape, Result1, Result2>(input: Input, command: @escaping (Input)->EventLoopFuture<Output>, resultKey1: String, resultKey2: String, tokenKey: String) -> EventLoopFuture<([Result1],[Result2])> {
+        var list1: [Result1] = []
+        var list2: [Result2] = []
         
-        func paginatePart(input: Input) -> EventLoopFuture<[PaginateOutput]> {
-            let objects = command(input).flatMap { (response: Output) -> EventLoopFuture<[PaginateOutput]> in
+        func paginatePart(input: Input) -> EventLoopFuture<([Result1],[Result2])> {
+            let objects = command(input).flatMap { (response: Output) -> EventLoopFuture<([Result1],[Result2])> in
                 // extract results from response and add to list
                 let mirror = Mirror(reflecting: response)
-                guard let results = mirror.getAttribute(forKey: resultKey) as? [PaginateOutput] else { return self.eventLoopGroup.next().makeSucceededFuture(list) }
-                list.append(contentsOf: results)
+                if let results = mirror.getAttribute(forKey: resultKey1) as? [Result1] {
+                    list1.append(contentsOf: results)
+                }
+                if let results = mirror.getAttribute(forKey: resultKey2) as? [Result2] {
+                    list2.append(contentsOf: results)
+                }
 
                 // get next block token and construct a new input with this token
-                guard let token = mirror.getAttribute(forKey: tokenKey) as? Int else { return self.eventLoopGroup.next().makeSucceededFuture(list) }
+                guard let token = mirror.getAttribute(forKey: tokenKey) as? String else { return self.eventLoopGroup.next().makeSucceededFuture((list1, list2)) }
+                let input = Input.init(input, token: token)
+
+                return paginatePart(input: input)
+            }
+            return objects
+        }
+        return paginatePart(input: input)
+    }*/
+
+    /// If an AWS command is returning an arbituary sized array sometimes it adds support for paginating this array
+    /// ie it will return the array in blocks of a defined size, each block also includes a token which can be used to access
+    /// the next block. This function returns a future that will contain the full contents of the array.
+    ///
+    /// - Parameters:
+    ///   - input: Input for request
+    ///   - command: Command to be paginated
+    ///   - resultKey: The name of the objects to be paginated in the response object
+    ///   - tokenKey: The name of token in the response object to continue pagination
+    func paginate<Input: AWSPaginateIntToken, Output: AWSShape, Result>(input: Input, command: @escaping (Input)->EventLoopFuture<Output>, resultKey: KeyPath<Output, [Result]?>, tokenKey: KeyPath<Output, Int?>) -> EventLoopFuture<[Result]> {
+        var list: [Result] = []
+        
+        func paginatePart(input: Input) -> EventLoopFuture<[Result]> {
+            let objects = command(input).flatMap { (response: Output) -> EventLoopFuture<[Result]> in
+                // extract results from response and add to list
+                if let results = response[keyPath: resultKey] {
+                    list.append(contentsOf: results)
+                }
+                // get next block token and construct a new input with this token
+                guard let token = response[keyPath: tokenKey] else { return self.eventLoopGroup.next().makeSucceededFuture(list) }
                 let input = Input.init(input, token: token)
 
                 return paginatePart(input: input)

--- a/Tests/AWSSDKSwiftCoreTests/PaginateTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/PaginateTests.swift
@@ -67,6 +67,7 @@ class PaginateTests: XCTestCase {
         return client.paginate(input: input, command: counter, resultKey: \CounterOutput.array, tokenKey: \CounterOutput.outputToken, onPage: onPage)
     }
     
+    #if !os(Linux)
     func testPaginate() throws {
         
         // paginate input
@@ -106,11 +107,11 @@ class PaginateTests: XCTestCase {
             XCTAssertEqual(finalArray[i], i)
         }
     }
-    
+    #endif
+
     static var allTests : [(String, (PaginateTests) -> () throws -> Void)] {
         return [
-            ("testPaginate", testPaginate),
+            //("testPaginate", testPaginate),
         ]
     }
-
 }

--- a/Tests/AWSSDKSwiftCoreTests/PaginateTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/PaginateTests.swift
@@ -1,0 +1,116 @@
+//
+//  PaginateTests.swift
+//  AWSSDKSwiftCoreTests
+//
+//  Created by Adam Fowler on 2020/01/21.
+//
+//
+
+import NIO
+import XCTest
+@testable import AWSSDKSwiftCore
+
+class PaginateTests: XCTestCase {
+
+    var eventLoopGroup: EventLoopGroup!
+    var awsServer: AWSTestServer!
+    var client: AWSClient!
+
+    override func setUp() {
+        // create server and client
+        eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
+        awsServer = AWSTestServer(serviceProtocol: .json, eventLoopGroup: eventLoopGroup)
+        client = AWSClient(
+            region: .useast1,
+            service:"TestClient",
+            serviceProtocol: ServiceProtocol(type: .json, version: ServiceProtocol.Version(major: 1, minor: 1)),
+            apiVersion: "2020-01-21",
+            endpoint: "http://localhost:\(awsServer.serverPort)",
+            middlewares: [AWSLoggingMiddleware()],
+            eventLoopGroupProvider: .shared(eventLoopGroup)
+        )
+    }
+    
+    override func tearDown() {
+        XCTAssertNoThrow(try self.awsServer.stop())
+        XCTAssertNoThrow(try self.eventLoopGroup.syncShutdownGracefully())
+        self.eventLoopGroup = nil
+    }
+    
+    // test structures/functions
+    struct CounterInput: AWSShape, AWSPaginateIntToken {
+        public static var _members: [AWSShapeMember] = [
+            AWSShapeMember(label: "inputToken", required: true, type: .integer)
+        ]
+        let inputToken: Int?
+        let pageSize: Int
+        
+        init(inputToken: Int?, pageSize: Int) {
+            self.inputToken = inputToken
+            self.pageSize = pageSize
+        }
+        init(_ original: CounterInput, token: Int) {
+            self.inputToken = token
+            self.pageSize = original.pageSize
+        }
+    }
+    struct CounterOutput: AWSShape {
+        let array: [Int]
+        let outputToken: Int?
+    }
+    
+    func counter(_ input: CounterInput) -> EventLoopFuture<CounterOutput> {
+        return client.send(operation: "TestOperation", path: "/", httpMethod: "POST", input: input)
+    }
+    
+    func counterPaginator(_ input: CounterInput, onPage: @escaping ([Int], EventLoop)->EventLoopFuture<Bool>) -> EventLoopFuture<Void> {
+        return client.paginate(input: input, command: counter, resultKey: \CounterOutput.array, tokenKey: \CounterOutput.outputToken, onPage: onPage)
+    }
+    
+    func testPaginate() throws {
+        
+        // paginate input
+        var finalArray: [Int] = []
+        let input = CounterInput(inputToken: nil, pageSize: 4)
+        let future = counterPaginator(input) { result, eventloop in
+            // collate results into array
+            finalArray.append(contentsOf: result)
+            return eventloop.makeSucceededFuture(true)
+        }
+        
+        let arraySize = 23
+        do {
+            // aws server process
+            try awsServer.process { (input: CounterInput) throws -> AWSTestServer.Result<CounterOutput> in
+                // send part of array of numbers based on input startIndex and pageSize
+                let startIndex = input.inputToken ?? 0
+                let endIndex = min(startIndex+input.pageSize, arraySize)
+                var array: [Int] = []
+                for i in startIndex..<endIndex {
+                    array.append(i)
+                }
+                let continueProcessing = (endIndex != arraySize)
+                let output = CounterOutput(array: array, outputToken: endIndex != arraySize ? endIndex : nil)
+                return AWSTestServer.Result(output: output, continueProcessing: continueProcessing)
+            }
+
+            // wait for response
+            try future.wait()
+        } catch {
+            print(error)
+        }
+        
+        // verify contents of array
+        XCTAssertEqual(finalArray.count, arraySize)
+        for i in 0..<finalArray.count {
+            XCTAssertEqual(finalArray[i], i)
+        }
+    }
+    
+    static var allTests : [(String, (PaginateTests) -> () throws -> Void)] {
+        return [
+            ("testPaginate", testPaginate),
+        ]
+    }
+
+}

--- a/Tests/AWSSDKSwiftCoreTests/PaginateTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/PaginateTests.swift
@@ -53,9 +53,9 @@ class PaginateTests: XCTestCase {
             self.inputToken = inputToken
             self.pageSize = pageSize
         }
-        init(_ original: CounterInput, token: Int) {
-            self.inputToken = token
-            self.pageSize = original.pageSize
+        
+        func usingPaginationToken(_ token: Int) -> CounterInput {
+            return .init(inputToken: token, pageSize: self.pageSize)
         }
     }
     struct CounterOutput: AWSShape {
@@ -123,9 +123,9 @@ class PaginateTests: XCTestCase {
             self.inputToken = inputToken
             self.pageSize = pageSize
         }
-        init(_ original: StringListInput, token: String) {
-            self.inputToken = token
-            self.pageSize = original.pageSize
+        
+        func usingPaginationToken(_ token: String) -> StringListInput {
+            return .init(inputToken: token, pageSize: self.pageSize)
         }
     }
     struct StringListOutput: AWSShape {

--- a/Tests/AWSSDKSwiftCoreTests/PaginateTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/PaginateTests.swift
@@ -11,7 +11,9 @@ import XCTest
 @testable import AWSSDKSwiftCore
 
 class PaginateTests: XCTestCase {
-
+    enum Error: Swift.Error {
+        case didntFindToken
+    }
     var eventLoopGroup: EventLoopGroup!
     var awsServer: AWSTestServer!
     var client: AWSClient!
@@ -21,6 +23,8 @@ class PaginateTests: XCTestCase {
         eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
         awsServer = AWSTestServer(serviceProtocol: .json, eventLoopGroup: eventLoopGroup)
         client = AWSClient(
+            accessKeyId: "",
+            secretAccessKey: "",
             region: .useast1,
             service:"TestClient",
             serviceProtocol: ServiceProtocol(type: .json, version: ServiceProtocol.Version(major: 1, minor: 1)),
@@ -63,19 +67,18 @@ class PaginateTests: XCTestCase {
         return client.send(operation: "TestOperation", path: "/", httpMethod: "POST", input: input)
     }
     
-    func counterPaginator(_ input: CounterInput, onPage: @escaping ([Int], EventLoop)->EventLoopFuture<Bool>) -> EventLoopFuture<Void> {
-        return client.paginate(input: input, command: counter, resultKey: \CounterOutput.array, tokenKey: \CounterOutput.outputToken, onPage: onPage)
+    func counterPaginator(_ input: CounterInput, onPage: @escaping (CounterOutput, EventLoop)->EventLoopFuture<Bool>) -> EventLoopFuture<Void> {
+        return client.paginate(input: input, command: counter, tokenKey: \CounterOutput.outputToken, onPage: onPage)
     }
     
-    #if !os(Linux)
-    func testPaginate() throws {
+    func testIntegerTokenPaginate() throws {
         
         // paginate input
         var finalArray: [Int] = []
         let input = CounterInput(inputToken: nil, pageSize: 4)
         let future = counterPaginator(input) { result, eventloop in
             // collate results into array
-            finalArray.append(contentsOf: result)
+            finalArray.append(contentsOf: result.array)
             return eventloop.makeSucceededFuture(true)
         }
         
@@ -107,11 +110,92 @@ class PaginateTests: XCTestCase {
             XCTAssertEqual(finalArray[i], i)
         }
     }
-    #endif
+    
+    // test structures/functions
+    struct StringListInput: AWSShape, AWSPaginateStringToken {
+        public static var _members: [AWSShapeMember] = [
+            AWSShapeMember(label: "inputToken", required: true, type: .string)
+        ]
+        let inputToken: String?
+        let pageSize: Int
+        
+        init(inputToken: String?, pageSize: Int) {
+            self.inputToken = inputToken
+            self.pageSize = pageSize
+        }
+        init(_ original: StringListInput, token: String) {
+            self.inputToken = token
+            self.pageSize = original.pageSize
+        }
+    }
+    struct StringListOutput: AWSShape {
+        let array: [String]
+        let outputToken: String?
+    }
+    
+    func stringList(_ input: StringListInput) -> EventLoopFuture<StringListOutput> {
+        return client.send(operation: "TestOperation", path: "/", httpMethod: "POST", input: input)
+    }
+    
+    func stringListPaginator(_ input: StringListInput, onPage: @escaping (StringListOutput, EventLoop)->EventLoopFuture<Bool>) -> EventLoopFuture<Void> {
+        return client.paginate(input: input, command: stringList, tokenKey: \StringListOutput.outputToken, onPage: onPage)
+    }
+    
+    func testStringTokenPaginate() throws {
+        
+        // paginate input
+        var finalArray: [String] = []
+        let input = StringListInput(inputToken: nil, pageSize: 5)
+        let future = stringListPaginator(input) { result, eventloop in
+            // collate results into array
+            finalArray.append(contentsOf: result.array)
+            return eventloop.makeSucceededFuture(true)
+        }
+        
+        // create list of unique strings
+        let stringList = Set("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.".split(separator: " ").map {String($0)}).map {$0}
+        
+        do {
+            // aws server process
+            try awsServer.process { (input: StringListInput) throws -> AWSTestServer.Result<StringListOutput> in
+                // send part of array of numbers based on input startIndex and pageSize
+                var startIndex = 0
+                if let inputToken = input.inputToken {
+                    guard let stringIndex = stringList.firstIndex(of:inputToken) else { throw Error.didntFindToken }
+                    startIndex = stringIndex
+                }
+                let endIndex = min(startIndex+input.pageSize, stringList.count)
+                var array: [String] = []
+                for i in startIndex..<endIndex {
+                    array.append(stringList[i])
+                }
+                var outputToken: String? = nil
+                var continueProcessing = false
+                if endIndex < stringList.count {
+                    outputToken = stringList[endIndex]
+                    continueProcessing = true
+                }
+                let output = StringListOutput(array: array, outputToken: outputToken)
+                return AWSTestServer.Result(output: output, continueProcessing: continueProcessing)
+            }
+
+            // wait for response
+            try future.wait()
+        } catch {
+            print(error)
+        }
+        
+        // verify contents of array
+        XCTAssertEqual(finalArray.count, stringList.count)
+        for i in 0..<finalArray.count {
+            XCTAssertEqual(finalArray[i], stringList[i])
+        }
+    }
 
     static var allTests : [(String, (PaginateTests) -> () throws -> Void)] {
         return [
-            //("testPaginate", testPaginate),
+            ("testIntegerTokenPaginate", testIntegerTokenPaginate),
+            ("testStringTokenPaginate", testStringTokenPaginate),
         ]
     }
 }

--- a/Tests/AWSSDKSwiftCoreTests/PerformanceTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/PerformanceTests.swift
@@ -1,8 +1,8 @@
 //
-//  AWSClient.swift
-//  AWSSDKSwift
+//  PerformanceTests.swift
+//  AWSSDKSwiftCoreTests
 //
-//  Created by Jonathan McAllister on 2018/10/13.
+//  Created by Adam Fowler on 2018/10/13.
 //
 //
 

--- a/Tests/AWSSDKSwiftCoreTests/TestServer.swift
+++ b/Tests/AWSSDKSwiftCoreTests/TestServer.swift
@@ -1,0 +1,92 @@
+//TestServer.swift
+//
+//
+
+import NIO
+import NIOFoundationCompat
+import NIOHTTP1
+import NIOTestUtils
+import XCTest
+@testable import AWSSDKSwiftCore
+
+/// Test server for AWSClient. Input and Output shapes are defined by process function
+class AWSTestServer {
+    
+    enum Error: Swift.Error {
+        case notHead
+        case notBody
+        case notEnd
+        case emptyBody
+        case noXMLBody
+    }
+    enum ServiceProtocol {
+        case json
+        case xml
+    }
+    struct Result<Output>{
+        let output: Output
+        let continueProcessing: Bool
+    }
+    
+    let web: NIOHTTP1TestServer
+    let serviceProtocol: ServiceProtocol
+    var serverPort: Int { return web.serverPort }
+    let byteBufferAllocator: ByteBufferAllocator
+
+    
+    init(serviceProtocol: ServiceProtocol, eventLoopGroup: EventLoopGroup) {
+        self.web = NIOHTTP1TestServer(group: eventLoopGroup)
+        self.serviceProtocol = serviceProtocol
+        self.byteBufferAllocator = ByteBufferAllocator()
+    }
+    
+    func process<Input: AWSShape, Output: AWSShape>(_ process: (Input) throws -> Result<Output>) throws {
+        
+        var continueProcessing =  true
+        while(continueProcessing) {
+            // read inbound
+            let head = try web.readInbound()
+            guard case .head(_) = head else {throw Error.notHead}
+            let body = try web.readInbound()
+            guard case .body(let buffer) = body else {throw Error.notBody}
+            let end = try web.readInbound()
+            guard case .end(_) = end else {throw Error.notEnd}
+            guard let data = buffer.getData(at: 0, length: buffer.readableBytes) else {throw Error.emptyBody}
+            
+            let input: Input
+            switch serviceProtocol {
+            case .json:
+                input = try JSONDecoder().decode(Input.self, from: data)
+            case .xml:
+                guard let xmlNode = try XML.Document(data: data).rootElement() else {throw Error.noXMLBody}
+                input = try XMLDecoder().decode(Input.self, from: xmlNode)
+            }
+            
+            // process
+            let result = try process(input)
+            
+            continueProcessing = result.continueProcessing
+            
+            // write outbound
+            let outputData: Data
+            switch serviceProtocol {
+            case .json:
+                outputData = try JSONEncoder().encode(result.output)
+            case .xml:
+                outputData = try XMLEncoder().encode(result.output).xmlString.data(using: .utf8) ?? Data()
+            }
+
+            var byteBuffer = byteBufferAllocator.buffer(capacity: 0)
+            byteBuffer.writeBytes(outputData)
+            XCTAssertNoThrow(try web.writeOutbound(.head(.init(version: .init(major: 1, minor: 1),
+                                                               status: .ok))))
+            XCTAssertNoThrow(try web.writeOutbound(.body(.byteBuffer(byteBuffer))))
+            XCTAssertNoThrow(try web.writeOutbound(.end(nil)))
+        }
+    }
+    
+    func stop() throws {
+        try web.stop()
+    }
+}
+

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -7,6 +7,7 @@ XCTMain([
     testCase(DictionaryEncoderTests.allTests),
     testCase(HTTPClientTests.allTests),
     testCase(MetaDataServiceTests.allTests),
+    testCase(PaginateTests.allTests),
     testCase(SerializersTests.allTests),
     testCase(SignersV4Tests.allTests),
     testCase(TimeStampTests.allTests),


### PR DESCRIPTION
This is the core routine for paginating results. It uses `Mirror` to extract the results and a continuation token to get the remaining results. The code generation PR can be found here https://github.com/swift-aws/aws-sdk-swift/pull/227

At the moment to create a new request with the new continuation token I have had to create a protocol which requires a new initialiser which take the original request and a token. The initialiser should copy the contents of the original request but with the new token.

The code below demonstrates the extension for S3.ListObjectsV2 and the paginate function used to get the data.
```
extension S3.ListObjectsV2Request: AWSPaginateable {
    public init(_ original: S3.ListObjectsV2Request, token: String) {
        self.init(
            bucket: original.bucket, 
            continuationToken: token, 
            delimiter: original.delimiter, 
            encodingType: original.encodingType, 
            fetchOwner: original.fetchOwner, 
            maxKeys: original.maxKeys, 
            prefix: original.prefix, 
            requestPayer: original.requestPayer, 
            startAfter: original.startAfter
        )
    }
}

extension S3 {
    public func listObjectsV2Paginator(_ input: ListObjectsV2Request) -> EventLoopFuture<[Object]> {
        return client.paginate(input: input, command: listObjectsV2, resultKey: "contents", tokenKey: "nextContinuationToken")
    }
}
```

