### PR TITLE
Added possibility of arbituary named regions

### DIFF
--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -102,10 +102,10 @@ public final class AWSClient {
         if let _region = givenRegion {
             region = _region
         }
-        else if let partitionEndpoint = partitionEndpoint, let reg = Region(rawValue: partitionEndpoint) {
-            region = reg
-        } else if let defaultRegion = ProcessInfo.processInfo.environment["AWS_DEFAULT_REGION"], let reg = Region(rawValue: defaultRegion) {
-            region = reg
+        else if let partitionEndpoint = partitionEndpoint {
+            region = Region(rawValue: partitionEndpoint)
+        } else if let defaultRegion = ProcessInfo.processInfo.environment["AWS_DEFAULT_REGION"] {
+            region = Region(rawValue: defaultRegion)
         } else {
             region = .useast1
         }

--- a/Sources/AWSSDKSwiftCore/Doc/Region.swift
+++ b/Sources/AWSSDKSwiftCore/Doc/Region.swift
@@ -12,23 +12,114 @@
 //
 //===----------------------------------------------------------------------===//
 
-public enum Region: String {
-    case useast1 = "us-east-1"
-    case useast2 = "us-east-2"
-    case uswest1 = "us-west-1"
-    case uswest2 = "us-west-2"
-    case apsouth1 = "ap-south-1"
-    case apnortheast2 = "ap-northeast-2"
-    case apsoutheast1 = "ap-southeast-1"
-    case apsoutheast2 = "ap-southeast-2"
-    case apnortheast1 = "ap-northeast-1"
-    case apeast1 = "ap-east-1"
-    case cacentral1 = "ca-central-1"
-    case euwest1 = "eu-west-1"
-    case euwest3 = "eu-west-3"
-    case euwest2 = "eu-west-2"
-    case eucentral1 = "eu-central-1"
-    case eunorth1 = "eu-north-1"
-    case saeast1 = "sa-east-1"
-    case mesouth1 = "me-south-1"
+public enum Region {
+    case useast1
+    case useast2
+    case uswest1
+    case uswest2
+    case apsouth1
+    case apnortheast2
+    case apsoutheast1
+    case apsoutheast2
+    case apnortheast1
+    case apeast1
+    case cacentral1
+    case euwest1
+    case euwest3
+    case euwest2
+    case eucentral1
+    case eunorth1
+    case saeast1
+    case mesouth1
+    case other(String)
+}
+
+extension Region {
+    
+    init(rawValue: String) {
+        switch rawValue {
+        case "us-east-1":
+            self = .useast1
+        case "us-east-2":
+            self = .useast2
+        case "us-west-1":
+            self = .uswest1
+        case "us-west-2":
+            self = .uswest2
+        case "ap-south-1":
+            self = .apsouth1
+        case "ap-northeast-2":
+            self = .apnortheast2
+        case "ap-southeast-1":
+            self = .apsoutheast1
+        case "ap-southeast-2":
+            self = .apsoutheast2
+        case "ap-northeast-1":
+            self = .apnortheast1
+        case "ap-east-1":
+            self = .apeast1
+        case "ca-central-1":
+            self = .cacentral1
+        case "eu-west-1":
+            self = .euwest1
+        case "eu-west-3":
+            self = .euwest3
+        case "eu-west-2":
+            self = .euwest2
+        case "eu-central-1":
+            self = .eucentral1
+        case "eu-north-1":
+            self = .eunorth1
+        case "sa-east-1":
+            self = .saeast1
+        case "me-south-1":
+            self = .mesouth1
+        default:
+            self = .other(rawValue)
+        }
+
+    }
+    
+    var rawValue: String {
+        switch self {
+        case .useast1:
+            return "us-east-1"
+        case .useast2:
+            return "us-east-2"
+        case .uswest1:
+            return "us-west-1"
+        case .uswest2:
+            return "us-west-2"
+        case .apsouth1:
+            return "ap-south-1"
+        case .apnortheast2:
+            return "ap-northeast-2"
+        case .apsoutheast1:
+            return "ap-southeast-1"
+        case .apsoutheast2:
+            return "ap-southeast-2"
+        case .apnortheast1:
+            return "ap-northeast-1"
+        case .apeast1:
+            return "ap-east-1"
+        case .cacentral1:
+            return "ca-central-1"
+        case .euwest1:
+            return "eu-west-1"
+        case .euwest3:
+            return "eu-west-3"
+        case .euwest2:
+            return "eu-west-2"
+        case .eucentral1:
+            return "eu-central-1"
+        case .eunorth1:
+            return "eu-north-1"
+        case .saeast1:
+            return "sa-east-1"
+        case .mesouth1:
+            return "me-south-1"
+        case .other(let string):
+            return string
+        }
+    }
 }

--- a/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
@@ -493,7 +493,7 @@ class AWSClientTests: XCTestCase {
             headers: ["header-member": "test-header"],
             bodyData: nil
         )
-        
+
         // XML
         do {
             let result: Output = try sesClient.validate(operation: "Test", response: response)
@@ -501,7 +501,7 @@ class AWSClientTests: XCTestCase {
         } catch {
             XCTFail("\(error)")
         }
-        
+
         // JSON
         do {
             let result: Output = try kinesisClient.validate(operation: "Test", response: response)
@@ -521,7 +521,7 @@ class AWSClientTests: XCTestCase {
             headers: HTTPHeaders(),
             bodyData: nil
         )
-        
+
         // XML
         do {
             let result: Output = try s3Client.validate(operation: "Test", response: response)
@@ -1020,6 +1020,44 @@ class AWSClientTests: XCTestCase {
             XCTAssertEqual(error.message, "It doesn't exist")
         } catch {
             XCTFail("Throwing the wrong error")
+        }
+    }
+
+    func testRegionEnum() {
+        let regions = [
+            "us-east-1",
+            "us-east-2",
+            "us-west-1",
+            "us-west-2",
+            "ap-south-1",
+            "ap-northeast-2",
+            "ap-southeast-1",
+            "ap-southeast-2",
+            "ap-northeast-1",
+            "ap-east-1",
+            "ca-central-1",
+            "eu-west-1",
+            "eu-west-3",
+            "eu-west-2",
+            "eu-central-1",
+            "eu-north-1",
+            "sa-east-1",
+            "me-south-1"
+        ]
+        regions.forEach {
+            let region = Region(rawValue: $0)
+            if case .other(_) = region {
+                XCTFail("\($0) is not a region")
+            }
+            let rawValue = region.rawValue
+            XCTAssertEqual(rawValue, $0)
+        }
+
+        let region = Region(rawValue: "my-region")
+        if case .other(let regionName) = region {
+            XCTAssertEqual(regionName, "my-region")
+        } else {
+            XCTFail("Did not construct Region.other()")
         }
     }
 }


### PR DESCRIPTION
Allow users to provide an arbituary region name using enum case Region.other(String). See #226

This has meant we have had to add our own version of `init(rawValue)` and `rawValue`.