### PR TITLE
Error handling for restjson and EC2

### DIFF
--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -693,6 +693,9 @@ extension AWSClient {
 
         case .restjson:
             code = response.headers["x-amzn-ErrorType"] as? String
+            if code == nil {
+                code = bodyDict.filter({ $0.key.lowercased() == "code" }).first?.value as? String
+            }
             message = bodyDict.filter({ $0.key.lowercased() == "message" }).first?.value as? String
 
         case .json:

--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -699,8 +699,14 @@ extension AWSClient {
             code = bodyDict["__type"] as? String
             message = bodyDict.filter({ $0.key.lowercased() == "message" }).first?.value as? String
 
-        default:
-            break
+        case .other(let service):
+            if service == "ec2" {
+                guard case .xml(let element) = response.body else { break }
+                guard let errors = element.elements(forName: "Errors").first else { break }
+                guard let error = errors.elements(forName: "Error").first else { break }
+                code = error.elements(forName: "Code").first?.stringValue
+                message = error.elements(forName: "Message").first?.stringValue
+            }
         }
 
         if let errorCode = code {


### PR DESCRIPTION
- If restjson service cannot find error code in "x-amzn-ErrorType" header check response body
- Process EC2 errors so we return error codes