### PR TITLE
Set XML namespace in AWSShapeEncoder

### DIFF
--- a/Sources/AWSSDKSwiftCore/Encoder/AWSShapeEncoder.swift
+++ b/Sources/AWSSDKSwiftCore/Encoder/AWSShapeEncoder.swift
@@ -30,7 +30,11 @@ class AWSShapeEncoder {
     }
     
     public func xml<Input: AWSShape>(_ input: Input, overrideName: String? = nil) throws -> XML.Element {
-        return try XMLEncoder().encode(input, name: overrideName)
+        let xml = try XMLEncoder().encode(input, name: overrideName)
+        if let xmlNamespace = Input._xmlNamespace {
+            xml.addNamespace(XML.Node.namespace(stringValue: xmlNamespace))
+        }
+        return xml
     }
 
     public func query<Input: AWSShape>(_ input: Input, flattenArrays: Bool = false) throws -> [String : Any] {

--- a/Sources/AWSSDKSwiftCore/Error.swift
+++ b/Sources/AWSSDKSwiftCore/Error.swift
@@ -39,7 +39,7 @@ public struct AWSError: Error, CustomStringConvertible {
     public let rawBody: String
     public let statusCode: HTTPResponseStatus
 
-    public init(statusCode: HTTPResponseStatus, message: String, rawBody: String){
+    init(statusCode: HTTPResponseStatus, message: String, rawBody: String){
         self.statusCode = statusCode
         self.message = message
         self.rawBody = rawBody

--- a/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
@@ -434,6 +434,28 @@ class AWSClientTests: XCTestCase {
             XCTFail(error.localizedDescription)
         }
     }
+    
+    func testCreateWithXMLNamespace() {
+        struct Input: AWSShape {
+            public static let _xmlNamespace: String? = "https://test.amazonaws.com/doc/2020-03-11/"
+            public static var _members: [AWSShapeMember] = [
+                AWSShapeMember(label: "number", required: true, type: .integer)
+            ]
+            let number: Int
+        }
+        do {
+            let input = Input(number: 5)
+            let request = try s3Client.createAWSRequest(operation: "Test", path: "/", httpMethod: "GET", input: input)
+            if case .xml(let element) = request.body {
+                XCTAssertEqual(element.xmlString, "<Input xmlns=\"https://test.amazonaws.com/doc/2020-03-11/\"><number>5</number></Input>")
+            } else {
+                XCTFail("Shouldn't get here")
+            }
+        } catch {
+            XCTFail("\(error)")
+        }
+    }
+    
     func testValidateCode() {
         let response = AWSHTTPResponseImpl(
             status: .ok,


### PR DESCRIPTION
Previously XML namespaces only ever set when they were attached to Payload objects. This change fixes the situation where the XML namespace is for the parent AWSShape and not the payload object.