### PR TITLE
Moved `toHTTPRequest()` from AWSClient to AWSRequest.

### DIFF
--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -205,7 +205,7 @@ extension AWSClient {
                         path: path,
                         httpMethod: httpMethod,
                         input: input)
-            return self.createHTTPRequest(awsRequest, signer: signer)
+            return awsRequest.createHTTPRequest(signer: signer)
         }.flatMap { request in
             return self.invoke(request)
         }.flatMapThrowing { response in
@@ -228,7 +228,7 @@ extension AWSClient {
                         operation: operationName,
                         path: path,
                         httpMethod: httpMethod)
-            return self.createHTTPRequest(awsRequest, signer: signer)
+            return awsRequest.createHTTPRequest(signer: signer)
         }.flatMap { request in
             return self.invoke(request)
         }.flatMapThrowing { response in
@@ -251,7 +251,7 @@ extension AWSClient {
                         operation: operationName,
                         path: path,
                         httpMethod: httpMethod)
-            return self.createHTTPRequest(awsRequest, signer: signer)
+            return awsRequest.createHTTPRequest(signer: signer)
         }.flatMap { request in
             return self.invoke(request)
         }.flatMapThrowing { response in
@@ -276,7 +276,7 @@ extension AWSClient {
                         path: path,
                         httpMethod: httpMethod,
                         input: input)
-            return self.createHTTPRequest(awsRequest, signer: signer)
+            return awsRequest.createHTTPRequest(signer: signer)
         }.flatMap { request in
             return self.invoke(request)
         }.flatMapThrowing { response in
@@ -302,27 +302,6 @@ extension AWSClient {
     var signer: EventLoopFuture<AWSSigner> {
         return credentialProvider.getCredential().map { credential in
             return AWSSigner(credentials: credential, name: self.signingName, region: self.region.rawValue)
-        }
-    }
-
-    func createHTTPRequest(_ awsRequest: AWSRequest, signer: AWSSigner) -> AWSHTTPRequest {
-        // if credentials are empty don't sign request
-        if signer.credentials.isEmpty() {
-            return awsRequest.toHTTPRequest()
-        }
-
-        switch (awsRequest.httpMethod, self.serviceProtocol.type) {
-        case ("GET",  .restjson), ("HEAD", .restjson):
-            return awsRequest.toHTTPRequestWithSignedHeader(signer: signer)
-
-        case ("GET",  _), ("HEAD", _):
-            if awsRequest.httpHeaders.count > 0 {
-                return awsRequest.toHTTPRequestWithSignedHeader(signer: signer)
-            }
-            return awsRequest.toHTTPRequestWithSignedURL(signer: signer)
-
-        default:
-            return awsRequest.toHTTPRequestWithSignedHeader(signer: signer)
         }
     }
 

--- a/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
@@ -390,7 +390,7 @@ class AWSClientTests: XCTestCase {
                 input: input2
             )
 
-            let awsHTTPRequest: AWSHTTPRequest = kinesisClient.createHTTPRequest(awsRequest, signer: try kinesisClient.signer.wait())
+            let awsHTTPRequest: AWSHTTPRequest = awsRequest.createHTTPRequest(signer: try kinesisClient.signer.wait())
             XCTAssertEqual(awsHTTPRequest.method, HTTPMethod.POST)
             if let host = awsHTTPRequest.headers.first(where: { $0.name == "Host" }) {
                 XCTAssertEqual(host.value, "kinesis.us-east-1.amazonaws.com")
@@ -427,7 +427,7 @@ class AWSClientTests: XCTestCase {
                 input: input
             )
 
-            let request: AWSHTTPRequest = client.createHTTPRequest(awsRequest, signer: try client.signer.wait())
+            let request: AWSHTTPRequest = awsRequest.createHTTPRequest(signer: try client.signer.wait())
 
             XCTAssertNil(request.headers["Authorization"].first)
         } catch {

--- a/Tests/AWSSDKSwiftCoreTests/PerformanceTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/PerformanceTests.swift
@@ -208,7 +208,7 @@ class PerformanceTests: XCTestCase {
         let signer = try! client.signer.wait()
         measure {
             for _ in 0..<1000 {
-                _ = client.createHTTPRequest(awsRequest, signer: signer)
+                _ = awsRequest.createHTTPRequest(signer: signer)
             }
         }
     }
@@ -227,7 +227,7 @@ class PerformanceTests: XCTestCase {
         let signer = try! client.signer.wait()
         measure {
             for _ in 0..<1000 {
-                _ = client.createHTTPRequest(awsRequest, signer: signer)
+                _ = awsRequest.createHTTPRequest(signer: signer)
             }
         }
     }
@@ -248,7 +248,7 @@ class PerformanceTests: XCTestCase {
         let signer = try! client.signer.wait()
         measure {
             for _ in 0..<1000 {
-                _ = client.createHTTPRequest(awsRequest, signer: signer)
+                _ = awsRequest.createHTTPRequest(signer: signer)
             }
         }
     }


### PR DESCRIPTION
### Motivation

The AWSClient encapsulates *a lot* of functionality. For this reason it is in the interest of the maintainers to distribute functionality to the objects it belongs to.

### Modifications

I moved the conceptionally static method `createHTTPRequest` from the AWSClient to AWSRequest where it is a great fit as an instance method.

### Result

Less Code on AWSClient. Clearer encapsulation of functionality on AWSRequest.