### PR TITLE
Fixed Dictionary<enum, object> in XMLEncoder/XMLDecoder plus optimization

### DIFF
--- a/Sources/AWSSDKSwiftCore/Encoder/XMLDecoder.swift
+++ b/Sources/AWSSDKSwiftCore/Encoder/XMLDecoder.swift
@@ -373,9 +373,6 @@ fileprivate class _XMLDecoder : Decoder {
         }
 
         func decode<T>(_ type: T.Type, forKey key: Key) throws -> T where T : Decodable {
-            // store containerCoding to reset at the exit of thie function
-            let prevContainerCoding = decoder.containerCoding
-            defer { decoder.containerCoding = prevContainerCoding }
             self.decoder.codingPath.append(key)
             defer { self.decoder.codingPath.removeLast() }
 
@@ -441,6 +438,7 @@ fileprivate class _XMLDecoder : Decoder {
 
         init(_ element: XML.Node, decoder: _XMLDecoder) {
             var elements : [XML.Node]?
+            
             // build array of elements based on the container coding
             switch decoder.containerCoding {
             case .array(let member):
@@ -583,9 +581,6 @@ fileprivate class _XMLDecoder : Decoder {
         }
 
         mutating func decode<T>(_ type: T.Type) throws -> T where T : Decodable {
-            // store containerCoding to reset at the exit of thie function
-            let prevContainerCoding = decoder.containerCoding
-            defer { decoder.containerCoding = prevContainerCoding }
             // set containerCoding
             if type is _XMLDictionaryDecodableMarker.Type {
                 decoder.containerCoding = decoder.options.dictionaryDecodingStrategy

--- a/Sources/AWSSDKSwiftCore/Encoder/XMLDecoder.swift
+++ b/Sources/AWSSDKSwiftCore/Encoder/XMLDecoder.swift
@@ -583,6 +583,18 @@ fileprivate class _XMLDecoder : Decoder {
         }
 
         mutating func decode<T>(_ type: T.Type) throws -> T where T : Decodable {
+            // store containerCoding to reset at the exit of thie function
+            let prevContainerCoding = decoder.containerCoding
+            defer { decoder.containerCoding = prevContainerCoding }
+            // set containerCoding
+            if type is _XMLDictionaryDecodableMarker.Type {
+                decoder.containerCoding = decoder.options.dictionaryDecodingStrategy
+            } else if type is _XMLArrayDecodableMarker.Type {
+                decoder.containerCoding = decoder.options.arrayDecodingStrategy
+            } else {
+                decoder.containerCoding = .default
+            }
+
             let value = try decoder.unbox(elements[currentIndex], as:T.self)
             currentIndex += 1
             return value
@@ -694,6 +706,18 @@ fileprivate class _XMLDecoder : Decoder {
         }
 
         func decode<T>(_ type: T.Type) throws -> T where T : Decodable {
+            // store containerCoding to reset at the exit of thie function
+            let prevContainerCoding = decoder.containerCoding
+            defer { decoder.containerCoding = prevContainerCoding }
+            // set containerCoding
+            if type is _XMLDictionaryDecodableMarker.Type {
+                decoder.containerCoding = decoder.options.dictionaryDecodingStrategy
+            } else if type is _XMLArrayDecodableMarker.Type {
+                decoder.containerCoding = decoder.options.arrayDecodingStrategy
+            } else {
+                decoder.containerCoding = .default
+            }
+
             return try decoder.unbox(element, as: T.self)
         }
 

--- a/Sources/AWSSDKSwiftCore/Encoder/XMLEncoder.swift
+++ b/Sources/AWSSDKSwiftCore/Encoder/XMLEncoder.swift
@@ -220,22 +220,29 @@ class _XMLEncoder : Encoder {
         let encoder : _XMLEncoder
         let element : XML.Element
         var codingPath: [CodingKey] { return encoder.codingPath }
-        
+        let dictionaryElementNames: (entry: String, key: String, value: String)?
+
         init(_ element : XML.Element, referencing encoder: _XMLEncoder) {
             self.element = element
             self.encoder = encoder
+            
+            // extract dictionary element naming from container coding
+            if case .dictionary(let entryName, let keyName, let valueName) = encoder.containerCoding {
+                dictionaryElementNames = (entry: entryName ?? encoder.currentKey, key: keyName, value: valueName)
+            } else {
+                dictionaryElementNames = nil
+            }
         }
         
         /// returns the element to add value xml elements to and what to name those elements
         func collectionElement(forKey key: Key) -> (element:XML.Element, key:String) {
-            // create enclosing xmlelement for dictionary entry, then create key and value xmlelements under that element
-            if case .dictionary(let entryName, let keyName, let valueName) = encoder.containerCoding {
-                let entryName = entryName ?? encoder.currentKey
-                let entryElement = XML.Element(name: entryName)
-                let keyElement = XML.Element(name: keyName, stringValue:key.stringValue)
+            // if dictionary element names are available output as dictionary wth entry, key and value xml elements, otherwise output one element
+            if let dictionaryElementNames = self.dictionaryElementNames {
+                let entryElement = XML.Element(name: dictionaryElementNames.entry)
+                let keyElement = XML.Element(name: dictionaryElementNames.key, stringValue:key.stringValue)
                 entryElement.addChild(keyElement)
                 element.addChild(entryElement)
-                return (element:entryElement, key:valueName)
+                return (element:entryElement, key:dictionaryElementNames.value)
             }
             // return current element
             return (element:element, key:key.stringValue)
@@ -329,14 +336,11 @@ class _XMLEncoder : Encoder {
         }
         
         func encode<T>(_ value: T, forKey key: Key) throws where T : Encodable {
-            // store containerCoding to reset at the exit of thie function
-            let prevContainerCoding = encoder.containerCoding
-            defer { encoder.containerCoding = prevContainerCoding }
             // get element to attach child elements, also what to name those elements
             let dict = collectionElement(forKey: key)
             self.encoder.codingPath.append(_XMLKey(stringValue: dict.key, intValue: nil))
             defer { self.encoder.codingPath.removeLast() }
-            // if element returned from dictionaryElement is different, then replace the top of the storage stack
+            // if element returned from collectionElement is different, then replace the top of the storage stack
             if element !== dict.element {
                 self.encoder.storage.popContainer()
                 self.encoder.storage.push(container: dict.element)
@@ -390,6 +394,9 @@ class _XMLEncoder : Encoder {
     
     func unkeyedContainer() -> UnkeyedEncodingContainer {
         var createEnclosingElement = false
+        // Should I create an enclosing element. If the container has an entry element, then structure
+        // is `<array><entry>...</entry><entry>...</entry></array>` and we need to create the `array`
+        // element
         switch self.containerCoding {
         case .dictionary(let entry,_,_):
             // if entry is nil don't create enclosing element
@@ -423,33 +430,45 @@ class _XMLEncoder : Encoder {
         let element : XML.Element
         var codingPath: [CodingKey] { return encoder.codingPath }
         var count : Int
+        let entryElementName: String
+        let dictionaryElementNames: (key: String, value: String)?
 
         init(_ element : XML.Element, referencing encoder: _XMLEncoder) {
             self.element = element
             self.encoder = encoder
             self.count = 0
+            
+            // work out entry element name, and if we are outputting a dictionary the key/value element names
+            switch encoder.containerCoding {
+            case .dictionary(let entryName, let keyName, let valueName):
+                entryElementName = entryName ?? encoder.currentKey
+                dictionaryElementNames = (key: keyName, value: valueName)
+                
+            case .array(let member):
+                entryElementName = member ?? encoder.currentKey
+                dictionaryElementNames = nil
+
+            default:
+                entryElementName = encoder.currentKey
+                dictionaryElementNames = nil
+                break
+            }
         }
         
         /// returns the element to add value xml elements to, what to name those elements and whether we should pop the last element off the storage stack
         func collectionElement() -> (element:XML.Element, key:String, popElement: Bool) {
-            switch encoder.containerCoding {
-            case .dictionary(let entryName, let keyName, let valueName):
-                // key element
+            if let dictionaryElementNames = self.dictionaryElementNames {
                 if (count & 1 == 0) {
-                    // construct enclosing key element
-                    let entryName = entryName ?? encoder.currentKey
+                    // construct enclosing entry element
+                    let entryName = entryElementName
                     let entryElement = XML.Element(name: entryName)
                     element.addChild(entryElement)
-                    return (element:entryElement, key: keyName, popElement:false)
+                    return (element:entryElement, key: dictionaryElementNames.key, popElement:false)
                 } else {
-                    return (element:element, key: valueName, popElement:true)
+                    return (element:element, key: dictionaryElementNames.value, popElement:true)
                 }
-                
-            case .array(let member):
-                return (element:element, key: member ?? encoder.currentKey, popElement:false)
-                
-            default:
-                return (element:element, key: encoder.currentKey, popElement:false)
+            } else {
+                return (element:element, key: entryElementName, popElement:false)
             }
         }
         
@@ -556,13 +575,10 @@ class _XMLEncoder : Encoder {
         }
         
         mutating func encode<T>(_ value: T) throws where T : Encodable {
-            // store containerCoding to reset at the exit of thie function
-            let prevContainerCoding = encoder.containerCoding
-            defer { encoder.containerCoding = prevContainerCoding }
-
             let collection = collectionElement()
             self.encoder.codingPath.append(_XMLKey(stringValue: collection.key, intValue: nil))
             defer { self.encoder.codingPath.removeLast() }
+            
             // if element returned from collectionElement is different, then replace the top of the storage stack
             if element !== collection.element {
                 self.encoder.storage.push(container: collection.element)

--- a/Tests/AWSSDKSwiftCoreTests/JSONCoderTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/JSONCoderTests.swift
@@ -1,0 +1,162 @@
+//  JSONCoderTests.swift
+//  AWSSDKSwiftTests
+//
+//  Created by Adam Fowler 2020/01/30
+
+import XCTest
+@testable import AWSSDKSwiftCore
+
+class JSONCoderTests: XCTestCase {
+    
+    struct Numbers : AWSShape {
+
+       init(bool:Bool, integer:Int, float:Float, double:Double, intEnum:IntEnum) {
+           self.bool = bool
+           self.integer = integer
+           self.float = float
+           self.double = double
+           self.intEnum = intEnum
+           self.int8 = 4
+           self.uint16 = 5
+           self.int32 = 7
+           self.uint64 = 90
+       }
+
+       enum IntEnum : Int, Codable {
+           case first
+           case second
+           case third
+       }
+       let bool : Bool
+       let integer : Int
+       let float : Float
+       let double : Double
+       let intEnum : IntEnum
+       let int8 : Int8
+       let uint16 : UInt16
+       let int32 : Int32
+       let uint64 : UInt64
+
+       private enum CodingKeys : String, CodingKey {
+           case bool = "b"
+           case integer = "i"
+           case float = "s"
+           case double = "d"
+           case intEnum = "enum"
+           case int8 = "int8"
+           case uint16 = "uint16"
+           case int32 = "int32"
+           case uint64 = "uint64"
+       }
+    }
+
+    struct StringShape : AWSShape {
+       enum StringEnum : String, Codable {
+           case first="first"
+           case second="second"
+           case third="third"
+           case fourth="fourth"
+       }
+       let string : String
+       let optionalString : String?
+       let stringEnum : StringEnum
+    }
+
+    struct Arrays : AWSShape {
+       public static var _members: [AWSShapeMember] = [
+           AWSShapeMember(label: "ArrayOfNatives", location: .body(locationName: "ArrayOfNatives"), required: true, type: .list, encoding: .list(member: "member")),
+           AWSShapeMember(label: "ArrayOfShapes", location: .body(locationName: "ArrayOfShapes"), required: true, type: .list)
+       ]
+       
+       let arrayOfNatives : [Int]
+       let arrayOfShapes : [Numbers]
+    }
+
+    struct Dictionaries : AWSShape {
+       public static var _members: [AWSShapeMember] = [
+           AWSShapeMember(label: "DictionaryOfNatives", location: .body(locationName: "Natives"), required: true, type: .list, encoding: .map(entry: "entry", key: "key", value: "value")),
+           AWSShapeMember(label: "DictionaryOfShapes", location: .body(locationName: "Shapes"), required: true, type: .list, encoding: .flatMap(key: "key", value: "value"))
+       ]
+       let dictionaryOfNatives : [String:Int]
+       let dictionaryOfShapes : [String:StringShape]
+
+       private enum CodingKeys : String, CodingKey {
+           case dictionaryOfNatives = "natives"
+           case dictionaryOfShapes = "shapes"
+       }
+    }
+
+    struct Shape : AWSShape {
+       let numbers : Numbers
+       let stringShape : StringShape
+       let arrays : Arrays
+
+       private enum CodingKeys : String, CodingKey {
+           case numbers = "Numbers"
+           case stringShape = "Strings"
+           case arrays = "Arrays"
+       }
+    }
+
+    struct ShapeWithDictionaries : AWSShape {
+       let shape : Shape
+       let dictionaries : Dictionaries
+
+       private enum CodingKeys : String, CodingKey {
+           case shape = "s"
+           case dictionaries = "d"
+       }
+    }
+
+    var testShape : Shape {
+       return Shape(numbers: Numbers(bool:true, integer: 45, float: 3.4, double: 7.89234, intEnum: .second),
+                             stringShape: StringShape(string: "String1", optionalString: "String2", stringEnum: .third),
+                             arrays: Arrays(arrayOfNatives: [34,1,4098], arrayOfShapes: [Numbers(bool:false, integer: 1, float: 1.2, double: 1.4, intEnum: .first), Numbers(bool:true, integer: 3, float: 2.01, double: 1.01, intEnum: .third)]))
+    }
+
+    var testShapeWithDictionaries : ShapeWithDictionaries {
+       return ShapeWithDictionaries(shape: testShape, dictionaries: Dictionaries(dictionaryOfNatives: ["first":1, "second":2, "third":3],
+                                                                                         dictionaryOfShapes: ["strings":StringShape(string:"one", optionalString: "two", stringEnum: .third),
+                                                                                                              "strings2":StringShape(string:"cat", optionalString: nil, stringEnum: .fourth)]))
+    }
+
+    func testSerializeToDictionaryAndJSON() {
+        let json = try! AWSShapeEncoder().json(testShapeWithDictionaries)
+        let dict = try! JSONSerialization.jsonObject(with: json, options: []) as? [String: Any] ?? [:]
+
+        let dict2 = dict["s"] as? [String:Any]
+
+        // Member scalar
+        let stringsDict = dict2?["Strings"]! as? [String: Any]
+        let string = stringsDict?["string"] as? String
+        XCTAssertEqual(string, "String1")
+
+        // array member
+        let arrayDict = dict2?["Arrays"] as? [String: Any]
+        let nativeArray = arrayDict?["arrayOfNatives"] as? [Any]
+        let value = nativeArray?[2] as? Int
+        XCTAssertEqual(value, 4098)
+
+        // dicationary member
+        let dictionaryDict = dict["d"] as? [String: Any]
+        let dictionaryOfShapes = dictionaryDict?["shapes"] as? [String:Any]
+        let stringsDict2 = dictionaryOfShapes?["strings"] as? [String:Any]
+        let stringEnum = stringsDict2?["stringEnum"] as? String
+        XCTAssertEqual(stringEnum, "third")
+
+        do {
+            let shape2 = try DictionaryDecoder().decode(ShapeWithDictionaries.self, from: dict)
+            XCTAssertEqual(shape2.shape.numbers.intEnum, .second)
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
+    }
+
+    static var allTests : [(String, (JSONCoderTests) -> () throws -> Void)] {
+        return [
+            ("testSerializeToDictionaryAndJSON", testSerializeToDictionaryAndJSON),
+        ]
+    }
+}
+
+

--- a/Tests/AWSSDKSwiftCoreTests/PerformanceTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/PerformanceTests.swift
@@ -29,13 +29,15 @@ struct StandardRequest: AWSShape {
         AWSShapeMember(label: "item1", location: .body(locationName: "item1"), required: true, type: .string),
         AWSShapeMember(label: "item2", location: .body(locationName: "item2"), required: true, type: .integer),
         AWSShapeMember(label: "item3", location: .body(locationName: "item3"), required: true, type: .double),
-        AWSShapeMember(label: "item4", location: .body(locationName: "item4"), required: true, type: .timestamp)
+        AWSShapeMember(label: "item4", location: .body(locationName: "item4"), required: true, type: .timestamp),
+        AWSShapeMember(label: "item5", location: .body(locationName: "item5"), required: true, type: .list)
     ]
 
     let item1: String
     let item2: Int
     let item3: Double
     let item4: TimeStamp
+    let item5: [Int]
 }
 
 struct PayloadRequest: AWSShape {
@@ -94,7 +96,7 @@ class PerformanceTests: XCTestCase {
             eventLoopGroupProvider: .useAWSClientShared
         )
         let date = Date()
-        let request = StandardRequest(item1: "item1", item2: 45, item3: 3.14, item4: TimeStamp(date))
+        let request = StandardRequest(item1: "item1", item2: 45, item3: 3.14, item4: TimeStamp(date), item5: [1,2,3,4,5])
         measure {
             do {
                 for _ in 0..<1000 {
@@ -115,7 +117,7 @@ class PerformanceTests: XCTestCase {
             eventLoopGroupProvider: .useAWSClientShared
         )
         let date = Date()
-        let request = PayloadRequest(payload: StandardRequest(item1: "item1", item2: 45, item3: 3.14, item4: TimeStamp(date)))
+        let request = PayloadRequest(payload: StandardRequest(item1: "item1", item2: 45, item3: 3.14, item4: TimeStamp(date), item5: [1,2,3,4,5]))
         measure {
             do {
                 for _ in 0..<1000 {
@@ -136,7 +138,7 @@ class PerformanceTests: XCTestCase {
             eventLoopGroupProvider: .useAWSClientShared
         )
         let date = Date()
-        let request = StandardRequest(item1: "item1", item2: 45, item3: 3.14, item4: TimeStamp(date))
+        let request = StandardRequest(item1: "item1", item2: 45, item3: 3.14, item4: TimeStamp(date), item5: [1,2,3,4,5])
         measure {
             do {
                 for _ in 0..<1000 {
@@ -157,7 +159,7 @@ class PerformanceTests: XCTestCase {
             eventLoopGroupProvider: .useAWSClientShared
         )
         let date = Date()
-        let request = PayloadRequest(payload: StandardRequest(item1: "item1", item2: 45, item3: 3.14, item4: TimeStamp(date)))
+        let request = PayloadRequest(payload: StandardRequest(item1: "item1", item2: 45, item3: 3.14, item4: TimeStamp(date), item5: [1,2,3,4,5]))
         measure {
             do {
                 for _ in 0..<1000 {
@@ -178,7 +180,7 @@ class PerformanceTests: XCTestCase {
             eventLoopGroupProvider: .useAWSClientShared
         )
         let date = Date()
-        let request = StandardRequest(item1: "item1", item2: 45, item3: 3.14, item4: TimeStamp(date))
+        let request = StandardRequest(item1: "item1", item2: 45, item3: 3.14, item4: TimeStamp(date), item5: [1,2,3,4,5])
         measure {
             do {
                 for _ in 0..<1000 {
@@ -245,7 +247,7 @@ class PerformanceTests: XCTestCase {
             eventLoopGroupProvider: .useAWSClientShared
         )
         let date = Date()
-        let request = StandardRequest(item1: "item1", item2: 45, item3: 3.14, item4: TimeStamp(date))
+        let request = StandardRequest(item1: "item1", item2: 45, item3: 3.14, item4: TimeStamp(date), item5: [1,2,3,4,5])
         let awsRequest = try! client.createAWSRequest(operation: "Test", path: "/", httpMethod: "POST", input: request)
         measure {
             do {
@@ -271,7 +273,7 @@ class PerformanceTests: XCTestCase {
                 version: HTTPVersion(major: 1, minor: 1),
                 status: HTTPResponseStatus(statusCode: 200)
             ),
-            body: "<Output><item1>Hello</item1><item2>5</item2><item3>3.141</item3><item4>2001-12-23T15:34:12.590Z</item4></Output>".data(using: .utf8)!
+            body: "<Output><item1>Hello</item1><item2>5</item2><item3>3.141</item3><item4>2001-12-23T15:34:12.590Z</item4><item5>3</item5><item5>6</item5><item5>325</item5></Output>".data(using: .utf8)!
         )
         measure {
             do {
@@ -297,7 +299,9 @@ class PerformanceTests: XCTestCase {
                 version: HTTPVersion(major: 1, minor: 1),
                 status: HTTPResponseStatus(statusCode: 200)
             ),
-            body: "{\"item1\":\"Hello\", \"item2\":5, \"item3\":3.14, \"item4\":\"2001-12-23T15:34:12.590Z\"}".data(using: .utf8)!
+            body: """
+                {"item1":"Hello", "item2":5, "item3":3.14, "item4":"2001-12-23T15:34:12.590Z", "item5": [1,56,3,7]}
+                """.data(using: .utf8)!
         )
         measure {
             do {

--- a/Tests/AWSSDKSwiftCoreTests/SerializersTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/SerializersTests.swift
@@ -388,9 +388,25 @@ class SerializersTests: XCTestCase {
         }
         struct Shape : AWSShape {
             static let _members = [AWSShapeMember(label: "d", required: true, type: .map, encoding:.map(entry:"item", key: "key", value: "value"))]
-            let d : [KeyEnum:Int]
+            let d : [KeyEnum: Int]
         }
         let xmldata = "<Shape><d><item><key>member</key><value>4</value></item></d></Shape>"
+        testDecodeEncode(type: Shape.self, xml: xmldata)
+    }
+    
+    func testEnumShapeDictionaryEncodingDecodeEncode() {
+        enum KeyEnum : String, Codable {
+            case member = "member"
+            case member2 = "member2"
+        }
+        struct Shape2 : AWSShape {
+            let a: String
+        }
+        struct Shape : AWSShape {
+            static let _members = [AWSShapeMember(label: "d", required: true, type: .map, encoding:.map(entry:"item", key: "k", value: "v"))]
+            let d : [KeyEnum: Shape2]
+        }
+        let xmldata = "<Shape><d><item><k>member</k><v><a>thisisastring</a></v></item></d></Shape>"
         testDecodeEncode(type: Shape.self, xml: xmldata)
     }
     

--- a/Tests/AWSSDKSwiftCoreTests/XMLCoderTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/XMLCoderTests.swift
@@ -1,126 +1,124 @@
+//  XMLCoderTests.swift
+//  AWSSDKSwiftTests
 //
-//  DictionarySerializer.swift
-//  AWSSDKSwift
-//
-//  Created by Yuki Takei on 2017/04/06.
-//
-//
-
+//  Created by Adam Fowler 2020/01/30
 import XCTest
 @testable import AWSSDKSwiftCore
 
-class SerializersTests: XCTestCase {
 
+
+class XMLCoderTests: XCTestCase {
+    
     struct Numbers : AWSShape {
 
-        init(bool:Bool, integer:Int, float:Float, double:Double, intEnum:IntEnum) {
-            self.bool = bool
-            self.integer = integer
-            self.float = float
-            self.double = double
-            self.intEnum = intEnum
-            self.int8 = 4
-            self.uint16 = 5
-            self.int32 = 7
-            self.uint64 = 90
-        }
+       init(bool:Bool, integer:Int, float:Float, double:Double, intEnum:IntEnum) {
+           self.bool = bool
+           self.integer = integer
+           self.float = float
+           self.double = double
+           self.intEnum = intEnum
+           self.int8 = 4
+           self.uint16 = 5
+           self.int32 = 7
+           self.uint64 = 90
+       }
 
-        enum IntEnum : Int, Codable {
-            case first
-            case second
-            case third
-        }
-        let bool : Bool
-        let integer : Int
-        let float : Float
-        let double : Double
-        let intEnum : IntEnum
-        let int8 : Int8
-        let uint16 : UInt16
-        let int32 : Int32
-        let uint64 : UInt64
+       enum IntEnum : Int, Codable {
+           case first
+           case second
+           case third
+       }
+       let bool : Bool
+       let integer : Int
+       let float : Float
+       let double : Double
+       let intEnum : IntEnum
+       let int8 : Int8
+       let uint16 : UInt16
+       let int32 : Int32
+       let uint64 : UInt64
 
-        private enum CodingKeys : String, CodingKey {
-            case bool = "b"
-            case integer = "i"
-            case float = "s"
-            case double = "d"
-            case intEnum = "enum"
-            case int8 = "int8"
-            case uint16 = "uint16"
-            case int32 = "int32"
-            case uint64 = "uint64"
-        }
+       private enum CodingKeys : String, CodingKey {
+           case bool = "b"
+           case integer = "i"
+           case float = "s"
+           case double = "d"
+           case intEnum = "enum"
+           case int8 = "int8"
+           case uint16 = "uint16"
+           case int32 = "int32"
+           case uint64 = "uint64"
+       }
     }
 
     struct StringShape : AWSShape {
-        enum StringEnum : String, Codable {
-            case first="first"
-            case second="second"
-            case third="third"
-            case fourth="fourth"
-        }
-        let string : String
-        let optionalString : String?
-        let stringEnum : StringEnum
+       enum StringEnum : String, Codable {
+           case first="first"
+           case second="second"
+           case third="third"
+           case fourth="fourth"
+       }
+       let string : String
+       let optionalString : String?
+       let stringEnum : StringEnum
     }
 
     struct Arrays : AWSShape {
-        public static var _members: [AWSShapeMember] = [
-            AWSShapeMember(label: "ArrayOfNatives", location: .body(locationName: "ArrayOfNatives"), required: true, type: .list, encoding: .list(member: "member")),
-            AWSShapeMember(label: "ArrayOfShapes", location: .body(locationName: "ArrayOfShapes"), required: true, type: .list)
-        ]
-        
-        let arrayOfNatives : [Int]
-        let arrayOfShapes : [Numbers]
+       public static var _members: [AWSShapeMember] = [
+           AWSShapeMember(label: "ArrayOfNatives", location: .body(locationName: "ArrayOfNatives"), required: true, type: .list, encoding: .list(member: "member")),
+           AWSShapeMember(label: "ArrayOfShapes", location: .body(locationName: "ArrayOfShapes"), required: true, type: .list)
+       ]
+       
+       let arrayOfNatives : [Int]
+       let arrayOfShapes : [Numbers]
     }
 
     struct Dictionaries : AWSShape {
-        public static var _members: [AWSShapeMember] = [
-            AWSShapeMember(label: "DictionaryOfNatives", location: .body(locationName: "Natives"), required: true, type: .list, encoding: .map(entry: "entry", key: "key", value: "value")),
-            AWSShapeMember(label: "DictionaryOfShapes", location: .body(locationName: "Shapes"), required: true, type: .list, encoding: .flatMap(key: "key", value: "value"))
-        ]
-        let dictionaryOfNatives : [String:Int]
-        let dictionaryOfShapes : [String:StringShape]
+       public static var _members: [AWSShapeMember] = [
+           AWSShapeMember(label: "DictionaryOfNatives", location: .body(locationName: "Natives"), required: true, type: .list, encoding: .map(entry: "entry", key: "key", value: "value")),
+           AWSShapeMember(label: "DictionaryOfShapes", location: .body(locationName: "Shapes"), required: true, type: .list, encoding: .flatMap(key: "key", value: "value"))
+       ]
+       let dictionaryOfNatives : [String:Int]
+       let dictionaryOfShapes : [String:StringShape]
 
-        private enum CodingKeys : String, CodingKey {
-            case dictionaryOfNatives = "natives"
-            case dictionaryOfShapes = "shapes"
-        }
+       private enum CodingKeys : String, CodingKey {
+           case dictionaryOfNatives = "natives"
+           case dictionaryOfShapes = "shapes"
+       }
     }
 
     struct Shape : AWSShape {
-        let numbers : Numbers
-        let stringShape : StringShape
-        let arrays : Arrays
+       let numbers : Numbers
+       let stringShape : StringShape
+       let arrays : Arrays
 
-        private enum CodingKeys : String, CodingKey {
-            case numbers = "Numbers"
-            case stringShape = "Strings"
-            case arrays = "Arrays"
-        }
+       private enum CodingKeys : String, CodingKey {
+           case numbers = "Numbers"
+           case stringShape = "Strings"
+           case arrays = "Arrays"
+       }
     }
 
     struct ShapeWithDictionaries : AWSShape {
-        let shape : Shape
-        let dictionaries : Dictionaries
+       let shape : Shape
+       let dictionaries : Dictionaries
 
-        private enum CodingKeys : String, CodingKey {
-            case shape = "s"
-            case dictionaries = "d"
-        }
+       private enum CodingKeys : String, CodingKey {
+           case shape = "s"
+           case dictionaries = "d"
+       }
     }
 
     var testShape : Shape {
-        return Shape(numbers: Numbers(bool:true, integer: 45, float: 3.4, double: 7.89234, intEnum: .second),
-                              stringShape: StringShape(string: "String1", optionalString: "String2", stringEnum: .third),
-                              arrays: Arrays(arrayOfNatives: [34,1,4098], arrayOfShapes: [Numbers(bool:false, integer: 1, float: 1.2, double: 1.4, intEnum: .first), Numbers(bool:true, integer: 3, float: 2.01, double: 1.01, intEnum: .third)]))
+       return Shape(numbers: Numbers(bool:true, integer: 45, float: 3.4, double: 7.89234, intEnum: .second),
+                             stringShape: StringShape(string: "String1", optionalString: "String2", stringEnum: .third),
+                             arrays: Arrays(arrayOfNatives: [34,1,4098], arrayOfShapes: [Numbers(bool:false, integer: 1, float: 1.2, double: 1.4, intEnum: .first), Numbers(bool:true, integer: 3, float: 2.01, double: 1.01, intEnum: .third)]))
     }
 
     var testShapeWithDictionaries : ShapeWithDictionaries {
-        return ShapeWithDictionaries(shape: testShape, dictionaries: Dictionaries(dictionaryOfNatives: ["first":1, "second":2, "third":3],
-                                                                                          dictionaryOfShapes: ["strings":StringShape(string:"one", optionalString: "two", stringEnum: .third),
-                                                                                                               "strings2":StringShape(string:"cat", optionalString: nil, stringEnum: .fourth)]))
+       return ShapeWithDictionaries(shape: testShape, dictionaries: Dictionaries(dictionaryOfNatives: ["first":1, "second":2, "third":3],
+                                                                                         dictionaryOfShapes: ["strings":StringShape(string:"one", optionalString: "two", stringEnum: .third),
+                                                                                                              "strings2":StringShape(string:"cat", optionalString: nil, stringEnum: .fourth)]))
     }
 
     /// helper test function to use throughout all the decode/encode tests
@@ -447,39 +445,7 @@ class SerializersTests: XCTestCase {
         }
     }
 
-    func testSerializeToDictionaryAndJSON() {
-        let json = try! AWSShapeEncoder().json(testShapeWithDictionaries)
-        let dict = try! JSONSerialization.jsonObject(with: json, options: []) as? [String: Any] ?? [:]
-
-        let dict2 = dict["s"] as? [String:Any]
-
-        // Member scalar
-        let stringsDict = dict2?["Strings"]! as? [String: Any]
-        let string = stringsDict?["string"] as? String
-        XCTAssertEqual(string, "String1")
-
-        // array member
-        let arrayDict = dict2?["Arrays"] as? [String: Any]
-        let nativeArray = arrayDict?["arrayOfNatives"] as? [Any]
-        let value = nativeArray?[2] as? Int
-        XCTAssertEqual(value, 4098)
-
-        // dicationary member
-        let dictionaryDict = dict["d"] as? [String: Any]
-        let dictionaryOfShapes = dictionaryDict?["shapes"] as? [String:Any]
-        let stringsDict2 = dictionaryOfShapes?["strings"] as? [String:Any]
-        let stringEnum = stringsDict2?["stringEnum"] as? String
-        XCTAssertEqual(stringEnum, "third")
-
-        do {
-            let shape2 = try DictionaryDecoder().decode(ShapeWithDictionaries.self, from: dict)
-            XCTAssertEqual(shape2.shape.numbers.intEnum, .second)
-        } catch {
-            XCTFail(error.localizedDescription)
-        }
-    }
-
-    static var allTests : [(String, (SerializersTests) -> () throws -> Void)] {
+    static var allTests : [(String, (XMLCoderTests) -> () throws -> Void)] {
         return [
             ("testSimpleStructureDecodeEncode", testSimpleStructureDecodeEncode),
             ("testContainingStructureDecodeEncode", testContainingStructureDecodeEncode),
@@ -502,8 +468,7 @@ class SerializersTests: XCTestCase {
 
             ("testEncodeDecodeXML", testEncodeDecodeXML),
             ("testDecodeFail", testDecodeFail),
-            ("testEncodeDecodeDictionariesXML", testEncodeDecodeDictionariesXML),
-            ("testSerializeToDictionaryAndJSON", testSerializeToDictionaryAndJSON)
+            ("testEncodeDecodeDictionariesXML", testEncodeDecodeDictionariesXML)
         ]
     }
 }

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -6,12 +6,13 @@ XCTMain([
     testCase(CredentialTests.allTests),
     testCase(DictionaryEncoderTests.allTests),
     testCase(HTTPClientTests.allTests),
+    testCase(JSONCoderTests.allTests),
     testCase(MetaDataServiceTests.allTests),
     testCase(PaginateTests.allTests),
     testCase(PerformanceTests.allTests),
-    testCase(SerializersTests.allTests),
     testCase(SignersV4Tests.allTests),
     testCase(TimeStampTests.allTests),
     testCase(ValidationTests.allTests),
+    testCase(XMLCoderTests.allTests),
     testCase(XMLTests.allTests)
 ])


### PR DESCRIPTION
Found this while implementing the QueryEncoder.

The container coding was not being reset in the UKEC encode/decode encode<T>(_) functions so the container coding was being applied to the child elements of the array. This only caused an issue when encoding/decoding dictionaries where the key was not a base type eg an enum and the value was a Codable type. The container coding for the UKEC was being passed to the KEC that coded the Codable type.