### PR TITLE
Remove HypertextApplicationLanguage framework

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,14 +11,12 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio.git", .upToNextMajor(from:"2.11.0")),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", .upToNextMajor(from:"2.4.0")),
         .package(url: "https://github.com/apple/swift-nio-transport-services.git", .upToNextMajor(from:"1.0.0")),
-        .package(url: "https://github.com/swift-aws/HypertextApplicationLanguage.git", .upToNextMinor(from: "1.1.0")),
         .package(url: "https://github.com/swift-aws/Perfect-INIParser.git", .upToNextMinor(from: "3.0.0")),
     ],
     targets: [
         .target(
             name: "AWSSDKSwiftCore",
             dependencies: [
-                "HypertextApplicationLanguage",
                 "NIO",
                 "NIOHTTP1",
                 "NIOSSL",

--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -582,7 +582,7 @@ extension AWSClient {
 
         try validateCode(response: awsResponse)
 
-        awsResponse = try hypertextApplicationLanguageProcess(response: awsResponse, members: Output._members)
+        awsResponse = try hypertextApplicationLanguageProcess(response: awsResponse)
 
         let decoder = DictionaryDecoder()
 

--- a/Sources/AWSSDKSwiftCore/Message/AWSResponse.swift
+++ b/Sources/AWSSDKSwiftCore/Message/AWSResponse.swift
@@ -8,7 +8,6 @@
 
 import NIO
 import NIOHTTP1
-import HypertextApplicationLanguage
 
 /// Structure encapsulating a processed HTTP Response
 public struct AWSResponse {

--- a/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
@@ -535,7 +535,7 @@ class AWSClientTests: XCTestCase {
                 headers: ["Content-Type":"application/hal+json"]
             ),
             body: """
-                {"_embedded": {"a": [{"s":"Hello", "i":1234}, {"s":"Hello2", "i":12345}]}, "d":3.14, "b":true}
+                {"_embedded": {"a": [{"s":"Hello", "i":1234}, {"s":"Hello2", "i":12345}], "d":3.14, "b":true}}
                 """.data(using: .utf8)!
         )
         do {


### PR DESCRIPTION
We aren't interested in the majority of hal+json output. The only things we need are the resources. Resources can be included as normal, or they can be included inside an "_embedded" tag. Instead of running the HAL code I just look for the "_embedded" tag and if it exists merge everything underneath with the top level json dictionary and output that.
