### PR TITLE
Allow user to set the HTTPClient for AWSClient

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,9 +39,6 @@ jobs:
         tag: ['swift:5.1.5', 'swift:5.2.1']
     container:
       image: ${{ matrix.tag }}
-      volumes:
-      - $GITHUB_WORKSPACE:/src
-      options: --workdir /src
     steps:
     - name: Checkout
       uses: actions/checkout@v1

--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -33,12 +33,13 @@ public final class AWSClient {
         case invalidURL(String)
     }
 
-    /// Specifies how `EventLoopGroup` will be created and establishes lifecycle ownership.
+    /// Specifies how `HTTPClient` will be created and establishes lifecycle ownership.
     public enum HTTPClientProvider {
-        /// `EventLoopGroup` will be provided by the user. Owner of this group is responsible for its lifecycle.
+        /// `HTTPClient` will be provided by the user. Owner of this group is responsible for its lifecycle. Any HTTPClient that conforms to
+        /// `AWSHTTPClient` can be specified here including AsyncHTTPClient
         case shared(AWSHTTPClient)
-        /// `EventLoopGroup` will be created by the client. When `syncShutdown` is called, created `EventLoopGroup` will be shut down as well.
-        case useAWSClientShared
+        /// `HTTPClient` will be created by the client. When `deinit` is called, created `HTTPClient` will be shut down as well.
+        case createNew
     }
 
     let credentialProvider: CredentialProvider
@@ -65,21 +66,13 @@ public final class AWSClient {
 
     var possibleErrorTypes: [AWSErrorType.Type]
 
-    let httpClient: AWSHTTPClient
+    /// HTTP client used by AWSClient
+    public let httpClient: AWSHTTPClient
 
-    public let eventLoopGroup: EventLoopGroup
+    let httpClientProvider: HTTPClientProvider
 
-    private static let sharedHTTPClient: AWSHTTPClient = createSharedHTTPClient()
-
-    /// create default HTTPClient
-    private static func createSharedHTTPClient() -> AWSHTTPClient {
-        #if canImport(Network)
-            if #available(OSX 10.15, iOS 12.0, tvOS 12.0, watchOS 6.0, *) {
-                return NIOTSHTTPClient(eventLoopGroup: NIOTSEventLoopGroup())
-            }
-        #endif
-        return AsyncHTTPClient.HTTPClient(eventLoopGroupProvider: .shared(MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)))
-    }
+    /// EventLoopGroup used by AWSClient
+    public var eventLoopGroup: EventLoopGroup { return httpClient.eventLoopGroup }
 
     /// Initialize an AWSClient struct
     /// - parameters:
@@ -126,25 +119,26 @@ public final class AWSClient {
             region = .useast1
         }
 
-        // setup eventLoopGroup and httpClient
+        // setup httpClient
+        self.httpClientProvider = httpClientProvider
         switch httpClientProvider {
         case .shared(let providedHTTPClient):
             self.httpClient = providedHTTPClient
-        case .useAWSClientShared:
-            self.httpClient = AWSClient.sharedHTTPClient
+        case .createNew:
+            self.httpClient = AWSClient.createHTTPClient()
         }
-        self.eventLoopGroup = self.httpClient.eventLoopGroup
 
+        let eventLoopGroup = self.httpClient.eventLoopGroup
         // create credentialProvider
         if let accessKey = accessKeyId, let secretKey = secretAccessKey {
             let credential = StaticCredential(accessKeyId: accessKey, secretAccessKey: secretKey, sessionToken: sessionToken)
-            self.credentialProvider = StaticCredentialProvider(credential: credential, eventLoopGroup: self.eventLoopGroup)
+            self.credentialProvider = StaticCredentialProvider(credential: credential, eventLoopGroup: eventLoopGroup)
         } else if let ecredential = EnvironmentCredential() {
             let credential = ecredential
-            self.credentialProvider = StaticCredentialProvider(credential: credential, eventLoopGroup: self.eventLoopGroup)
+            self.credentialProvider = StaticCredentialProvider(credential: credential, eventLoopGroup: eventLoopGroup)
         } else if let scredential = try? SharedCredential() {
             let credential = scredential
-            self.credentialProvider = StaticCredentialProvider(credential: credential, eventLoopGroup: self.eventLoopGroup)
+            self.credentialProvider = StaticCredentialProvider(credential: credential, eventLoopGroup: eventLoopGroup)
         } else {
             self.credentialProvider = MetaDataCredentialProvider(httpClient: self.httpClient)
         }
@@ -174,6 +168,17 @@ public final class AWSClient {
             self.endpoint = "https://\(serviceHost)"
         }
     }
+    
+    deinit {
+        // if httpClient was created by AWSClient then it is required to shutdown the httpClient
+        if case .createNew = httpClientProvider {
+            do {
+                try httpClient.syncShutdown()
+            } catch {
+                print("Error shutting down HTTP client: \(error)")
+            }
+        }
+    }
 }
 
 // invoker
