### PR TITLE
Remove all `import Foundation` and replace with specific imports.

### DIFF
--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -7,10 +7,17 @@
 //
 
 import HypertextApplicationLanguage
-import Foundation
 import NIO
 import NIOHTTP1
 import NIOTransportServices
+import class  Foundation.ProcessInfo
+import class  Foundation.JSONSerialization
+import struct Foundation.Data
+import struct Foundation.Date
+import struct Foundation.URL
+import struct Foundation.URLComponents
+import struct Foundation.URLQueryItem
+import struct Foundation.CharacterSet
 
 /// Convenience shorthand for `EventLoopFuture`.
 @available(*, deprecated, message: "Use the EventLoopFuture directly")

--- a/Sources/AWSSDKSwiftCore/AWSShapes/TimeStamp.swift
+++ b/Sources/AWSSDKSwiftCore/AWSShapes/TimeStamp.swift
@@ -5,7 +5,10 @@
 //  Created by Yuki Takei/Adam Fowler on 2017/10/09.
 //
 
-import Foundation
+import class  Foundation.DateFormatter
+import struct Foundation.Locale
+import struct Foundation.Date
+import struct Foundation.TimeZone
 
 /// Time stamp object that can encoded to ISO8601 format and decoded from ISO8601, HTTP date format and UNIX epoch seconds
 public struct TimeStamp {

--- a/Sources/AWSSDKSwiftCore/Bytes.swift
+++ b/Sources/AWSSDKSwiftCore/Bytes.swift
@@ -6,8 +6,6 @@
 //
 //
 
-import Foundation
-
 extension UInt8 {
     public func hexdigest() -> String {
         return String(format: "%02x", self)

--- a/Sources/AWSSDKSwiftCore/Credential/Credential.swift
+++ b/Sources/AWSSDKSwiftCore/Credential/Credential.swift
@@ -6,8 +6,10 @@
 //
 //
 
-import Foundation
 import INIParser
+import struct Foundation.Date
+import class  Foundation.ProcessInfo
+import class  Foundation.NSString
 
 /// Protocol defining requirements for object providing AWS credentials
 public protocol CredentialProvider {

--- a/Sources/AWSSDKSwiftCore/Doc/AWSShape.swift
+++ b/Sources/AWSSDKSwiftCore/Doc/AWSShape.swift
@@ -6,7 +6,10 @@
 //
 //
 
-import Foundation
+import struct Foundation.UUID
+import class  Foundation.NSRegularExpression
+import var    Foundation.NSNotFound
+import func   Foundation.NSMakeRange
 
 /// Protocol for the input and output objects for all AWS service commands. They need to be Codable so they can be serialized. They also need to provide details on how their container classes are coded when serializing XML.
 public protocol AWSShape: XMLCodable {

--- a/Sources/AWSSDKSwiftCore/Doc/AWSShapeMember.swift
+++ b/Sources/AWSSDKSwiftCore/Doc/AWSShapeMember.swift
@@ -6,8 +6,6 @@
 //
 //
 
-import Foundation
-
 /// Structure defining how to serialize member of AWSShape.
 public struct AWSShapeMember {
     /// Type of AWSShapeMember

--- a/Sources/AWSSDKSwiftCore/Doc/Mirror.swift
+++ b/Sources/AWSSDKSwiftCore/Doc/Mirror.swift
@@ -6,8 +6,6 @@
 //
 //
 
-import Foundation
-
 extension Mirror {
     func getAttribute(forKey key: String) -> Any? {
         guard let matched = children.filter({ $0.label == key }).first else {

--- a/Sources/AWSSDKSwiftCore/Doc/ServiceProtocol.swift
+++ b/Sources/AWSSDKSwiftCore/Doc/ServiceProtocol.swift
@@ -6,8 +6,6 @@
 //
 //
 
-import Foundation
-
 public enum ServiceProtocolType {
     case json
     case restjson

--- a/Sources/AWSSDKSwiftCore/Encoder/AWSShapeEncoder.swift
+++ b/Sources/AWSSDKSwiftCore/Encoder/AWSShapeEncoder.swift
@@ -5,7 +5,8 @@
 //  Created by Yuki Takei on 2017/10/07.
 //
 
-import Foundation
+import struct Foundation.Data
+import class  Foundation.JSONEncoder
 
 func unwrap(any: Any) -> Any? {
     let mi = Mirror(reflecting: any)

--- a/Sources/AWSSDKSwiftCore/Encoder/DictionaryEncoder.swift
+++ b/Sources/AWSSDKSwiftCore/Encoder/DictionaryEncoder.swift
@@ -14,7 +14,25 @@
 // https://github.com/apple/swift/blob/2771eb520c4e3058058baf6bb3f6dba6184a17d3/stdlib/public/Darwin/Foundation/JSONEncoder.swift
 
 import CoreFoundation
-import Foundation
+import struct Foundation.Date
+import class  Foundation.DateFormatter
+import struct Foundation.Data
+import struct Foundation.CharacterSet
+import struct Foundation.URL
+import struct Foundation.Decimal
+import class  Foundation.ISO8601DateFormatter
+
+import class  Foundation.NSObject
+import class  Foundation.NSMutableDictionary
+import class  Foundation.NSMutableArray
+import class  Foundation.NSNull
+import class  Foundation.NSNumber
+import class  Foundation.NSString
+import class  Foundation.NSData
+import class  Foundation.NSDictionary
+import class  Foundation.NSDecimalNumber
+import class  Foundation.NSURL
+import class  Foundation.NSDate
 
 /// A marker protocol used to determine whether a value is a `String`-keyed `Dictionary`
 /// containing `Encodable` values (in which case it should be exempt from key conversion strategies).

--- a/Sources/AWSSDKSwiftCore/Encoder/XMLDecoder.swift
+++ b/Sources/AWSSDKSwiftCore/Encoder/XMLDecoder.swift
@@ -5,7 +5,16 @@
 //  Created by Adam Fowler on 2019/05/01.
 //
 //
-import Foundation
+
+import struct Foundation.Data
+import struct Foundation.Date
+import struct Foundation.URL
+import class  Foundation.DateFormatter
+import class  Foundation.ISO8601DateFormatter
+
+import class  Foundation.NSURL
+import class  Foundation.NSDate
+import class  Foundation.NSData
 
 /// rules for encoding/decoding containers like arrays and dictionaries.
 public enum XMLContainerCoding {

--- a/Sources/AWSSDKSwiftCore/Encoder/XMLEncoder.swift
+++ b/Sources/AWSSDKSwiftCore/Encoder/XMLEncoder.swift
@@ -5,7 +5,17 @@
 //  Created by Adam Fowler on 2019/05/01.
 //
 //
-import Foundation
+
+import struct Foundation.Data
+import struct Foundation.Date
+import struct Foundation.URL
+import class  Foundation.DateFormatter
+import class  Foundation.ISO8601DateFormatter
+
+import class  Foundation.NSNumber
+import class  Foundation.NSURL
+import class  Foundation.NSDate
+import class  Foundation.NSData
 
 /// A marker protocols used to determine whether a value is a `Dictionary` or an `Array`
 ///

--- a/Sources/AWSSDKSwiftCore/Error.swift
+++ b/Sources/AWSSDKSwiftCore/Error.swift
@@ -6,8 +6,6 @@
 //
 //
 
-import Foundation
-
 /// Standard Error type returned by aws-sdk-swift. Initialized with error code and message. Must provide an implementation of var description : String
 public protocol AWSErrorType: Error, CustomStringConvertible {
     init?(errorCode: String, message: String?)

--- a/Sources/AWSSDKSwiftCore/HMAC.swift
+++ b/Sources/AWSSDKSwiftCore/HMAC.swift
@@ -6,8 +6,6 @@
 //
 //
 
-import Foundation
-
 #if canImport(CAWSSDKOpenSSL)
 
 import CAWSSDKOpenSSL

--- a/Sources/AWSSDKSwiftCore/HTTPClient.swift
+++ b/Sources/AWSSDKSwiftCore/HTTPClient.swift
@@ -10,12 +10,13 @@
 // https://github.com/swift-server/swift-nio-http-client
 //
 
-import Foundation
 import NIO
 import NIOConcurrencyHelpers
 import NIOFoundationCompat
 import NIOHTTP1
 import NIOSSL
+import struct Foundation.Data
+import struct Foundation.URL
 #if canImport(Network)
 import Network
 import NIOTransportServices

--- a/Sources/AWSSDKSwiftCore/Hash.swift
+++ b/Sources/AWSSDKSwiftCore/Hash.swift
@@ -6,7 +6,7 @@
 //
 //
 
-import Foundation
+import struct Foundation.Data
 
 #if canImport(CAWSSDKOpenSSL)
 

--- a/Sources/AWSSDKSwiftCore/Message/AWSRequest.swift
+++ b/Sources/AWSSDKSwiftCore/Message/AWSRequest.swift
@@ -6,9 +6,11 @@
 //
 //
 
-import Foundation
 import NIO
 import NIOHTTP1
+import struct Foundation.URL
+import struct Foundation.Date
+import struct Foundation.Data
 
 /// Object encapsulating all the information needed to generate a raw HTTP request to AWS
 public struct AWSRequest {

--- a/Sources/AWSSDKSwiftCore/Message/AWSResponse.swift
+++ b/Sources/AWSSDKSwiftCore/Message/AWSResponse.swift
@@ -6,7 +6,6 @@
 //
 //
 
-import Foundation
 import NIO
 import NIOHTTP1
 import HypertextApplicationLanguage

--- a/Sources/AWSSDKSwiftCore/Message/Body.swift
+++ b/Sources/AWSSDKSwiftCore/Message/Body.swift
@@ -6,7 +6,10 @@
 //
 //
 
-import Foundation
+import NIO
+import struct Foundation.Data
+import class  Foundation.InputStream
+import class  Foundation.JSONSerialization
 
 /// Enumaration used to store request/response body in various forms
 public enum Body {

--- a/Sources/AWSSDKSwiftCore/MetaDataService.swift
+++ b/Sources/AWSSDKSwiftCore/MetaDataService.swift
@@ -7,10 +7,18 @@
 //
 
 #if os(Linux)
-
-import Foundation
 import NIO
 import NIOHTTP1
+
+import struct Foundation.Data
+import struct Foundation.URL
+import class  Foundation.DateFormatter
+import struct Foundation.Date
+import struct Foundation.TimeInterval
+import struct Foundation.TimeZone
+import struct Foundation.Locale
+import class  Foundation.JSONDecoder
+import class  Foundation.ProcessInfo
 
 /// errors returned by metadata service
 enum MetaDataServiceError: Error {

--- a/Sources/AWSSDKSwiftCore/Signers/V4.swift
+++ b/Sources/AWSSDKSwiftCore/Signers/V4.swift
@@ -6,8 +6,16 @@
 //
 //
 
-import Foundation
 import NIO
+import struct Foundation.Data
+import struct Foundation.Date
+import struct Foundation.URL
+import struct Foundation.Locale
+import class  Foundation.DateFormatter
+import struct Foundation.TimeZone
+import struct Foundation.URLQueryItem
+import struct Foundation.URLComponents
+import enum   Foundation.ComparisonResult
 
 extension Signers {
     /// AWS V4 Signing code

--- a/Sources/AWSSDKSwiftCore/String.swift
+++ b/Sources/AWSSDKSwiftCore/String.swift
@@ -6,8 +6,6 @@
 //
 //
 
-import Foundation
-
 extension String {
     public func lowerFirst() -> String {
         return String(self[startIndex]).lowercased() + self[index(after: startIndex)...]

--- a/Sources/AWSSDKSwiftCore/XML.swift
+++ b/Sources/AWSSDKSwiftCore/XML.swift
@@ -7,11 +7,16 @@
 
 // Implemented to replace the XML Foundation classes. This was initially required as there is no implementation of the Foundation XMLNode classes in iOS. This is also here because the implementation of XMLNode in Linux Swift 4.2 was causing crashes. Whenever an XMLDocument was deleted all the underlying CoreFoundation objects were deleted. This meant if you still had a reference to a XMLElement from that document, while it was still valid the underlying CoreFoundation object had been deleted.
 
+import struct   Foundation.Data
+import class    Foundation.NSObject
 #if canImport(FoundationXML)
 import FoundationXML
+#else
+import class    Foundation.XMLParser
+import protocol Foundation.XMLParserDelegate
 #endif
 
-import Foundation
+
 
 // I have placed everything inside a holding XML class to avoid name clashes with the Foundation version. Otherwise this class reflects the behaviour of the Foundation classes as close as possible with the exceptions of, I haven't implemented queries, DTD, also XMLNodes do not contain an object reference. Also the node creation function in XMLNode return XMLNode instead of Any.
 public class XML {

--- a/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
@@ -6,10 +6,9 @@
 //
 //
 
-import Foundation
-import NIOHTTP1
 import XCTest
 import NIO
+import NIOHTTP1
 @testable import AWSSDKSwiftCore
 
 class AWSClientTests: XCTestCase {

--- a/Tests/AWSSDKSwiftCoreTests/CredentialTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/CredentialTests.swift
@@ -5,7 +5,6 @@
 //  Created by Oliver ONeill on 2/9/18.
 //
 
-import Foundation
 import XCTest
 @testable import AWSSDKSwiftCore
 

--- a/Tests/AWSSDKSwiftCoreTests/DictionaryEncoderTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/DictionaryEncoderTests.swift
@@ -5,7 +5,6 @@
 //  Created by Yuki Takei on 2017/10/08.
 //
 
-import Foundation
 import XCTest
 @testable import AWSSDKSwiftCore
 

--- a/Tests/AWSSDKSwiftCoreTests/HTTPClientTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/HTTPClientTests.swift
@@ -6,9 +6,11 @@
 //
 //
 
-import Foundation
-import NIOHTTP1
 import XCTest
+import NIO
+import NIOHTTP1
+import NIOTransportServices
+
 @testable import AWSSDKSwiftCore
 
 class HTTPClientTests: XCTestCase {

--- a/Tests/AWSSDKSwiftCoreTests/MetaDataServiceTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/MetaDataServiceTests.swift
@@ -4,9 +4,8 @@
 //
 //  Created by Jonathan McAllister on 2017/12/29.
 //
-#if os(Linux)
 
-import Foundation
+#if os(Linux)
 import XCTest
 @testable import AWSSDKSwiftCore
 

--- a/Tests/AWSSDKSwiftCoreTests/PerformanceTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/PerformanceTests.swift
@@ -6,9 +6,8 @@
 //
 //
 
-import Foundation
-import NIOHTTP1
 import XCTest
+import NIOHTTP1
 @testable import AWSSDKSwiftCore
 
 struct HeaderRequest: AWSShape {

--- a/Tests/AWSSDKSwiftCoreTests/QueryEncoderTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/QueryEncoderTests.swift
@@ -6,7 +6,6 @@
 //
 //
 
-import Foundation
 import XCTest
 @testable import AWSSDKSwiftCore
 

--- a/Tests/AWSSDKSwiftCoreTests/SerializersTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/SerializersTests.swift
@@ -6,7 +6,6 @@
 //
 //
 
-import Foundation
 import XCTest
 @testable import AWSSDKSwiftCore
 

--- a/Tests/AWSSDKSwiftCoreTests/SignersV4Tests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/SignersV4Tests.swift
@@ -6,7 +6,6 @@
 //
 //
 
-import Foundation
 import XCTest
 @testable import AWSSDKSwiftCore
 

--- a/Tests/AWSSDKSwiftCoreTests/TimeStampTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/TimeStampTests.swift
@@ -5,7 +5,6 @@
 //  Created by Yuki Takei on 2017/10/09.
 //
 
-import Foundation
 import XCTest
 @testable import AWSSDKSwiftCore
 

--- a/Tests/AWSSDKSwiftCoreTests/ValidationTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/ValidationTests.swift
@@ -5,7 +5,6 @@
 //  Created by Adam Fowler 2019/08/22
 //
 
-import Foundation
 import XCTest
 @testable import AWSSDKSwiftCore
 

--- a/Tests/AWSSDKSwiftCoreTests/XMLTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/XMLTests.swift
@@ -5,7 +5,6 @@
 //  Created by Adam Fowler 2019/07/06
 //
 
-import Foundation
 import XCTest
 @testable import AWSSDKSwiftCore
 


### PR DESCRIPTION
NOTE: This can be merged into master!

This will make much clearer where we depend on `Foundation`. In the future we can start to get rid of those parts.