### PR TITLE
Split AWSShape into AWSEncodableShape and AWSDecodableShape

### DIFF
--- a/Sources/AWSSDKSwiftCore/Doc/AWSShape+Encoder.swift
+++ b/Sources/AWSSDKSwiftCore/Doc/AWSShape+Encoder.swift
@@ -15,7 +15,7 @@
 import struct Foundation.Data
 import class  Foundation.JSONEncoder
 
-internal extension AWSShape {
+internal extension AWSEncodableShape {
 
     /// Encode AWSShape as JSON
     func encodeAsJSON() throws -> Data {

--- a/Sources/AWSSDKSwiftCore/Doc/AWSShape+Encoder.swift
+++ b/Sources/AWSSDKSwiftCore/Doc/AWSShape+Encoder.swift
@@ -16,12 +16,12 @@ import struct Foundation.Data
 import class  Foundation.JSONEncoder
 
 internal extension AWSShape {
-    
+
     /// Encode AWSShape as JSON
     func encodeAsJSON() throws -> Data {
         return try JSONEncoder().encode(self)
     }
-    
+
     /// Encode AWSShape as XML
     func encodeAsXML(rootName: String? = nil) throws -> XML.Element {
         let xml = try XMLEncoder().encode(self, name: rootName)
@@ -30,7 +30,7 @@ internal extension AWSShape {
         }
         return xml
     }
-    
+
     /// Encode AWSShape as a query array
     /// - Parameter flattenArrays: should all arrays be flattened
     func encodeAsQuery(flattenArrays: Bool = false) throws -> [String : Any] {
@@ -40,4 +40,3 @@ internal extension AWSShape {
     }
 
 }
-

--- a/Sources/AWSSDKSwiftCore/Doc/AWSShape.swift
+++ b/Sources/AWSSDKSwiftCore/Doc/AWSShape.swift
@@ -19,26 +19,11 @@ import func   Foundation.NSMakeRange
 
 /// Protocol for the input and output objects for all AWS service commands. They need to be Codable so they can be serialized. They also need to provide details on how their container classes are coded when serializing XML.
 public protocol AWSShape: XMLCodable {
-    /// The path to the object that is included in the request/response body
-    static var payloadPath: String? { get }
-    /// The XML namespace for the object
-    static var _xmlNamespace: String? { get }
     /// The array of members serialization helpers
     static var _encoding: [AWSMemberEncoding] { get }
-
-    /// returns if a shape is valid. The checks for validity are defined by the AWS model files we get from http://github.com/aws/aws-sdk-go
-    func validate(name: String) throws
 }
 
 extension AWSShape {
-    public static var payloadPath: String? {
-        return nil
-    }
-
-    public static var _xmlNamespace: String? {
-        return nil
-    }
-
     public static var _encoding: [AWSMemberEncoding] {
         return []
     }
@@ -85,70 +70,6 @@ extension AWSShape {
     }
 }
 
-/// Validation code to add to AWSShape
-extension AWSShape {
-    public func validate() throws {
-        try validate(name: "\(type(of:self))")
-    }
-
-    /// stub validate function for all shapes
-    public func validate(name: String) throws {
-    }
-
-    public func validate<T : BinaryInteger>(_ value: T, name: String, parent: String, min: T) throws {
-        guard value >= min else { throw AWSClientError.validationError(message: "\(parent).\(name) (\(value)) is less than minimum allowed value \(min).") }
-    }
-    public func validate<T : BinaryInteger>(_ value: T, name: String, parent: String, max: T) throws {
-        guard value <= max else { throw AWSClientError.validationError(message: "\(parent).\(name) (\(value)) is greater than the maximum allowed value \(max).") }
-    }
-    public func validate<T : FloatingPoint>(_ value: T, name: String, parent: String, min: T) throws {
-        guard value >= min else { throw AWSClientError.validationError(message: "\(parent).\(name) (\(value)) is less than minimum allowed value \(min).") }
-    }
-    public func validate<T : FloatingPoint>(_ value: T, name: String, parent: String, max: T) throws {
-        guard value <= max else { throw AWSClientError.validationError(message: "\(parent).\(name) (\(value)) is greater than the maximum allowed value \(max).") }
-    }
-    public func validate<T : Collection>(_ value: T, name: String, parent: String, min: Int) throws {
-        guard value.count >= min else { throw AWSClientError.validationError(message: "Length of \(parent).\(name) (\(value.count)) is less than minimum allowed value \(min).") }
-    }
-    public func validate<T : Collection>(_ value: T, name: String, parent: String, max: Int) throws {
-        guard value.count <= max else { throw AWSClientError.validationError(message: "Length of \(parent).\(name) (\(value.count)) is greater than the maximum allowed value \(max).") }
-    }
-    public func validate(_ value: String, name: String, parent: String, pattern: String) throws {
-        let regularExpression = try NSRegularExpression(pattern: pattern, options: [])
-        let firstMatch = regularExpression.rangeOfFirstMatch(in: value, options: .anchored, range: NSMakeRange(0, value.count))
-        guard firstMatch.location != NSNotFound && firstMatch.length > 0 else { throw AWSClientError.validationError(message: "\(parent).\(name) (\(value)) does not match pattern \(pattern).") }
-    }
-    // validate optional values
-    public func validate<T : BinaryInteger>(_ value: T?, name: String, parent: String, min: T) throws {
-        guard let value = value else {return}
-        try validate(value, name: name, parent: parent, min: min)
-    }
-    public func validate<T : BinaryInteger>(_ value: T?, name: String, parent: String, max: T) throws {
-        guard let value = value else {return}
-        try validate(value, name: name, parent: parent, max: max)
-    }
-    public func validate<T : FloatingPoint>(_ value: T?, name: String, parent: String, min: T) throws {
-        guard let value = value else {return}
-        try validate(value, name: name, parent: parent, min: min)
-    }
-    public func validate<T : FloatingPoint>(_ value: T?, name: String, parent: String, max: T) throws {
-        guard let value = value else {return}
-        try validate(value, name: name, parent: parent, max: max)
-    }
-    public func validate<T : Collection>(_ value: T?, name: String, parent: String, min: Int) throws {
-        guard let value = value else {return}
-        try validate(value, name: name, parent: parent, min: min)
-    }
-    public func validate<T : Collection>(_ value: T?, name: String, parent: String, max: Int) throws {
-        guard let value = value else {return}
-        try validate(value, name: name, parent: parent, max: max)
-    }
-    public func validate(_ value: String?, name: String, parent: String, pattern: String) throws {
-        guard let value = value else {return}
-        try validate(value, name: name, parent: parent, pattern: pattern)
-    }
-}
-
 extension AWSShape {
     /// Return an idempotencyToken 
     public static func idempotencyToken() -> String {
@@ -191,6 +112,98 @@ extension AWSShape {
         if let encoding = getEncoding(forKey: key) {
             return encoding.shapeEncoding.xmlEncoding
         }
+        return nil
+    }
+}
+
+/// AWSShape that can be encoded
+public protocol AWSEncodableShape: AWSShape & Encodable {
+    /// The XML namespace for the object
+    static var _xmlNamespace: String? { get }
+    
+    /// returns if a shape is valid. The checks for validity are defined by the AWS model files we get from http://github.com/aws/aws-sdk-go
+    func validate(name: String) throws
+}
+
+public extension AWSEncodableShape {
+    static var _xmlNamespace: String? { return nil }
+}
+
+/// Validation code to add to AWSEncodableShape
+public extension AWSEncodableShape {
+    func validate() throws {
+        try validate(name: "\(type(of:self))")
+    }
+
+    /// stub validate function for all shapes
+    func validate(name: String) throws {
+    }
+
+    func validate<T : BinaryInteger>(_ value: T, name: String, parent: String, min: T) throws {
+        guard value >= min else { throw AWSClientError.validationError(message: "\(parent).\(name) (\(value)) is less than minimum allowed value \(min).") }
+    }
+    func validate<T : BinaryInteger>(_ value: T, name: String, parent: String, max: T) throws {
+        guard value <= max else { throw AWSClientError.validationError(message: "\(parent).\(name) (\(value)) is greater than the maximum allowed value \(max).") }
+    }
+    func validate<T : FloatingPoint>(_ value: T, name: String, parent: String, min: T) throws {
+        guard value >= min else { throw AWSClientError.validationError(message: "\(parent).\(name) (\(value)) is less than minimum allowed value \(min).") }
+    }
+    func validate<T : FloatingPoint>(_ value: T, name: String, parent: String, max: T) throws {
+        guard value <= max else { throw AWSClientError.validationError(message: "\(parent).\(name) (\(value)) is greater than the maximum allowed value \(max).") }
+    }
+    func validate<T : Collection>(_ value: T, name: String, parent: String, min: Int) throws {
+        guard value.count >= min else { throw AWSClientError.validationError(message: "Length of \(parent).\(name) (\(value.count)) is less than minimum allowed value \(min).") }
+    }
+    func validate<T : Collection>(_ value: T, name: String, parent: String, max: Int) throws {
+        guard value.count <= max else { throw AWSClientError.validationError(message: "Length of \(parent).\(name) (\(value.count)) is greater than the maximum allowed value \(max).") }
+    }
+    func validate(_ value: String, name: String, parent: String, pattern: String) throws {
+        let regularExpression = try NSRegularExpression(pattern: pattern, options: [])
+        let firstMatch = regularExpression.rangeOfFirstMatch(in: value, options: .anchored, range: NSMakeRange(0, value.count))
+        guard firstMatch.location != NSNotFound && firstMatch.length > 0 else { throw AWSClientError.validationError(message: "\(parent).\(name) (\(value)) does not match pattern \(pattern).") }
+    }
+    // validate optional values
+    func validate<T : BinaryInteger>(_ value: T?, name: String, parent: String, min: T) throws {
+        guard let value = value else {return}
+        try validate(value, name: name, parent: parent, min: min)
+    }
+    func validate<T : BinaryInteger>(_ value: T?, name: String, parent: String, max: T) throws {
+        guard let value = value else {return}
+        try validate(value, name: name, parent: parent, max: max)
+    }
+    func validate<T : FloatingPoint>(_ value: T?, name: String, parent: String, min: T) throws {
+        guard let value = value else {return}
+        try validate(value, name: name, parent: parent, min: min)
+    }
+    func validate<T : FloatingPoint>(_ value: T?, name: String, parent: String, max: T) throws {
+        guard let value = value else {return}
+        try validate(value, name: name, parent: parent, max: max)
+    }
+    func validate<T : Collection>(_ value: T?, name: String, parent: String, min: Int) throws {
+        guard let value = value else {return}
+        try validate(value, name: name, parent: parent, min: min)
+    }
+    func validate<T : Collection>(_ value: T?, name: String, parent: String, max: Int) throws {
+        guard let value = value else {return}
+        try validate(value, name: name, parent: parent, max: max)
+    }
+    func validate(_ value: String?, name: String, parent: String, pattern: String) throws {
+        guard let value = value else {return}
+        try validate(value, name: name, parent: parent, pattern: pattern)
+    }
+}
+
+/// AWSShape that can be decoded
+public protocol AWSDecodableShape: AWSShape & Decodable {}
+
+/// Root AWSShape which include a payload
+public protocol AWSShapeWithPayload {
+    /// The path to the object that is included in the request body
+    static var payloadPath: String? { get }
+}
+
+public extension AWSShapeWithPayload {
+    static var payloadPath: String? {
         return nil
     }
 }

--- a/Sources/AWSSDKSwiftCore/Encoder/XMLDecoder.swift
+++ b/Sources/AWSSDKSwiftCore/Encoder/XMLDecoder.swift
@@ -38,7 +38,7 @@ public enum XMLContainerCoding {
 }
 
 /// protocol to return XMLContainerCoding values. To control how the child elements of a Codable class are encoded inherit from this and return coding values for each
-public protocol XMLCodable: Codable {
+public protocol XMLCodable {
     static func getXMLContainerCoding(for key: CodingKey) -> XMLContainerCoding?
 }
 

--- a/Tests/AWSSDKSwiftCoreTests/DictionaryEncoderTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/DictionaryEncoderTests.swift
@@ -115,11 +115,11 @@ class DictionaryEncoderTests: XCTestCase {
     }
     
     func testContainingStructureDecodeEncode() {
-        struct Test2 : Codable {
+        struct Test2 : AWSDecodableShape {
             let a : Int
             let b : String
         }
-        struct Test : Codable {
+        struct Test : AWSDecodableShape {
             let t : Test2
         }
         let dictionary: [String:Any] = ["t": ["a":4, "b":"Hello"]]
@@ -130,7 +130,7 @@ class DictionaryEncoderTests: XCTestCase {
     }
     
     func testEnumDecodeEncode() {
-        struct Test : Codable {
+        struct Test : AWSDecodableShape {
             enum TestEnum : String, Codable {
                 case first = "First"
                 case second = "Second"
@@ -144,7 +144,7 @@ class DictionaryEncoderTests: XCTestCase {
     }
     
     func testArrayDecodeEncode() {
-        struct Test : Codable {
+        struct Test : AWSDecodableShape {
             let a : [Int]
         }
         let dictionary: [String:Any] = ["a":[1,2,3,4,5]]
@@ -154,10 +154,10 @@ class DictionaryEncoderTests: XCTestCase {
     }
     
     func testArrayOfStructuresDecodeEncode() {
-        struct Test2 : Codable {
+        struct Test2 : AWSDecodableShape {
             let b : String
         }
-        struct Test : Codable {
+        struct Test : AWSDecodableShape {
             let a : [Test2]
         }
         let dictionary: [String:Any] = ["a":[["b":"hello"], ["b":"goodbye"]]]
@@ -168,7 +168,7 @@ class DictionaryEncoderTests: XCTestCase {
     }
     
     func testDictionaryDecodeEncode() {
-        struct Test : Codable {
+        struct Test : AWSDecodableShape {
             let a : [String:Int]
         }
         let dictionary: [String:Any] = ["a":["key":45]]
@@ -178,7 +178,7 @@ class DictionaryEncoderTests: XCTestCase {
     }
     
     func testEnumDictionaryDecodeEncode() {
-        struct Test : Codable {
+        struct Test : AWSDecodableShape {
             enum TestEnum : String, Codable {
                 case first = "First"
                 case second = "Second"
@@ -193,7 +193,7 @@ class DictionaryEncoderTests: XCTestCase {
     }
     
     func testDateDecodeEncode() {
-        struct Test : Codable {
+        struct Test : AWSDecodableShape {
             let date : Date
         }
         let dictionary: [String:Any] = ["date":0]
@@ -215,7 +215,7 @@ class DictionaryEncoderTests: XCTestCase {
     }
     
     func testDataDecodeEncode() {
-        struct Test : Codable {
+        struct Test : AWSDecodableShape {
             let data : Data
         }
         let dictionary: [String:Any] = ["data":"Hello, world".data(using:.utf8)!.base64EncodedString()]
@@ -233,7 +233,7 @@ class DictionaryEncoderTests: XCTestCase {
     }
     
     func testUrlDecodeEncode() {
-        struct Test : Codable {
+        struct Test : AWSDecodableShape {
             let url : URL
         }
         let dictionary: [String:Any] = ["url":"www.google.com"]
@@ -242,7 +242,7 @@ class DictionaryEncoderTests: XCTestCase {
         }
     }
     
-    func testDecodeErrors<T : Codable>(type: T.Type, dictionary: [String:Any], decoder: DictionaryDecoder = DictionaryDecoder()) {
+    func testDecodeErrors<T : Decodable>(type: T.Type, dictionary: [String:Any], decoder: DictionaryDecoder = DictionaryDecoder()) {
         do {
             _ = try DictionaryDecoder().decode(T.self, from: dictionary)
             XCTFail("Decoder did not throw an error when it should have")
@@ -252,7 +252,7 @@ class DictionaryEncoderTests: XCTestCase {
     }
     
     func testFloatOverflowDecodeErrors() {
-        struct Test : Codable {
+        struct Test : AWSDecodableShape {
             let float : Float
         }
         let dictionary: [String:Any] = ["float":Double.infinity]
@@ -260,7 +260,7 @@ class DictionaryEncoderTests: XCTestCase {
     }
     
     func testMissingKeyDecodeErrors() {
-        struct Test : Codable {
+        struct Test : AWSDecodableShape {
             let a : Int
             let b : Int
         }
@@ -269,7 +269,7 @@ class DictionaryEncoderTests: XCTestCase {
     }
     
     func testInvalidValueDecodeErrors() {
-        struct Test : Codable {
+        struct Test : AWSDecodableShape {
             let a : Int
         }
         let dictionary: [String:Any] = ["b":"test"]
@@ -277,7 +277,7 @@ class DictionaryEncoderTests: XCTestCase {
     }
     
     func testNestedContainer() {
-        struct Test : Decodable {
+        struct Test : AWSDecodableShape {
             let firstname : String
             let surname : String
             let age : Int
@@ -310,7 +310,7 @@ class DictionaryEncoderTests: XCTestCase {
     }
     
     func testSupercoder() {
-        class Base : Decodable {
+        class Base : AWSDecodableShape {
             let a : Int
         }
         class Test : Base {
@@ -336,7 +336,7 @@ class DictionaryEncoderTests: XCTestCase {
         }
     }
     
-    struct B: Codable {
+    struct B: AWSDecodableShape {
         let int: Int
         let int8: Int8
         let int16: Int16
@@ -355,7 +355,7 @@ class DictionaryEncoderTests: XCTestCase {
         let optional: String?
     }
     
-    struct A: Codable {
+    struct A: AWSDecodableShape {
         let b: B
         let dictionary: [String: String]
         let array: [String]

--- a/Tests/AWSSDKSwiftCoreTests/JSONCoderTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/JSONCoderTests.swift
@@ -17,7 +17,7 @@ import XCTest
 
 class JSONCoderTests: XCTestCase {
     
-    struct Numbers : AWSShape {
+    struct Numbers : AWSDecodableShape & AWSEncodableShape {
 
        init(bool:Bool, integer:Int, float:Float, double:Double, intEnum:IntEnum) {
            self.bool = bool
@@ -59,7 +59,7 @@ class JSONCoderTests: XCTestCase {
        }
     }
 
-    struct StringShape : AWSShape {
+    struct StringShape : AWSDecodableShape & AWSEncodableShape {
        enum StringEnum : String, Codable {
            case first="first"
            case second="second"
@@ -71,12 +71,12 @@ class JSONCoderTests: XCTestCase {
        let stringEnum : StringEnum
     }
 
-    struct Arrays : AWSShape {
+    struct Arrays : AWSDecodableShape & AWSEncodableShape {
        let arrayOfNatives : [Int]
        let arrayOfShapes : [Numbers]
     }
 
-    struct Dictionaries : AWSShape {
+    struct Dictionaries : AWSDecodableShape & AWSEncodableShape {
        let dictionaryOfNatives : [String:Int]
        let dictionaryOfShapes : [String:StringShape]
 
@@ -86,7 +86,7 @@ class JSONCoderTests: XCTestCase {
        }
     }
 
-    struct Shape : AWSShape {
+    struct Shape : AWSDecodableShape & AWSEncodableShape {
        let numbers : Numbers
        let stringShape : StringShape
        let arrays : Arrays
@@ -98,7 +98,7 @@ class JSONCoderTests: XCTestCase {
        }
     }
 
-    struct ShapeWithDictionaries : AWSShape {
+    struct ShapeWithDictionaries : AWSDecodableShape & AWSEncodableShape {
        let shape : Shape
        let dictionaries : Dictionaries
 

--- a/Tests/AWSSDKSwiftCoreTests/PaginateTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/PaginateTests.swift
@@ -38,40 +38,41 @@ class PaginateTests: XCTestCase {
             eventLoopGroupProvider: .useAWSClientShared
         )
     }
-    
+
     override func tearDown() {
         XCTAssertNoThrow(try self.awsServer.stop())
     }
-    
+
     // test structures/functions
-    struct CounterInput: AWSShape, AWSPaginateToken {
+    struct CounterInput: AWSEncodableShape, AWSPaginateToken, Decodable {
         let inputToken: Int?
         let pageSize: Int
-        
+
         init(inputToken: Int?, pageSize: Int) {
             self.inputToken = inputToken
             self.pageSize = pageSize
         }
-        
+
         func usingPaginationToken(_ token: Int) -> CounterInput {
             return .init(inputToken: token, pageSize: self.pageSize)
         }
     }
-    struct CounterOutput: AWSShape {
+    // conform to Encodable so server can encode these
+    struct CounterOutput: AWSDecodableShape, Encodable {
         let array: [Int]
         let outputToken: Int?
     }
-    
+
     func counter(_ input: CounterInput) -> EventLoopFuture<CounterOutput> {
         return client.send(operation: "TestOperation", path: "/", httpMethod: "POST", input: input)
     }
-    
+
     func counterPaginator(_ input: CounterInput, onPage: @escaping (CounterOutput, EventLoop)->EventLoopFuture<Bool>) -> EventLoopFuture<Void> {
         return client.paginate(input: input, command: counter, tokenKey: \CounterOutput.outputToken, onPage: onPage)
     }
-    
+
     func testIntegerTokenPaginate() throws {
-        
+
         // paginate input
         var finalArray: [Int] = []
         let input = CounterInput(inputToken: nil, pageSize: 4)
@@ -80,7 +81,7 @@ class PaginateTests: XCTestCase {
             finalArray.append(contentsOf: result.array)
             return eventloop.makeSucceededFuture(true)
         }
-        
+
         let arraySize = 23
         do {
             // aws server process
@@ -102,41 +103,42 @@ class PaginateTests: XCTestCase {
         } catch {
             print(error)
         }
-        
+
         // verify contents of array
         XCTAssertEqual(finalArray.count, arraySize)
         for i in 0..<finalArray.count {
             XCTAssertEqual(finalArray[i], i)
         }
     }
-    
+
     // test structures/functions
-    struct StringListInput: AWSShape, AWSPaginateToken {
+    struct StringListInput: AWSEncodableShape, AWSPaginateToken, Decodable {
         let inputToken: String?
         let pageSize: Int
-        
+
         init(inputToken: String?, pageSize: Int) {
             self.inputToken = inputToken
             self.pageSize = pageSize
         }
-        
+
         func usingPaginationToken(_ token: String) -> StringListInput {
             return .init(inputToken: token, pageSize: self.pageSize)
         }
     }
-    struct StringListOutput: AWSShape {
+    // conform to Encodable so server can encode these
+    struct StringListOutput: AWSDecodableShape, Encodable {
         let array: [String]
         let outputToken: String?
     }
-    
+
     func stringList(_ input: StringListInput) -> EventLoopFuture<StringListOutput> {
         return client.send(operation: "TestOperation", path: "/", httpMethod: "POST", input: input)
     }
-    
+
     func stringListPaginator(_ input: StringListInput, onPage: @escaping (StringListOutput, EventLoop)->EventLoopFuture<Bool>) -> EventLoopFuture<Void> {
         return client.paginate(input: input, command: stringList, tokenKey: \StringListOutput.outputToken, onPage: onPage)
     }
-    
+
     // create list of unique strings
     let stringList = Set("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.".split(separator: " ").map {String($0)}).map {$0}
 
@@ -161,9 +163,9 @@ class PaginateTests: XCTestCase {
         let output = StringListOutput(array: array, outputToken: outputToken)
         return AWSTestServer.Result(output: output, continueProcessing: continueProcessing)
     }
-    
+
     func testStringTokenPaginate() throws {
-        
+
         // paginate input
         var finalArray: [String] = []
         let input = StringListInput(inputToken: nil, pageSize: 5)
@@ -172,7 +174,7 @@ class PaginateTests: XCTestCase {
             finalArray.append(contentsOf: result.array)
             return eventloop.makeSucceededFuture(true)
         }
-        
+
         do {
             // aws server process
             try awsServer.process(stringListServerProcess)
@@ -182,7 +184,7 @@ class PaginateTests: XCTestCase {
         } catch {
             print(error)
         }
-        
+
         // verify contents of array
         XCTAssertEqual(finalArray.count, stringList.count)
         for i in 0..<finalArray.count {
@@ -195,20 +197,20 @@ class PaginateTests: XCTestCase {
     }
 
     func testPaginateError() throws {
-        
+
         // paginate input
         let input = StringListInput(inputToken: nil, pageSize: 5)
         let future = stringListPaginator(input) { _,eventloop in
             return eventloop.makeSucceededFuture(true)
         }
-        
+
         do {
             // aws server process
             try awsServer.ProcessWithErrors(stringListServerProcess, error: AWSTestServer.ErrorType(status: 400, errorCode:"InvalidAction", message: "You didn't mean that"), errorAfter: 0)
 
             // wait for response
             try future.wait()
-            
+
             XCTFail("testPaginateError: should have errored")
         } catch {
             print(error)
@@ -216,20 +218,20 @@ class PaginateTests: XCTestCase {
     }
 
     func testPaginateErrorAfterFirstRequest() throws {
-        
+
         // paginate input
         let input = StringListInput(inputToken: nil, pageSize: 5)
         let future = stringListPaginator(input) { _,eventloop in
             return eventloop.makeSucceededFuture(true)
         }
-        
+
         do {
             // aws server process
             try awsServer.ProcessWithErrors(stringListServerProcess, error: AWSTestServer.ErrorType(status: 400, errorCode:"InvalidAction", message: "You didn't mean that"), errorAfter: 1)
 
             // wait for response
             try future.wait()
-            
+
             XCTFail("testPaginateError: should have errored")
         } catch {
             print(error)

--- a/Tests/AWSSDKSwiftCoreTests/PerformanceTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/PerformanceTests.swift
@@ -18,7 +18,7 @@ import NIOHTTP1
 import AsyncHTTPClient
 @testable import AWSSDKSwiftCore
 
-struct HeaderRequest: AWSShape {
+struct HeaderRequest: AWSEncodableShape {
     static var _encoding: [AWSMemberEncoding] = [
         AWSMemberEncoding(label: "Header1", location: .header(locationName: "Header1")),
         AWSMemberEncoding(label: "Header2", location: .header(locationName: "Header2")),
@@ -32,7 +32,7 @@ struct HeaderRequest: AWSShape {
     let header4: TimeStamp
 }
 
-struct StandardRequest: AWSShape {
+struct StandardRequest: AWSEncodableShape {
     let item1: String
     let item2: Int
     let item3: Double
@@ -40,13 +40,13 @@ struct StandardRequest: AWSShape {
     let item5: [Int]
 }
 
-struct PayloadRequest: AWSShape {
+struct PayloadRequest: AWSEncodableShape & AWSShapeWithPayload {
     public static let payloadPath: String? = "payload"
 
     let payload: StandardRequest
 }
 
-struct MixedRequest: AWSShape {
+struct MixedRequest: AWSEncodableShape {
     static var _encoding: [AWSMemberEncoding] = [
         AWSMemberEncoding(label: "item1", location: .header(locationName: "item1")),
     ]
@@ -55,6 +55,14 @@ struct MixedRequest: AWSShape {
     let item2: Int
     let item3: Double
     let item4: TimeStamp
+}
+
+struct StandardResponse: AWSDecodableShape {
+    let item1: String
+    let item2: Int
+    let item3: Double
+    let item4: TimeStamp
+    let item5: [Int]
 }
 
 
@@ -275,7 +283,7 @@ class PerformanceTests: XCTestCase {
         measure {
             do {
                 for _ in 0..<1000 {
-                    let _: StandardRequest = try client.validate(operation: "Output", response: response)
+                    let _: StandardResponse = try client.validate(operation: "Output", response: response)
                 }
             } catch {
                 XCTFail(error.localizedDescription)
@@ -303,7 +311,7 @@ class PerformanceTests: XCTestCase {
         measure {
             do {
                 for _ in 0..<1000 {
-                    let _: StandardRequest = try client.validate(operation: "Output", response: response)
+                    let _: StandardResponse = try client.validate(operation: "Output", response: response)
                 }
             } catch {
                 XCTFail(error.localizedDescription)

--- a/Tests/AWSSDKSwiftCoreTests/QueryEncoderTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/QueryEncoderTests.swift
@@ -26,8 +26,8 @@ class QueryEncoderTests: XCTestCase {
         }
         return nil
     }
-    
-    func testQuery<Input: AWSShape>(_ value: Input, query: String) {
+
+    func testQuery<Input: Encodable>(_ value: Input, query: String) {
         do {
             let queryDict = try QueryEncoder().encode(value)
             let query2 = queryString(dictionary: queryDict)
@@ -37,10 +37,10 @@ class QueryEncoderTests: XCTestCase {
         }
     }
     func testSimpleStructureEncode() {
-        struct Test : AWSShape {
+        struct Test : AWSEncodableShape {
             let a : String
             let b : Int
-            
+
             private enum CodingKeys: String, CodingKey {
                 case a = "A"
                 case b = "B"
@@ -49,20 +49,20 @@ class QueryEncoderTests: XCTestCase {
         let test = Test(a:"Testing", b:42)
         testQuery(test, query:"A=Testing&B=42")
     }
-    
+
     func testContainingStructureEncode() {
-        struct Test : AWSShape {
+        struct Test : AWSEncodableShape {
             let a : Int
             let b : String
-            
+
             private enum CodingKeys: String, CodingKey {
                 case a = "A"
                 case b = "B"
             }
         }
-        struct Test2 : AWSShape {
+        struct Test2 : AWSEncodableShape {
             let t : Test
-            
+
             private enum CodingKeys: String, CodingKey {
                 case t = "T"
             }
@@ -72,13 +72,13 @@ class QueryEncoderTests: XCTestCase {
     }
 
     func testEnumEncode() {
-        struct Test : AWSShape {
+        struct Test : AWSEncodableShape {
             enum TestEnum : String, Codable {
                 case first = "first"
                 case second = "second"
             }
             let a : TestEnum
-            
+
             private enum CodingKeys: String, CodingKey {
                 case a = "A"
             }
@@ -89,9 +89,9 @@ class QueryEncoderTests: XCTestCase {
     }
 
     func testArrayEncode() {
-        struct Test : AWSShape {
+        struct Test : AWSEncodableShape {
             let a : [Int]
-            
+
             private enum CodingKeys: String, CodingKey {
                 case a = "A"
             }
@@ -99,19 +99,19 @@ class QueryEncoderTests: XCTestCase {
         let test = Test(a:[9,8,7,6])
         testQuery(test, query:"A.1=9&A.2=8&A.3=7&A.4=6")
     }
-    
+
     func testArrayOfStructuresEncode() {
-        struct Test2 : AWSShape {
+        struct Test2 : AWSEncodableShape {
             let b : String
-            
+
             private enum CodingKeys: String, CodingKey {
                 case b = "B"
             }
         }
-        struct Test : AWSShape {
+        struct Test : AWSEncodableShape {
             static let _encoding = [AWSMemberEncoding(label: "A", encoding:.list(member: "m") )]
             let a : [Test2]
-            
+
             private enum CodingKeys: String, CodingKey {
                 case a = "A"
             }
@@ -119,12 +119,12 @@ class QueryEncoderTests: XCTestCase {
         let test = Test(a:[Test2(b:"first"), Test2(b:"second")])
         testQuery(test, query:"A.m.1.B=first&A.m.2.B=second")
     }
-    
+
     func testDictionaryEncode() {
-        struct Test : AWSShape {
+        struct Test : AWSEncodableShape {
             static let _encoding = [AWSMemberEncoding(label: "A", encoding:.map(entry: "entry", key: "key", value: "value"))]
             let a : [String:Int]
-            
+
             private enum CodingKeys: String, CodingKey {
                 case a = "A"
             }
@@ -132,23 +132,23 @@ class QueryEncoderTests: XCTestCase {
         let test = Test(a:["first":1])
         testQuery(test, query:"A.entry.1.key=first&A.entry.1.value=1")
     }
-    
+
     func testDictionaryEnumKeyEncode() {
-        struct Test2 : AWSShape {
+        struct Test2 : AWSEncodableShape {
             let b : String
-            
+
             private enum CodingKeys: String, CodingKey {
                 case b = "B"
             }
         }
-        struct Test : AWSShape {
+        struct Test : AWSEncodableShape {
             static let _encoding = [AWSMemberEncoding(label: "A", encoding:.map(entry: "entry", key: "key", value: "value"))]
             enum TestEnum : String, Codable {
                 case first = "first"
                 case second = "second"
             }
             let a : [TestEnum:Test2]
-            
+
             private enum CodingKeys: String, CodingKey {
                 case a = "A"
             }
@@ -156,21 +156,21 @@ class QueryEncoderTests: XCTestCase {
         let test = Test(a:[.first:Test2(b:"1st")])
         testQuery(test, query:"A.entry.1.key=first&A.entry.1.value.B=1st")
     }
-    
+
     func testArrayEncodingEncode() {
-        struct Test : AWSShape {
+        struct Test : AWSEncodableShape {
             static let _encoding = [AWSMemberEncoding(label: "a", encoding:.list(member:"item"))]
             let a : [Int]
         }
         let test = Test(a:[9,8,7,6])
         testQuery(test, query:"a.item.1=9&a.item.2=8&a.item.3=7&a.item.4=6")
     }
-    
+
     func testDictionaryEncodingEncode() {
-        struct Test : AWSShape {
+        struct Test : AWSEncodableShape {
             static let _encoding = [AWSMemberEncoding(label: "A", encoding:.map(entry: "item", key: "k", value: "v"))]
             let a : [String:Int]
-            
+
             private enum CodingKeys: String, CodingKey {
                 case a = "A"
             }
@@ -178,12 +178,12 @@ class QueryEncoderTests: XCTestCase {
         let test = Test(a:["first":1])
         testQuery(test, query:"A.item.1.k=first&A.item.1.v=1")
     }
-    
+
     func testDictionaryEncodingEncode2() {
-        struct Test : AWSShape {
+        struct Test : AWSEncodableShape {
             static let _encoding = [AWSMemberEncoding(label: "A", encoding:.flatMap(key: "name", value: "entry"))]
             let a : [String:Int]
-            
+
             private enum CodingKeys: String, CodingKey {
                 case a = "A"
             }
@@ -191,13 +191,13 @@ class QueryEncoderTests: XCTestCase {
         let test = Test(a:["first":1])
         testQuery(test, query:"A.1.entry=1&A.1.name=first")
     }
-    
+
     // array performance in QueryEncoder is slower than expected
     func testQueryArrayPerformance() {
         guard Self.enableTimingTests == true else { return }
-        struct Test : AWSShape {
+        struct Test : AWSEncodableShape {
             let a : [Int]
-            
+
             private enum CodingKeys: String, CodingKey {
                 case a = "A"
             }
@@ -213,9 +213,9 @@ class QueryEncoderTests: XCTestCase {
             }
         }
     }
-    
+
     func testDataBlobEncode() {
-        struct Test : AWSShape {
+        struct Test : AWSEncodableShape {
             let a : Data
         }
         let data = Data("Testing".utf8)

--- a/Tests/AWSSDKSwiftCoreTests/TestServer.swift
+++ b/Tests/AWSSDKSwiftCoreTests/TestServer.swift
@@ -79,12 +79,12 @@ class AWSTestServer {
     }
     
     /// run server reading request, convert from to an input shape processing them and converting the result back to a response.
-    func process<Input: AWSShape, Output: AWSShape>(_ process: (Input) throws -> Result<Output>) throws {
+    func process<Input: Decodable, Output: Encodable>(_ process: (Input) throws -> Result<Output>) throws {
         while(try processSingleRequest(process)) { }
     }
     
     /// run server reading request, convert from to an input shape processing them and converting the result back to a response. Return an error after so many requests
-    func ProcessWithErrors<Input: AWSShape, Output: AWSShape>(_ process: (Input) throws -> Result<Output>, error: ErrorType, errorAfter: Int) throws {
+    func ProcessWithErrors<Input: Decodable, Output:  Encodable>(_ process: (Input) throws -> Result<Output>, error: ErrorType, errorAfter: Int) throws {
         var count = errorAfter
         repeat {
             if count == 0 {
@@ -159,7 +159,7 @@ extension AWSTestServer {
     }
 
     /// read one request, convert it from to an input shape, processing it and convert the result back to a response.
-    func processSingleRequest<Input: AWSShape, Output: AWSShape>(_ process: (Input) throws -> Result<Output>) throws -> Bool {
+    func processSingleRequest<Input: Decodable, Output: Encodable>(_ process: (Input) throws -> Result<Output>) throws -> Bool {
         let request = try readRequest()
 
         // Convert to Input AWSShape

--- a/Tests/AWSSDKSwiftCoreTests/ValidationTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/ValidationTests.swift
@@ -16,9 +16,9 @@ import XCTest
 @testable import AWSSDKSwiftCore
 
 class ValidationTests: XCTestCase {
-    
+
     /// test validation
-    func testValidationFail(_ shape: AWSShape) {
+    func testValidationFail(_ shape: AWSEncodableShape) {
         do {
             try shape.validate()
             XCTFail()
@@ -28,19 +28,19 @@ class ValidationTests: XCTestCase {
             XCTFail(error.localizedDescription)
         }
     }
-    
-    func testValidationSuccess(_ shape: AWSShape) {
+
+    func testValidationSuccess(_ shape: AWSEncodableShape) {
         do {
             try shape.validate()
         } catch {
             XCTFail(error.localizedDescription)
         }
     }
-    
+
     func testNumericMinMaxValidation() {
-        struct A: AWSShape {
+        struct A: AWSEncodableShape {
             let size: Int?
-            
+
             public func validate(name: String) throws {
                 try validate(size, name:"size", parent: name, max: 100)
                 try validate(size, name:"size", parent: name, min: 1)
@@ -53,11 +53,11 @@ class ValidationTests: XCTestCase {
         let a3 = A(size: 1000)
         testValidationFail(a3)
     }
-    
+
     func testFloatingPointMinMaxValidation() {
-        struct A: AWSShape {
+        struct A: AWSEncodableShape {
             let size: Float?
-            
+
             public func validate(name: String) throws {
                 try validate(size, name:"size", parent: name, max: 50.0)
                 try validate(size, name:"size", parent: name, min: 1.0)
@@ -70,11 +70,11 @@ class ValidationTests: XCTestCase {
         let a3 = A(size: 1000)
         testValidationFail(a3)
     }
-    
+
     func testStringLengthMinMaxValidation() {
-        struct A: AWSShape {
+        struct A: AWSEncodableShape {
             let string: String?
-            
+
             public func validate(name: String) throws {
                 try validate(string, name:"string", parent: name, max: 24)
                 try validate(string, name:"string", parent: name, min: 2)
@@ -87,11 +87,11 @@ class ValidationTests: XCTestCase {
         let a3 = A(string: "a")
         testValidationFail(a3)
     }
-    
+
     func testArrayLengthMinMaxValidation() {
-        struct A: AWSShape {
+        struct A: AWSEncodableShape {
             let numbers: [Int]?
-            
+
             public func validate(name: String) throws {
                 try validate(numbers, name:"numbers", parent: name, max: 4)
                 try validate(numbers, name:"numbers", parent: name, min: 2)
@@ -104,11 +104,11 @@ class ValidationTests: XCTestCase {
         let a3 = A(numbers: [1])
         testValidationFail(a3)
     }
-    
+
     func testStringPatternValidation() {
-        struct A: AWSShape {
+        struct A: AWSEncodableShape {
             let string: String?
-            
+
             public func validate(name: String) throws {
                 try validate(string, name:"string", parent: name, pattern: "^[A-Za-z]{3}$")
             }
@@ -120,11 +120,11 @@ class ValidationTests: XCTestCase {
         let a3 = A(string: "a-c")
         testValidationFail(a3)
     }
-    
+
     func testStringPattern2Validation() {
-        struct A: AWSShape {
+        struct A: AWSEncodableShape {
             let path: String
-            
+
             public func validate(name: String) throws {
                 try validate(path, name:"path", parent: name, pattern: "((/[A-Za-z0-9\\.,\\+@=_-]+)*)/")
             }
@@ -139,7 +139,7 @@ class ValidationTests: XCTestCase {
         let a4 = A(path:"/%hello/test/")
         testValidationSuccess(a4)
     }
-    
+
     static var allTests : [(String, (ValidationTests) -> () throws -> Void)] {
         return [
             ("testNumericMinMaxValidation", testNumericMinMaxValidation),
@@ -151,4 +151,3 @@ class ValidationTests: XCTestCase {
         ]
     }
 }
-

--- a/Tests/AWSSDKSwiftCoreTests/XMLCoderTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/XMLCoderTests.swift
@@ -19,7 +19,7 @@ import XCTest
 
 class XMLCoderTests: XCTestCase {
     
-    struct Numbers : AWSShape {
+    struct Numbers : AWSDecodableShape & AWSEncodableShape {
 
        init(bool:Bool, integer:Int, float:Float, double:Double, intEnum:IntEnum) {
            self.bool = bool
@@ -61,7 +61,7 @@ class XMLCoderTests: XCTestCase {
        }
     }
 
-    struct StringShape : AWSShape {
+    struct StringShape : AWSDecodableShape & AWSEncodableShape {
        enum StringEnum : String, Codable {
            case first="first"
            case second="second"
@@ -73,7 +73,7 @@ class XMLCoderTests: XCTestCase {
        let stringEnum : StringEnum
     }
 
-    struct Arrays : AWSShape {
+    struct Arrays : AWSDecodableShape & AWSEncodableShape {
        public static var _encoding: [AWSMemberEncoding] = [
            AWSMemberEncoding(label: "ArrayOfNatives", encoding: .list(member: "member"))
        ]
@@ -82,7 +82,7 @@ class XMLCoderTests: XCTestCase {
        let arrayOfShapes : [Numbers]
     }
 
-    struct Dictionaries : AWSShape {
+    struct Dictionaries : AWSDecodableShape & AWSEncodableShape {
        public static var _encoding: [AWSMemberEncoding] = [
            AWSMemberEncoding(label: "natives", encoding: .map(entry: "entry", key: "key", value: "value")),
            AWSMemberEncoding(label: "shapes", encoding: .flatMap(key: "key", value: "value"))
@@ -96,7 +96,7 @@ class XMLCoderTests: XCTestCase {
        }
     }
 
-    struct Shape : AWSShape {
+    struct Shape : AWSDecodableShape & AWSEncodableShape {
        let numbers : Numbers
        let stringShape : StringShape
        let arrays : Arrays
@@ -108,7 +108,7 @@ class XMLCoderTests: XCTestCase {
        }
     }
 
-    struct ShapeWithDictionaries : AWSShape {
+    struct ShapeWithDictionaries : AWSDecodableShape & AWSEncodableShape {
        let shape : Shape
        let dictionaries : Dictionaries
 
@@ -131,7 +131,7 @@ class XMLCoderTests: XCTestCase {
     }
 
     /// helper test function to use throughout all the decode/encode tests
-    func testDecode<T : Codable>(type: T.Type, xml: String) -> T? {
+    func testDecode<T : Decodable>(type: T.Type, xml: String) -> T? {
         do {
             let xmlDocument = try XML.Document(data: xml.data(using: .utf8)!)
             let rootElement = xmlDocument.rootElement()
@@ -322,7 +322,7 @@ class XMLCoderTests: XCTestCase {
     }
 
     func testDecodeExpandedContainers() {
-        struct Shape : AWSShape {
+        struct Shape : AWSDecodableShape {
             static let _encoding = [
                 AWSMemberEncoding(label: "array", encoding:.list(member: "member")),
                 AWSMemberEncoding(label: "dictionary", encoding:.map(entry: "entry", key: "key", value: "value"))
@@ -338,7 +338,7 @@ class XMLCoderTests: XCTestCase {
     }
 
     func testArrayEncodingDecodeEncode() {
-        struct Shape : AWSShape {
+        struct Shape : AWSDecodableShape & AWSEncodableShape {
             static let _encoding = [AWSMemberEncoding(label: "array", encoding:.list(member: "member"))]
             let array : [Int]
         }
@@ -347,10 +347,10 @@ class XMLCoderTests: XCTestCase {
     }
     
     func testArrayOfStructuresEncodingDecodeEncode() {
-        struct Shape2 : AWSShape {
+        struct Shape2 : AWSDecodableShape & AWSEncodableShape {
             let value : String
         }
-        struct Shape : AWSShape {
+        struct Shape : AWSDecodableShape & AWSEncodableShape {
             static let _encoding = [AWSMemberEncoding(label: "array", encoding:.list(member: "member"))]
             let array : [Shape2]
         }
@@ -359,7 +359,7 @@ class XMLCoderTests: XCTestCase {
     }
     
     func testDictionaryEncodingDecodeEncode() {
-        struct Shape : AWSShape {
+        struct Shape : AWSDecodableShape & AWSEncodableShape {
             static let _encoding = [AWSMemberEncoding(label: "d", encoding:.map(entry:"item", key: "key", value: "value"))]
             let d : [String:Int]
         }
@@ -368,10 +368,10 @@ class XMLCoderTests: XCTestCase {
     }
     
     func testDictionaryOfStructuresEncodingDecodeEncode() {
-        struct Shape2 : AWSShape {
+        struct Shape2 : AWSDecodableShape & AWSEncodableShape {
             let float : Float
         }
-        struct Shape : AWSShape {
+        struct Shape : AWSDecodableShape & AWSEncodableShape {
             static let _encoding = [AWSMemberEncoding(label: "d", encoding:.map(entry:"item", key: "key", value: "value"))]
             let d : [String:Shape2]
         }
@@ -380,7 +380,7 @@ class XMLCoderTests: XCTestCase {
     }
     
     func testFlatDictionaryEncodingDecodeEncode() {
-        struct Shape : AWSShape {
+        struct Shape : AWSDecodableShape & AWSEncodableShape {
             static let _encoding = [AWSMemberEncoding(label: "d", encoding:.flatMap(key: "key", value: "value"))]
             let d : [String:Int]
         }
@@ -393,7 +393,7 @@ class XMLCoderTests: XCTestCase {
             case member = "member"
             case member2 = "member2"
         }
-        struct Shape : AWSShape {
+        struct Shape : AWSDecodableShape & AWSEncodableShape {
             static let _encoding = [AWSMemberEncoding(label: "d", encoding:.map(entry:"item", key: "key", value: "value"))]
             let d : [KeyEnum: Int]
         }
@@ -406,10 +406,10 @@ class XMLCoderTests: XCTestCase {
             case member = "member"
             case member2 = "member2"
         }
-        struct Shape2 : AWSShape {
+        struct Shape2 : AWSDecodableShape & AWSEncodableShape {
             let a: String
         }
-        struct Shape : AWSShape {
+        struct Shape : AWSDecodableShape & AWSEncodableShape {
             static let _encoding = [AWSMemberEncoding(label: "d", encoding:.map(entry:"item", key: "k", value: "v"))]
             let d : [KeyEnum: Shape2]
         }
@@ -422,7 +422,7 @@ class XMLCoderTests: XCTestCase {
             case member = "member"
             case member2 = "member2"
         }
-        struct Shape : AWSShape {
+        struct Shape : AWSDecodableShape & AWSEncodableShape {
             static let _encoding = [AWSMemberEncoding(label: "d", encoding:.flatMap(key: "key", value: "value"))]
             let d : [KeyEnum:Int]
         }


### PR DESCRIPTION
You can find the associated aws-sdk-swift PR [here](https://github.com/swift-aws/aws-sdk-swift/pull/253).

This means we don't generate unnecessary codable code. Requests only need to be encodable and responses only need to be decodable.

This also allows us to remove coding keys for header, query and uri variables for requests as they are not needed for the encode (decode requires them).