### PR TITLE
Fix QueryEncoder for Data blob AWSShapeMember

### DIFF
--- a/Sources/AWSSDKSwiftCore/Encoder/AWSShapeEncoder.swift
+++ b/Sources/AWSSDKSwiftCore/Encoder/AWSShapeEncoder.swift
@@ -121,7 +121,7 @@ class AWSShapeEncoder {
                         dictionary["\(fullLabel).\(entryString)\(iterator.offset+1).\(valueString)"] = iterator.element.value
                     }
                 case let v as Data:
-                    dictionary[fullLabel] = String(decoding: v, as: UTF8.self)
+                    dictionary[fullLabel] = v.base64EncodedString()
                 default:
                     dictionary[fullLabel] = value
                 }

--- a/Sources/AWSSDKSwiftCore/Encoder/AWSShapeEncoder.swift
+++ b/Sources/AWSSDKSwiftCore/Encoder/AWSShapeEncoder.swift
@@ -120,7 +120,8 @@ class AWSShapeEncoder {
                         dictionary["\(fullLabel).\(entryString)\(iterator.offset+1).\(keyString)"] = iterator.element.key
                         dictionary["\(fullLabel).\(entryString)\(iterator.offset+1).\(valueString)"] = iterator.element.value
                     }
-                
+                case let v as Data:
+                    dictionary[fullLabel] = String(decoding: v, as: UTF8.self)
                 default:
                     dictionary[fullLabel] = value
                 }

--- a/Tests/AWSSDKSwiftCoreTests/QueryEncoderTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/QueryEncoderTests.swift
@@ -13,7 +13,7 @@ class QueryEncoderTests: XCTestCase {
 
     func queryString(dictionary:[String:Any]) -> String? {
         var components = URLComponents()
-        components.queryItems = dictionary.map( {URLQueryItem(name:$0.key, value:String(describing: $0.value))} ).sorted(by: { $0.name < $1.name })
+        components.queryItems = dictionary.map( {URLQueryItem(name:$0.key, value:String(describing: $0.value).addingPercentEncoding(withAllowedCharacters: AWSClient.queryAllowedCharacters)!)} ).sorted(by: { $0.name < $1.name })
         if components.queryItems != nil, let url = components.url {
             return url.query
         }
@@ -134,7 +134,7 @@ class QueryEncoderTests: XCTestCase {
             let a : Data
         }
         let test = Test(a:Data("Testing".utf8))
-        testQuery(test, query:"A=Testing")
+        testQuery(test, query:"A=VGVzdGluZw%253D%253D")
     }
 
     static var allTests : [(String, (QueryEncoderTests) -> () throws -> Void)] {

--- a/Tests/AWSSDKSwiftCoreTests/QueryEncoderTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/QueryEncoderTests.swift
@@ -128,6 +128,15 @@ class QueryEncoderTests: XCTestCase {
         testQuery(test, query:"A.1.entry=1&A.1.name=first")
     }
     
+    func testDataBlobEncode() {
+        struct Test : AWSShape {
+            static let _members = [AWSShapeMember(label: "A", required: true, type: .blob)]
+            let a : Data
+        }
+        let test = Test(a:Data("Testing".utf8))
+        testQuery(test, query:"A=Testing")
+    }
+
     static var allTests : [(String, (QueryEncoderTests) -> () throws -> Void)] {
         return [
             ("testSimpleStructureEncode", testSimpleStructureEncode),
@@ -140,6 +149,7 @@ class QueryEncoderTests: XCTestCase {
             ("testArrayEncodingEncode", testArrayEncodingEncode),
             ("testDictionaryEncodingEncode", testDictionaryEncodingEncode),
             ("testDictionaryEncodingEncode2", testDictionaryEncodingEncode2),
+            ("testDataBlobEncode", testDataBlobEncode),
         ]
     }
 }

--- a/Tests/AWSSDKSwiftCoreTests/QueryEncoderTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/QueryEncoderTests.swift
@@ -13,7 +13,7 @@ class QueryEncoderTests: XCTestCase {
 
     func queryString(dictionary:[String:Any]) -> String? {
         var components = URLComponents()
-        components.queryItems = dictionary.map( {URLQueryItem(name:$0.key, value:String(describing: $0.value).addingPercentEncoding(withAllowedCharacters: AWSClient.queryAllowedCharacters)!)} ).sorted(by: { $0.name < $1.name })
+        components.queryItems = dictionary.map( {URLQueryItem(name:$0.key, value:String(describing: $0.value))} ).sorted(by: { $0.name < $1.name })
         if components.queryItems != nil, let url = components.url {
             return url.query
         }
@@ -134,7 +134,7 @@ class QueryEncoderTests: XCTestCase {
             let a : Data
         }
         let test = Test(a:Data("Testing".utf8))
-        testQuery(test, query:"A=VGVzdGluZw%253D%253D")
+        testQuery(test, query:"A=VGVzdGluZw%3D%3D")
     }
 
     static var allTests : [(String, (QueryEncoderTests) -> () throws -> Void)] {


### PR DESCRIPTION
Hi, there

The email subject is empty when I send raw email via [SES.sendRawEmail](https://github.com/swift-aws/aws-sdk-swift/blob/4.x.x/Sources/AWSSDKSwift/Services/SES/SES_API.swift#L294), because the request body "RawMessage.Data" is like "xx bytes".

This PR make a AWSShape same as [SES.RawMessage](https://github.com/swift-aws/aws-sdk-swift/blob/4.x.x/Sources/AWSSDKSwift/Services/SES/SES_Shapes.swift#L2199), and tested it.

Please review it. thank you.

