### PR TITLE
Payload Object

### DIFF
--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -383,10 +383,12 @@ extension AWSClient {
             if let payload = (Input.self as? AWSShapeWithPayload.Type)?.payloadPath {
                 if let payloadBody = mirror.getAttribute(forKey: payload) {
                     switch payloadBody {
+                    case let awsPayload as AWSPayload:
+                        body = Body(awsPayload)
                     case let shape as AWSEncodableShape:
                         body = .json(try shape.encodeAsJSON())
                     default:
-                        body = Body(anyValue: payloadBody)
+                        preconditionFailure("Cannot add this as a payload")
                     }
                 } else {
                     body = .empty
@@ -417,6 +419,8 @@ extension AWSClient {
             if let payload = (Input.self as? AWSShapeWithPayload.Type)?.payloadPath {
                 if let payloadBody = mirror.getAttribute(forKey: payload) {
                     switch payloadBody {
+                    case let awsPayload as AWSPayload:
+                        body = Body(awsPayload)
                     case let shape as AWSEncodableShape:
                         var rootName: String? = nil
                         // extract custom payload name
@@ -425,7 +429,7 @@ extension AWSClient {
                         }
                         body = .xml(try shape.encodeAsXML(rootName: rootName))
                     default:
-                        body = Body(anyValue: payloadBody)
+                        preconditionFailure("Cannot add this as a payload")
                     }
                 } else {
                     body = .empty
@@ -468,7 +472,7 @@ extension AWSClient {
             urlString.append("?")
             urlString.append(queryParams.map{"\($0.key)=\(urlEncodeQueryParam("\($0.value)"))"}.sorted().joined(separator:"&"))
         }
-        
+
         guard let url = URL(string: urlString) else {
             throw RequestError.invalidURL("\(urlString)")
         }
@@ -485,7 +489,7 @@ extension AWSClient {
     }
 
     static let queryAllowedCharacters = CharacterSet(charactersIn:"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~:/")
-    
+
     fileprivate func urlEncodeQueryParam(_ value: String) -> String {
         return value.addingPercentEncoding(withAllowedCharacters: AWSClient.queryAllowedCharacters) ?? value
     }

--- a/Sources/AWSSDKSwiftCore/AWSShapes/Payload.swift
+++ b/Sources/AWSSDKSwiftCore/AWSShapes/Payload.swift
@@ -1,0 +1,44 @@
+//
+//  Payload.swift
+//  AWSSDKCore
+//
+//  Created by Adam Fowler on 2020/03/01.
+//
+import struct Foundation.Data
+import NIO
+
+public struct AWSPayload {
+    
+    public static func byteBuffer(_ byteBuffer: ByteBuffer) -> Self {
+        return Self(byteBuffer: byteBuffer)
+    }
+    
+    public static func data(_ data: Data) -> Self {
+        var byteBuffer = ByteBufferAllocator().buffer(capacity: data.count)
+        byteBuffer.writeBytes(data)
+        return Self(byteBuffer: byteBuffer)
+    }
+    
+    public static func string(_ string: String) -> Self {
+        var byteBuffer = ByteBufferAllocator().buffer(capacity: string.utf8.count)
+        byteBuffer.writeString(string)
+        return Self(byteBuffer: byteBuffer)
+    }
+
+    let byteBuffer: ByteBuffer
+}
+
+// The decode/encode functions are here temporarily until we merge in https://github.com/swift-aws/aws-sdk-swift-core/pull/214. After that we
+// should be able to remove them
+extension AWSPayload: Codable {
+    
+    // AWSPayload has to comform to Codable so I can add it to AWSShape objects (which conform to Codable). But we don't want the
+    // Encoder/Decoder ever to process a AWSPayload
+    public init(from decoder: Decoder) throws {
+        preconditionFailure("Cannot decode an AWSPayload")
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        preconditionFailure("Cannot encode an AWSPayload")
+    }
+}

--- a/Sources/AWSSDKSwiftCore/AWSShapes/Payload.swift
+++ b/Sources/AWSSDKSwiftCore/AWSShapes/Payload.swift
@@ -27,18 +27,3 @@ public struct AWSPayload {
 
     let byteBuffer: ByteBuffer
 }
-
-// The decode/encode functions are here temporarily until we merge in https://github.com/swift-aws/aws-sdk-swift-core/pull/214. After that we
-// should be able to remove them
-extension AWSPayload: Codable {
-    
-    // AWSPayload has to comform to Codable so I can add it to AWSShape objects (which conform to Codable). But we don't want the
-    // Encoder/Decoder ever to process a AWSPayload
-    public init(from decoder: Decoder) throws {
-        preconditionFailure("Cannot decode an AWSPayload")
-    }
-    
-    public func encode(to encoder: Encoder) throws {
-        preconditionFailure("Cannot encode an AWSPayload")
-    }
-}

--- a/Sources/AWSSDKSwiftCore/Message/Body.swift
+++ b/Sources/AWSSDKSwiftCore/Message/Body.swift
@@ -32,20 +32,8 @@ public enum Body {
 }
 
 extension Body {
-    /// initialize Body with Any. If it is Data, create .buffer() otherwise create a String describing the value
-    init(anyValue: Any) {
-        switch anyValue {
-        case let data as Data:
-            var byteBuffer = ByteBufferAllocator().buffer(capacity: data.count)
-            byteBuffer.writeBytes(data)
-            self = .buffer(byteBuffer)
-            
-        case let byteBuffer as ByteBuffer:
-            self = .buffer(byteBuffer)
-            
-        default:
-            self = .text("\(anyValue)")
-        }
+    init(_ payload: AWSPayload) {
+        self = .buffer(payload.byteBuffer)
     }
 
     /// return as a raw data buffer

--- a/Tests/AWSSDKSwiftCoreTests/PayloadTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/PayloadTests.swift
@@ -1,0 +1,91 @@
+//
+//  PayloadTests.swift
+//  AWSSDKSwift
+//
+//  Created by Adam Fowler 2020/03/01
+//
+//
+
+import NIO
+import XCTest
+@testable import AWSSDKSwiftCore
+
+class PayloadTests: XCTestCase {
+
+    func testDataRequestPayload() {
+        struct DataPayload: AWSShape {
+            static var payloadPath: String? = "data"
+            let data: AWSPayload
+        }
+        
+        do {
+            let awsServer = AWSTestServer(serviceProtocol: .json)
+            let client = AWSClient(
+                accessKeyId: "",
+                secretAccessKey: "",
+                region: .useast1,
+                service:"TestClient",
+                serviceProtocol: ServiceProtocol(type: .json, version: ServiceProtocol.Version(major: 1, minor: 1)),
+                apiVersion: "2020-01-21",
+                endpoint: awsServer.address,
+                middlewares: [AWSLoggingMiddleware()],
+                eventLoopGroupProvider: .useAWSClientShared
+            )
+            let input = DataPayload(data: .string("testDataPayload"))
+            let response = client.send(operation: "test", path: "/", httpMethod: "POST", input: input)
+
+            try awsServer.process { request in
+                XCTAssertEqual(request.body.getString(at: 0, length: request.body.readableBytes), "testDataPayload")
+                return AWSTestServer.Result(output: .ok, continueProcessing: false)
+            }
+
+            try response.wait()
+            try awsServer.stop()
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+    
+    func testByteBufferRequestPayload() {
+        struct DataPayload: AWSShape {
+            static var payloadPath: String? = "data"
+            let data: AWSPayload
+        }
+        
+        do {
+            let awsServer = AWSTestServer(serviceProtocol: .json)
+            let client = AWSClient(
+                accessKeyId: "",
+                secretAccessKey: "",
+                region: .useast1,
+                service:"TestClient",
+                serviceProtocol: ServiceProtocol(type: .json, version: ServiceProtocol.Version(major: 1, minor: 1)),
+                apiVersion: "2020-01-21",
+                endpoint: awsServer.address,
+                middlewares: [AWSLoggingMiddleware()],
+                eventLoopGroupProvider: .useAWSClientShared
+            )
+            var byteBuffer = ByteBufferAllocator().buffer(capacity: 32)
+            byteBuffer.writeString("testByteBufferPayload")
+            let input = DataPayload(data:.byteBuffer(byteBuffer))
+            let response = client.send(operation: "test", path: "/", httpMethod: "POST", input: input)
+
+            try awsServer.process { request in
+                XCTAssertEqual(request.body.getString(at: 0, length: request.body.readableBytes), "testByteBufferPayload")
+                return AWSTestServer.Result(output: .ok, continueProcessing: false)
+            }
+
+            try response.wait()
+            try awsServer.stop()
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+    
+    static var allTests : [(String, (PayloadTests) -> () throws -> Void)] {
+        return [
+            ("testDataRequestPayload", testDataRequestPayload),
+            ("testByteBufferRequestPayload", testByteBufferRequestPayload),
+        ]
+    }
+}

--- a/Tests/AWSSDKSwiftCoreTests/PayloadTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/PayloadTests.swift
@@ -13,9 +13,11 @@ import XCTest
 class PayloadTests: XCTestCase {
 
     func testDataRequestPayload() {
-        struct DataPayload: AWSShape {
+        struct DataPayload: AWSEncodableShape & AWSShapeWithPayload {
             static var payloadPath: String? = "data"
             let data: AWSPayload
+            
+            private enum CodingKeys: CodingKey {}
         }
         
         do {
@@ -47,9 +49,11 @@ class PayloadTests: XCTestCase {
     }
     
     func testByteBufferRequestPayload() {
-        struct DataPayload: AWSShape {
+        struct DataPayload: AWSEncodableShape & AWSShapeWithPayload {
             static var payloadPath: String? = "data"
             let data: AWSPayload
+            
+            private enum CodingKeys: CodingKey {}
         }
         
         do {

--- a/Tests/AWSSDKSwiftCoreTests/QueryEncoderTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/QueryEncoderTests.swift
@@ -205,7 +205,7 @@ class QueryEncoderTests: XCTestCase {
         let test = Test(a:[9,8,7,6,5,4,3])
         measure {
             do {
-                for _ in 1...10000 {
+                for _ in 1...1000 {
                     _ = try QueryEncoder().encode(test)
                 }
             } catch {

--- a/Tests/AWSSDKSwiftCoreTests/TestServer.swift
+++ b/Tests/AWSSDKSwiftCoreTests/TestServer.swift
@@ -47,7 +47,16 @@ class AWSTestServer {
         let httpStatus: HTTPResponseStatus
         let headers: [String: String]
         let body: ByteBuffer?
+        
+        init(httpStatus: HTTPResponseStatus, headers: [String: String] = [:], body: ByteBuffer? = nil) {
+            self.httpStatus = httpStatus
+            self.headers = headers
+            self.body = body
+        }
+        
+        static let ok = Response(httpStatus: .ok)
     }
+
     // result from process
     struct Result<Output>{
         let output: Output


### PR DESCRIPTION
Associated PR in aws-sdk-swift is https://github.com/swift-aws/aws-sdk-swift/pull/257

Add a `AWSPayload` object for data blob payloads in requests. The internal representation is ByteBuffer but allow it to be initialised with `Data`, `ByteBuffer` or `String`. While the user still has the ability to create a payload from a `Data` object as before, they can also supply a `ByteBuffer` which they may have received from another process eg `NIONonBlockingFileIO`.

NB This also removes `Body.init(anyValue: Any)`