@@ -186,13 +191,13 @@ extension AWSClient {
     }
 
     /// create HTTPClient
-    fileprivate static func createHTTPClient(eventLoopGroup: EventLoopGroup) -> AWSHTTPClient {
+    fileprivate static func createHTTPClient() -> AWSHTTPClient {
         #if canImport(Network)
-        if #available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *), let nioTSEventLoopGroup = eventLoopGroup as? NIOTSEventLoopGroup {
-            return NIOTSHTTPClient(eventLoopGroup: nioTSEventLoopGroup)
+        if #available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *) {
+            return NIOTSHTTPClient(eventLoopGroupProvider: .createNew)
         }
         #endif
-        return AsyncHTTPClient.HTTPClient(eventLoopGroupProvider: .shared(eventLoopGroup))
+        return AsyncHTTPClient.HTTPClient(eventLoopGroupProvider: .createNew)
     }
 
 }

--- a/Sources/AWSSDKSwiftCore/HTTP/AWSHTTPClient.swift
+++ b/Sources/AWSSDKSwiftCore/HTTP/AWSHTTPClient.swift
@@ -17,22 +17,22 @@ import NIO
 import NIOHTTP1
 
 /// HTTP Request
-struct AWSHTTPRequest {
-    let url: URL
-    let method: HTTPMethod
-    let headers: HTTPHeaders
-    let body: ByteBuffer?
+public struct AWSHTTPRequest {
+    public let url: URL
+    public let method: HTTPMethod
+    public let headers: HTTPHeaders
+    public let body: ByteBuffer?
 }
 
 /// HTTP Response
-protocol AWSHTTPResponse {
+public protocol AWSHTTPResponse {
     var status: HTTPResponseStatus { get }
     var headers: HTTPHeaders { get }
     var body: ByteBuffer? { get }
 }
 
 /// Protocol defining requirements for a HTTPClient
-protocol AWSHTTPClient {
+public protocol AWSHTTPClient {
     /// Execute HTTP request and return a future holding a HTTP Response
     func execute(request: AWSHTTPRequest, timeout: TimeAmount) -> EventLoopFuture<AWSHTTPResponse>
     

--- a/Sources/AWSSDKSwiftCore/HTTP/AsyncHTTPClient.swift
+++ b/Sources/AWSSDKSwiftCore/HTTP/AsyncHTTPClient.swift
@@ -18,7 +18,7 @@ import NIO
 
 /// comply with AWSHTTPClient protocol
 extension AsyncHTTPClient.HTTPClient: AWSHTTPClient {
-    func execute(request: AWSHTTPRequest, timeout: TimeAmount) -> EventLoopFuture<AWSHTTPResponse> {
+    public func execute(request: AWSHTTPRequest, timeout: TimeAmount) -> EventLoopFuture<AWSHTTPResponse> {
         let requestBody: AsyncHTTPClient.HTTPClient.Body?
         if let body = request.body {
             requestBody = .byteBuffer(body)

--- a/Sources/AWSSDKSwiftCore/HTTP/NIOTSHTTPClient.swift
+++ b/Sources/AWSSDKSwiftCore/HTTP/NIOTSHTTPClient.swift
@@ -33,14 +33,14 @@ public final class NIOTSHTTPClient {
 
     /// Request structure to send
     public struct Request {
-        var head: HTTPRequestHead
-        var body: ByteBuffer?
+        public var head: HTTPRequestHead
+        public var body: ByteBuffer?
     }
 
     /// Response structure received back
     public struct Response {
-        let head: HTTPResponseHead
-        let body: ByteBuffer?
+        public let head: HTTPResponseHead
+        public let body: ByteBuffer?
     }
 
     /// Errors returned from HTTPClient when parsing responses
@@ -201,16 +201,16 @@ public final class NIOTSHTTPClient {
         }
     }
 
-    internal let eventLoopGroup: EventLoopGroup
+    public let eventLoopGroup: EventLoopGroup
 }
 
 /// comply with AWSHTTPClient protocol
 @available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
 extension NIOTSHTTPClient: AWSHTTPClient {
     
-    func syncShutdown() throws {}
+    public func syncShutdown() throws {}
 
-    func execute(request: AWSHTTPRequest, timeout: TimeAmount) -> EventLoopFuture<AWSHTTPResponse> {
+    public func execute(request: AWSHTTPRequest, timeout: TimeAmount) -> EventLoopFuture<AWSHTTPResponse> {
         var head = HTTPRequestHead(
           version: HTTPVersion(major: 1, minor: 1),
           method: request.method,
@@ -225,8 +225,8 @@ extension NIOTSHTTPClient: AWSHTTPClient {
 
 @available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
 extension NIOTSHTTPClient.Response: AWSHTTPResponse {
-    var status: HTTPResponseStatus { return head.status }
-    var headers: HTTPHeaders { return head.headers }
+    public var status: HTTPResponseStatus { return head.status }
+    public var headers: HTTPHeaders { return head.headers }
 }
 
 #endif

--- a/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
@@ -116,7 +116,7 @@ class AWSClientTests: XCTestCase {
             serviceProtocol: ServiceProtocol(type: .query),
             apiVersion: "2013-12-01",
             middlewares: [],
-            httpClientProvider: .useAWSClientShared
+            httpClientProvider: .createNew
         )
 
         do {
@@ -135,7 +135,7 @@ class AWSClientTests: XCTestCase {
             service: "email",
             serviceProtocol: ServiceProtocol(type: .query),
             apiVersion: "2013-12-01",
-            httpClientProvider: .useAWSClientShared)
+            httpClientProvider: .createNew)
 
         do {
             let credentials = try client.credentialProvider.getCredential().wait()
@@ -160,7 +160,7 @@ class AWSClientTests: XCTestCase {
         apiVersion: "2013-12-01",
         middlewares: [AWSLoggingMiddleware()],
         possibleErrorTypes: [SESErrorType.self],
-        httpClientProvider: .useAWSClientShared
+        httpClientProvider: .createNew
     )
 
     let kinesisClient = AWSClient(
@@ -173,7 +173,7 @@ class AWSClientTests: XCTestCase {
         apiVersion: "2013-12-02",
         middlewares: [AWSLoggingMiddleware()],
         possibleErrorTypes: [KinesisErrorType.self],
-        httpClientProvider: .useAWSClientShared
+        httpClientProvider: .createNew
     )
 
     let s3Client = AWSClient(
@@ -188,7 +188,7 @@ class AWSClientTests: XCTestCase {
         partitionEndpoint: "us-east-1",
         middlewares: [AWSLoggingMiddleware()],
         possibleErrorTypes: [S3ErrorType.self],
-        httpClientProvider: .useAWSClientShared
+        httpClientProvider: .createNew
     )
 
     let ec2Client = AWSClient(
@@ -199,7 +199,7 @@ class AWSClientTests: XCTestCase {
         serviceProtocol: ServiceProtocol(type: .other("ec2")),
         apiVersion: "2013-12-02",
         middlewares: [AWSLoggingMiddleware()],
-        httpClientProvider: .useAWSClientShared
+        httpClientProvider: .createNew
     )
 
     func testCreateAWSRequest() {
@@ -233,7 +233,7 @@ class AWSClientTests: XCTestCase {
             apiVersion: "2013-12-02",
             middlewares: [],
             possibleErrorTypes: [KinesisErrorType.self],
-            httpClientProvider: .useAWSClientShared
+            httpClientProvider: .createNew
         )
 
         do {
@@ -373,7 +373,7 @@ class AWSClientTests: XCTestCase {
             apiVersion: "2013-12-02",
             middlewares: [],
             possibleErrorTypes: [KinesisErrorType.self],
-            httpClientProvider: .useAWSClientShared
+            httpClientProvider: .createNew
         )
 
         do {
@@ -410,7 +410,7 @@ class AWSClientTests: XCTestCase {
             serviceProtocol: ServiceProtocol(type: .restxml),
             apiVersion: "2013-12-02",
             middlewares: [],
-            httpClientProvider: .useAWSClientShared
+            httpClientProvider: .createNew
         )
 
         do {
@@ -831,7 +831,7 @@ class AWSClientTests: XCTestCase {
                 apiVersion: "2020-01-21",
                 endpoint: awsServer.address,
                 middlewares: [AWSLoggingMiddleware()],
-                httpClientProvider: .useAWSClientShared
+                httpClientProvider: .createNew
             )
             let response = client.send(operation: "test", path: "/", httpMethod: "POST")
 
@@ -868,7 +868,7 @@ class AWSClientTests: XCTestCase {
                 apiVersion: "2020-01-21",
                 endpoint: awsServer.address,
                 middlewares: [AWSLoggingMiddleware()],
-                httpClientProvider: .useAWSClientShared
+                httpClientProvider: .createNew
             )
             let input = Input(e:.second, i: [1,2,4,8])
             let response = client.send(operation: "test", path: "/", httpMethod: "POST", input: input)
@@ -904,7 +904,7 @@ class AWSClientTests: XCTestCase {
                 apiVersion: "2020-01-21",
                 endpoint: awsServer.address,
                 middlewares: [AWSLoggingMiddleware()],
-                httpClientProvider: .useAWSClientShared
+                httpClientProvider: .createNew
             )
             let response: EventLoopFuture<Output> = client.send(operation: "test", path: "/", httpMethod: "POST")
 

--- a/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
@@ -108,9 +108,6 @@ class AWSClientTests: XCTestCase {
 
 
     func testGetCredential() {
-        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully()) }
-
         let sesClient = AWSClient(
             accessKeyId: "key",
             secretAccessKey: "secret",
@@ -119,7 +116,7 @@ class AWSClientTests: XCTestCase {
             serviceProtocol: ServiceProtocol(type: .query),
             apiVersion: "2013-12-01",
             middlewares: [],
-            eventLoopGroupProvider: .shared(eventLoopGroup)
+            httpClientProvider: .useAWSClientShared
         )
 
         do {
@@ -138,7 +135,7 @@ class AWSClientTests: XCTestCase {
             service: "email",
             serviceProtocol: ServiceProtocol(type: .query),
             apiVersion: "2013-12-01",
-            eventLoopGroupProvider: .useAWSClientShared)
+            httpClientProvider: .useAWSClientShared)
 
         do {
             let credentials = try client.credentialProvider.getCredential().wait()
@@ -163,7 +160,7 @@ class AWSClientTests: XCTestCase {
         apiVersion: "2013-12-01",
         middlewares: [AWSLoggingMiddleware()],
         possibleErrorTypes: [SESErrorType.self],
-        eventLoopGroupProvider: .useAWSClientShared
+        httpClientProvider: .useAWSClientShared
     )
 
     let kinesisClient = AWSClient(
@@ -176,7 +173,7 @@ class AWSClientTests: XCTestCase {
         apiVersion: "2013-12-02",
         middlewares: [AWSLoggingMiddleware()],
         possibleErrorTypes: [KinesisErrorType.self],
-        eventLoopGroupProvider: .useAWSClientShared
+        httpClientProvider: .useAWSClientShared
     )
 
     let s3Client = AWSClient(
@@ -191,7 +188,7 @@ class AWSClientTests: XCTestCase {
         partitionEndpoint: "us-east-1",
         middlewares: [AWSLoggingMiddleware()],
         possibleErrorTypes: [S3ErrorType.self],
-        eventLoopGroupProvider: .useAWSClientShared
+        httpClientProvider: .useAWSClientShared
     )
 
     let ec2Client = AWSClient(
@@ -202,13 +199,10 @@ class AWSClientTests: XCTestCase {
         serviceProtocol: ServiceProtocol(type: .other("ec2")),
         apiVersion: "2013-12-02",
         middlewares: [AWSLoggingMiddleware()],
-        eventLoopGroupProvider: .useAWSClientShared
+        httpClientProvider: .useAWSClientShared
     )
 
     func testCreateAWSRequest() {
-        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully()) }
-
         let input1 = C()
         let input2 = E()
         let input3 = F(fooParams: input2)
@@ -239,7 +233,7 @@ class AWSClientTests: XCTestCase {
             apiVersion: "2013-12-02",
             middlewares: [],
             possibleErrorTypes: [KinesisErrorType.self],
-            eventLoopGroupProvider: .shared(eventLoopGroup)
+            httpClientProvider: .useAWSClientShared
         )
 
         do {
@@ -367,9 +361,6 @@ class AWSClientTests: XCTestCase {
     }
 
     func testCreateNIORequest() {
-        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully()) }
-
         let input2 = E()
 
         let kinesisClient = AWSClient(
@@ -382,7 +373,7 @@ class AWSClientTests: XCTestCase {
             apiVersion: "2013-12-02",
             middlewares: [],
             possibleErrorTypes: [KinesisErrorType.self],
-            eventLoopGroupProvider: .shared(eventLoopGroup)
+            httpClientProvider: .useAWSClientShared
         )
 
         do {
@@ -419,7 +410,7 @@ class AWSClientTests: XCTestCase {
             serviceProtocol: ServiceProtocol(type: .restxml),
             apiVersion: "2013-12-02",
             middlewares: [],
-            eventLoopGroupProvider: .useAWSClientShared
+            httpClientProvider: .useAWSClientShared
         )
 
         do {
@@ -437,7 +428,7 @@ class AWSClientTests: XCTestCase {
             XCTFail(error.localizedDescription)
         }
     }
-    
+
     func testHeaderEncoding() {
         struct Input: AWSShape {
             static let _encoding = [AWSMemberEncoding(label: "h", location: .header(locationName: "header-member"))]
@@ -451,7 +442,7 @@ class AWSClientTests: XCTestCase {
             XCTFail("\(error)")
         }
     }
-    
+
     func testQueryEncoding() {
         struct Input: AWSShape {
             static let _encoding = [AWSMemberEncoding(label: "q", location: .querystring(locationName: "query"))]
@@ -465,7 +456,7 @@ class AWSClientTests: XCTestCase {
             XCTFail("\(error)")
         }
     }
-    
+
     func testURIEncoding() {
         struct Input: AWSShape {
             static let _encoding = [AWSMemberEncoding(label: "u", location: .uri(locationName: "key"))]
@@ -479,7 +470,7 @@ class AWSClientTests: XCTestCase {
             XCTFail("\(error)")
         }
     }
-    
+
     func testCreateWithXMLNamespace() {
         struct Input: AWSShape {
             public static let _xmlNamespace: String? = "https://test.amazonaws.com/doc/2020-03-11/"
@@ -497,8 +488,8 @@ class AWSClientTests: XCTestCase {
             XCTFail("\(error)")
         }
     }
-    
-    
+
+
     func testCreateWithPayloadAndXMLNamespace() {
         struct Payload: AWSShape {
             public static let _xmlNamespace: String? = "https://test.amazonaws.com/doc/2020-03-11/"
@@ -521,7 +512,7 @@ class AWSClientTests: XCTestCase {
             XCTFail("\(error)")
         }
     }
-    
+
     func testValidateCode() {
         let response = AWSHTTPResponseImpl(
             status: .ok,
@@ -572,7 +563,7 @@ class AWSClientTests: XCTestCase {
             static let payloadPath: String? = "name"
             let name : String
             let contentType: String
-            
+
             private enum CodingKeys: String, CodingKey {
                 case name = "name"
                 case contentType = "content-type"
@@ -612,7 +603,7 @@ class AWSClientTests: XCTestCase {
             XCTFail(error.localizedDescription)
         }
     }
-    
+
     func testValidateXMLError() {
         let response = AWSHTTPResponseImpl(
             status: .notFound,
@@ -683,7 +674,7 @@ class AWSClientTests: XCTestCase {
             XCTFail(error.localizedDescription)
         }
     }
-    
+
     func testValidateJSONCodablePayloadResponse() {
         class Output2 : AWSShape {
             let name : String
@@ -704,7 +695,7 @@ class AWSClientTests: XCTestCase {
             XCTFail(error.localizedDescription)
         }
     }
-    
+
     func testValidateJSONRawPayloadResponse() {
         struct Output : AWSShape {
             static let payloadPath: String? = "body"
@@ -714,7 +705,7 @@ class AWSClientTests: XCTestCase {
             ]
             let body : Data
             let contentType: String
-            
+
             private enum CodingKeys: String, CodingKey {
                 case body = "body"
                 case contentType = "content-type"
@@ -750,7 +741,7 @@ class AWSClientTests: XCTestCase {
         }
     }
 
-    
+
     func testProcessHAL() {
         class Output : AWSShape {
             let s: String
@@ -827,7 +818,7 @@ class AWSClientTests: XCTestCase {
             XCTFail(error.localizedDescription)
         }
     }
-    
+
     func testClientNoInputNoOutput() {
         do {
             let awsServer = AWSTestServer(serviceProtocol: .json)
@@ -840,7 +831,7 @@ class AWSClientTests: XCTestCase {
                 apiVersion: "2020-01-21",
                 endpoint: awsServer.address,
                 middlewares: [AWSLoggingMiddleware()],
-                eventLoopGroupProvider: .useAWSClientShared
+                httpClientProvider: .useAWSClientShared
             )
             let response = client.send(operation: "test", path: "/", httpMethod: "POST")
 
@@ -877,7 +868,7 @@ class AWSClientTests: XCTestCase {
                 apiVersion: "2020-01-21",
                 endpoint: awsServer.address,
                 middlewares: [AWSLoggingMiddleware()],
-                eventLoopGroupProvider: .useAWSClientShared
+                httpClientProvider: .useAWSClientShared
             )
             let input = Input(e:.second, i: [1,2,4,8])
             let response = client.send(operation: "test", path: "/", httpMethod: "POST", input: input)
@@ -913,7 +904,7 @@ class AWSClientTests: XCTestCase {
                 apiVersion: "2020-01-21",
                 endpoint: awsServer.address,
                 middlewares: [AWSLoggingMiddleware()],
-                eventLoopGroupProvider: .useAWSClientShared
+                httpClientProvider: .useAWSClientShared
             )
             let response: EventLoopFuture<Output> = client.send(operation: "test", path: "/", httpMethod: "POST")
 
@@ -933,7 +924,7 @@ class AWSClientTests: XCTestCase {
             XCTFail("Unexpected error: \(error)")
         }
     }
-    
+
     func testEC2ClientRequest() {
         struct Input: AWSShape {
             static let _encoding = [AWSMemberEncoding(label: "array", location: .body(locationName: "Array"), encoding: .list(member:"item"))]
@@ -947,7 +938,7 @@ class AWSClientTests: XCTestCase {
             XCTFail("\(error)")
         }
     }
-    
+
     func testEC2ValidateError() {
         let response = AWSHTTPResponseImpl(
             status: .notFound,
@@ -962,6 +953,44 @@ class AWSClientTests: XCTestCase {
             XCTAssertEqual(error.message, "It doesn't exist")
         } catch {
             XCTFail("Throwing the wrong error")
+        }
+    }
+
+    func testProvideHTTPClient() {
+        do {
+            // By default AsyncHTTPClient will follow redirects. This test creates an HTTP client that doesn't follow redirects and
+            // provides it to AWSClient
+            let awsServer = AWSTestServer(serviceProtocol: .json)
+            let httpClientConfig = AsyncHTTPClient.HTTPClient.Configuration(redirectConfiguration: .init(.disallow))
+            let httpClient = AsyncHTTPClient.HTTPClient(eventLoopGroupProvider: .createNew, configuration: httpClientConfig)
+            defer {
+                try? httpClient.syncShutdown()
+            }
+            let client = AWSClient(
+                accessKeyId: "",
+                secretAccessKey: "",
+                region: .useast1,
+                service:"TestClient",
+                serviceProtocol: ServiceProtocol(type: .json, version: ServiceProtocol.Version(major: 1, minor: 1)),
+                apiVersion: "2020-01-21",
+                endpoint: awsServer.address,
+                middlewares: [AWSLoggingMiddleware()],
+                httpClientProvider: .shared(httpClient)
+            )
+            let response = client.send(operation: "test", path: "/", httpMethod: "POST")
+
+            try awsServer.process { request in
+                let response = AWSTestServer.Response(httpStatus: .temporaryRedirect, headers: ["Location":awsServer.address], body: nil)
+                return AWSTestServer.Result(output: response, continueProcessing: false)
+            }
+
+            try response.wait()
+            try awsServer.stop()
+            XCTFail("Shouldn't get here as the provided client doesn't follow redirects")
+        } catch let error as AWSError {
+            XCTAssertEqual(error.message, "Unhandled Error. Response Code: 307")
+        } catch {
+            XCTFail("Unexpected error: \(error)")
         }
     }
 }
@@ -1034,4 +1063,3 @@ extension SESErrorType {
         }
     }
 }
-

--- a/Tests/AWSSDKSwiftCoreTests/HTTPClientTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/HTTPClientTests.swift
@@ -40,7 +40,7 @@ class NIOTSHTTPClientTests: XCTestCase {
 
     override func setUp() {
         self.awsServer = AWSTestServer(serviceProtocol: .json)
-        self.client = NIOTSHTTPClient(eventLoopGroup: NIOTSEventLoopGroup())
+        self.client = NIOTSHTTPClient(eventLoopGroupProvider: .shared(NIOTSEventLoopGroup()))
     }
 
     override func tearDown() {

--- a/Tests/AWSSDKSwiftCoreTests/PaginateTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/PaginateTests.swift
@@ -35,7 +35,7 @@ class PaginateTests: XCTestCase {
             apiVersion: "2020-01-21",
             endpoint: "http://localhost:\(awsServer.serverPort)",
             middlewares: [AWSLoggingMiddleware()],
-            httpClientProvider: .useAWSClientShared
+            httpClientProvider: .createNew
         )
     }
     

--- a/Tests/AWSSDKSwiftCoreTests/PaginateTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/PaginateTests.swift
@@ -35,7 +35,7 @@ class PaginateTests: XCTestCase {
             apiVersion: "2020-01-21",
             endpoint: "http://localhost:\(awsServer.serverPort)",
             middlewares: [AWSLoggingMiddleware()],
-            eventLoopGroupProvider: .useAWSClientShared
+            httpClientProvider: .useAWSClientShared
         )
     }
     

--- a/Tests/AWSSDKSwiftCoreTests/PayloadTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/PayloadTests.swift
@@ -31,7 +31,7 @@ class PayloadTests: XCTestCase {
                 apiVersion: "2020-01-21",
                 endpoint: awsServer.address,
                 middlewares: [AWSLoggingMiddleware()],
-                eventLoopGroupProvider: .useAWSClientShared
+                httpClientProvider: .createNew
             )
             let input = DataPayload(data: payload)
             let response = client.send(operation: "test", path: "/", httpMethod: "POST", input: input)

--- a/Tests/AWSSDKSwiftCoreTests/PerformanceTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/PerformanceTests.swift
@@ -68,7 +68,7 @@ class PerformanceTests: XCTestCase {
             service:"Test",
             serviceProtocol: ServiceProtocol(type: .restxml),
             apiVersion: "1.0",
-            httpClientProvider: .useAWSClientShared
+            httpClientProvider: .createNew
         )
         let date = Date()
         let request = HeaderRequest(header1: "Header1", header2: "Header2", header3: "Header3", header4: TimeStamp(date))
@@ -90,7 +90,7 @@ class PerformanceTests: XCTestCase {
             service:"Test",
             serviceProtocol: ServiceProtocol(type: .restxml),
             apiVersion: "1.0",
-            httpClientProvider: .useAWSClientShared
+            httpClientProvider: .createNew
         )
         let date = Date()
         let request = StandardRequest(item1: "item1", item2: 45, item3: 3.14, item4: TimeStamp(date), item5: [1,2,3,4,5])
@@ -112,7 +112,7 @@ class PerformanceTests: XCTestCase {
             service:"Test",
             serviceProtocol: ServiceProtocol(type: .restxml),
             apiVersion: "1.0",
-            httpClientProvider: .useAWSClientShared
+            httpClientProvider: .createNew
         )
         let date = Date()
         let request = PayloadRequest(payload: StandardRequest(item1: "item1", item2: 45, item3: 3.14, item4: TimeStamp(date), item5: [1,2,3,4,5]))
@@ -134,7 +134,7 @@ class PerformanceTests: XCTestCase {
             service:"Test",
             serviceProtocol: ServiceProtocol(type: .restjson),
             apiVersion: "1.0",
-            httpClientProvider: .useAWSClientShared
+            httpClientProvider: .createNew
         )
         let date = Date()
         let request = StandardRequest(item1: "item1", item2: 45, item3: 3.14, item4: TimeStamp(date), item5: [1,2,3,4,5])
@@ -156,7 +156,7 @@ class PerformanceTests: XCTestCase {
             service:"Test",
             serviceProtocol: ServiceProtocol(type: .restjson),
             apiVersion: "1.0",
-            httpClientProvider: .useAWSClientShared
+            httpClientProvider: .createNew
         )
         let date = Date()
         let request = PayloadRequest(payload: StandardRequest(item1: "item1", item2: 45, item3: 3.14, item4: TimeStamp(date), item5: [1,2,3,4,5]))
@@ -178,7 +178,7 @@ class PerformanceTests: XCTestCase {
             service:"Test",
             serviceProtocol: ServiceProtocol(type: .query),
             apiVersion: "1.0",
-            httpClientProvider: .useAWSClientShared
+            httpClientProvider: .createNew
         )
         let date = Date()
         let request = StandardRequest(item1: "item1", item2: 45, item3: 3.14, item4: TimeStamp(date), item5: [1,2,3,4,5])
@@ -202,7 +202,7 @@ class PerformanceTests: XCTestCase {
             service:"Test",
             serviceProtocol: ServiceProtocol(type: .json),
             apiVersion: "1.0",
-            httpClientProvider: .useAWSClientShared
+            httpClientProvider: .createNew
         )
         let awsRequest = try! client.createAWSRequest(operation: "Test", path: "/", httpMethod: "GET")
         let signer = try! client.signer.wait()
@@ -222,7 +222,7 @@ class PerformanceTests: XCTestCase {
             service:"Test",
             serviceProtocol: ServiceProtocol(type: .json),
             apiVersion: "1.0",
-            httpClientProvider: .useAWSClientShared
+            httpClientProvider: .createNew
         )
         let awsRequest = try! client.createAWSRequest(operation: "Test", path: "/", httpMethod: "GET")
         let signer = try! client.signer.wait()
@@ -242,7 +242,7 @@ class PerformanceTests: XCTestCase {
             service:"Test",
             serviceProtocol: ServiceProtocol(type: .json),
             apiVersion: "1.0",
-            httpClientProvider: .useAWSClientShared
+            httpClientProvider: .createNew
         )
         let date = Date()
         let request = StandardRequest(item1: "item1", item2: 45, item3: 3.14, item4: TimeStamp(date), item5: [1,2,3,4,5])
@@ -262,7 +262,7 @@ class PerformanceTests: XCTestCase {
             service:"Test",
             serviceProtocol: ServiceProtocol(type: .restxml),
             apiVersion: "1.0",
-            httpClientProvider: .useAWSClientShared
+            httpClientProvider: .createNew
         )
         var buffer = ByteBufferAllocator().buffer(capacity: 0)
         buffer.writeString("<Output><item1>Hello</item1><item2>5</item2><item3>3.141</item3><item4>2001-12-23T15:34:12.590Z</item4><item5>3</item5><item5>6</item5><item5>325</item5></Output>")
@@ -290,7 +290,7 @@ class PerformanceTests: XCTestCase {
             service:"Test",
             serviceProtocol: ServiceProtocol(type: .restjson),
             apiVersion: "1.0",
-            httpClientProvider: .useAWSClientShared
+            httpClientProvider: .createNew
         )
         var buffer = ByteBufferAllocator().buffer(capacity: 0)
         buffer.writeString("{\"item1\":\"Hello\", \"item2\":5, \"item3\":3.14, \"item4\":\"2001-12-23T15:34:12.590Z\", \"item5\": [1,56,3,7]}")

--- a/Tests/AWSSDKSwiftCoreTests/PerformanceTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/PerformanceTests.swift
@@ -68,7 +68,7 @@ class PerformanceTests: XCTestCase {
             service:"Test",
             serviceProtocol: ServiceProtocol(type: .restxml),
             apiVersion: "1.0",
-            eventLoopGroupProvider: .useAWSClientShared
+            httpClientProvider: .useAWSClientShared
         )
         let date = Date()
         let request = HeaderRequest(header1: "Header1", header2: "Header2", header3: "Header3", header4: TimeStamp(date))
@@ -90,7 +90,7 @@ class PerformanceTests: XCTestCase {
             service:"Test",
             serviceProtocol: ServiceProtocol(type: .restxml),
             apiVersion: "1.0",
-            eventLoopGroupProvider: .useAWSClientShared
+            httpClientProvider: .useAWSClientShared
         )
         let date = Date()
         let request = StandardRequest(item1: "item1", item2: 45, item3: 3.14, item4: TimeStamp(date), item5: [1,2,3,4,5])
@@ -112,7 +112,7 @@ class PerformanceTests: XCTestCase {
             service:"Test",
             serviceProtocol: ServiceProtocol(type: .restxml),
             apiVersion: "1.0",
-            eventLoopGroupProvider: .useAWSClientShared
+            httpClientProvider: .useAWSClientShared
         )
         let date = Date()
         let request = PayloadRequest(payload: StandardRequest(item1: "item1", item2: 45, item3: 3.14, item4: TimeStamp(date), item5: [1,2,3,4,5]))
@@ -134,7 +134,7 @@ class PerformanceTests: XCTestCase {
             service:"Test",
             serviceProtocol: ServiceProtocol(type: .restjson),
             apiVersion: "1.0",
-            eventLoopGroupProvider: .useAWSClientShared
+            httpClientProvider: .useAWSClientShared
         )
         let date = Date()
         let request = StandardRequest(item1: "item1", item2: 45, item3: 3.14, item4: TimeStamp(date), item5: [1,2,3,4,5])
@@ -156,7 +156,7 @@ class PerformanceTests: XCTestCase {
             service:"Test",
             serviceProtocol: ServiceProtocol(type: .restjson),
             apiVersion: "1.0",
-            eventLoopGroupProvider: .useAWSClientShared
+            httpClientProvider: .useAWSClientShared
         )
         let date = Date()
         let request = PayloadRequest(payload: StandardRequest(item1: "item1", item2: 45, item3: 3.14, item4: TimeStamp(date), item5: [1,2,3,4,5]))
@@ -178,7 +178,7 @@ class PerformanceTests: XCTestCase {
             service:"Test",
             serviceProtocol: ServiceProtocol(type: .query),
             apiVersion: "1.0",
-            eventLoopGroupProvider: .useAWSClientShared
+            httpClientProvider: .useAWSClientShared
         )
         let date = Date()
         let request = StandardRequest(item1: "item1", item2: 45, item3: 3.14, item4: TimeStamp(date), item5: [1,2,3,4,5])
@@ -202,7 +202,7 @@ class PerformanceTests: XCTestCase {
             service:"Test",
             serviceProtocol: ServiceProtocol(type: .json),
             apiVersion: "1.0",
-            eventLoopGroupProvider: .useAWSClientShared
+            httpClientProvider: .useAWSClientShared
         )
         let awsRequest = try! client.createAWSRequest(operation: "Test", path: "/", httpMethod: "GET")
         let signer = try! client.signer.wait()
@@ -222,7 +222,7 @@ class PerformanceTests: XCTestCase {
             service:"Test",
             serviceProtocol: ServiceProtocol(type: .json),
             apiVersion: "1.0",
-            eventLoopGroupProvider: .useAWSClientShared
+            httpClientProvider: .useAWSClientShared
         )
         let awsRequest = try! client.createAWSRequest(operation: "Test", path: "/", httpMethod: "GET")
         let signer = try! client.signer.wait()
@@ -242,7 +242,7 @@ class PerformanceTests: XCTestCase {
             service:"Test",
             serviceProtocol: ServiceProtocol(type: .json),
             apiVersion: "1.0",
-            eventLoopGroupProvider: .useAWSClientShared
+            httpClientProvider: .useAWSClientShared
         )
         let date = Date()
         let request = StandardRequest(item1: "item1", item2: 45, item3: 3.14, item4: TimeStamp(date), item5: [1,2,3,4,5])
@@ -262,7 +262,7 @@ class PerformanceTests: XCTestCase {
             service:"Test",
             serviceProtocol: ServiceProtocol(type: .restxml),
             apiVersion: "1.0",
-            eventLoopGroupProvider: .useAWSClientShared
+            httpClientProvider: .useAWSClientShared
         )
         var buffer = ByteBufferAllocator().buffer(capacity: 0)
         buffer.writeString("<Output><item1>Hello</item1><item2>5</item2><item3>3.141</item3><item4>2001-12-23T15:34:12.590Z</item4><item5>3</item5><item5>6</item5><item5>325</item5></Output>")
@@ -290,7 +290,7 @@ class PerformanceTests: XCTestCase {
             service:"Test",
             serviceProtocol: ServiceProtocol(type: .restjson),
             apiVersion: "1.0",
-            eventLoopGroupProvider: .useAWSClientShared
+            httpClientProvider: .useAWSClientShared
         )
         var buffer = ByteBufferAllocator().buffer(capacity: 0)
         buffer.writeString("{\"item1\":\"Hello\", \"item2\":5, \"item3\":3.14, \"item4\":\"2001-12-23T15:34:12.590Z\", \"item5\": [1,56,3,7]}")


### PR DESCRIPTION
Equivalent aws-sdk-swift PR can be found here https://github.com/swift-aws/aws-sdk-swift/pull/250

Added `httpClientProvider` parameter to `AWSClient.init()` which takes an enum that indicates if the user wants to use the default http client or one they provide.

Removed eventLoopGroupProvider as the user can provide this via their own httpClient and supplying both an httpClient and an eventLoopGroup doesn't make sense as the only place we use the eventLoopGroup is in the httpClient.

This allows the user to provide a version of `AsyncHTTPClient` with their own configuration, an application global HTTP client, or even a custom written client as long as it conforms to `AWSHTTPClient`.