### PR TITLE
Query encoder and Data

### DIFF
--- a/Sources/AWSSDKSwiftCore/Encoder/QueryEncoder.swift
+++ b/Sources/AWSSDKSwiftCore/Encoder/QueryEncoder.swift
@@ -5,6 +5,8 @@
 //  Created by Adam Fowler on 2020/01/28.
 //
 //
+import struct Foundation.Data
+import class Foundation.NSData
 
 /// A marker protocols used to determine whether a value is a `Dictionary` or an `Array`
 fileprivate protocol _QueryDictionaryEncodableMarker { }
@@ -335,6 +337,10 @@ extension _QueryEncoder {
         }
     }
 
+    func box(_ data: Data) throws {
+        try encode(data.base64EncodedString())
+    }
+    
     func box(_ value: Encodable) throws {
         // store previous container coding map to revert on function exit
         let prevContainerCodingOwner = self.containerCodingMapType
@@ -342,6 +348,11 @@ extension _QueryEncoder {
         // set the current container coding map
         let containerCodingMap = value as? XMLCodable
         containerCodingMapType = containerCodingMap != nil ? Swift.type(of:containerCodingMap!) : nil
+
+        let type = Swift.type(of: value)
+        if type == Data.self || type == NSData.self {
+            return try self.box((value as! Data))
+        }
         
         try value.encode(to: self)
     }

--- a/Tests/AWSSDKSwiftCoreTests/QueryEncoderTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/QueryEncoderTests.swift
@@ -206,6 +206,18 @@ class QueryEncoderTests: XCTestCase {
         }
     }
     
+    func testDataBlobEncode() {
+        struct Test : AWSShape {
+            let a : Data
+        }
+        let data = Data("Testing".utf8)
+        let test = Test(a:data)
+        
+        var components = URLComponents()
+        components.queryItems = [URLQueryItem(name: "a", value: data.base64EncodedString())]
+        testQuery(test, query: components.url!.query!)
+    }
+
     static var allTests : [(String, (QueryEncoderTests) -> () throws -> Void)] {
         return [
             ("testSimpleStructureEncode", testSimpleStructureEncode),
@@ -218,6 +230,7 @@ class QueryEncoderTests: XCTestCase {
             ("testArrayEncodingEncode", testArrayEncodingEncode),
             ("testDictionaryEncodingEncode", testDictionaryEncodingEncode),
             ("testDictionaryEncodingEncode2", testDictionaryEncodingEncode2),
+            ("testDataBlobEncode", testDataBlobEncode)
         ]
     }
 }

--- a/Tests/AWSSDKSwiftCoreTests/QueryEncoderTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/QueryEncoderTests.swift
@@ -212,10 +212,8 @@ class QueryEncoderTests: XCTestCase {
         }
         let data = Data("Testing".utf8)
         let test = Test(a:data)
-        
-        var components = URLComponents()
-        components.queryItems = [URLQueryItem(name: "a", value: data.base64EncodedString())]
-        testQuery(test, query: components.url!.query!)
+        let result = queryString(dictionary: ["a": data.base64EncodedString()])!
+        testQuery(test, query: result)
     }
 
     static var allTests : [(String, (QueryEncoderTests) -> () throws -> Void)] {


### PR DESCRIPTION
The query encoder should encode `Foundation.Data` as base64