### PR TITLE
Remove unnecessary public symbols

### DIFF
--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -304,7 +304,7 @@ extension AWSClient {
 
     internal func createAWSRequest(operation operationName: String, path: String, httpMethod: String) throws -> AWSRequest {
 
-        guard let url = URL(string: "\(endpoint)\(path)"), let _ = url.hostWithPort else {
+        guard let url = URL(string: "\(endpoint)\(path)"), let _ = url.host else {
             throw RequestError.invalidURL("\(endpoint)\(path) must specify url host and scheme")
         }
 
@@ -328,7 +328,7 @@ extension AWSClient {
         // validate input parameters
         try input.validate()
 
-        guard let baseURL = URL(string: "\(endpoint)"), let _ = baseURL.hostWithPort else {
+        guard let baseURL = URL(string: "\(endpoint)"), let _ = baseURL.host else {
             throw RequestError.invalidURL("\(endpoint) must specify url host and scheme")
         }
 
@@ -735,18 +735,6 @@ extension AWSClient.RequestError: CustomStringConvertible {
             This error is internal. So please make a issue on https://github.com/noppoMan/aws-sdk-swift/issues to solve it.
             """
         }
-    }
-}
-
-extension URL {
-    var hostWithPort: String? {
-        guard var host = self.host else {
-            return nil
-        }
-        if let port = self.port {
-            host+=":\(port)"
-        }
-        return host
     }
 }
 

--- a/Sources/AWSSDKSwiftCore/Encoder/DictionaryDecoder.swift
+++ b/Sources/AWSSDKSwiftCore/Encoder/DictionaryDecoder.swift
@@ -36,20 +36,9 @@ import class  Foundation.NSDate
 
 /// A marker protocol used to determine whether a value is a `String`-keyed `Dictionary`
 /// containing `Decodable` values (in which case it should be exempt from key conversion strategies).
-///
-/// The marker protocol also provides access to the type of the `Decodable` values,
-/// which is needed for the implementation of the key conversion strategy exemption.
-///
-/// NOTE: Please see comment above regarding SR-8276
-#if arch(i386) || arch(arm)
-internal protocol _DictionaryStringDictionaryDecodableMarker {
-    static var elementType: Decodable.Type { get }
-}
-#else
 fileprivate protocol _DictionaryStringDictionaryDecodableMarker {
     static var elementType: Decodable.Type { get }
 }
-#endif
 
 extension Dictionary : _DictionaryStringDictionaryDecodableMarker where Key == String, Value: Decodable {
     static var elementType: Decodable.Type { return Value.self }
@@ -60,7 +49,7 @@ extension Dictionary : _DictionaryStringDictionaryDecodableMarker where Key == S
 //===----------------------------------------------------------------------===//
 
 /// `DictionaryDecoder` facilitates the decoding of Dictionaries into semantic `Decodable` types.
-open class DictionaryDecoder {
+class DictionaryDecoder {
     // MARK: Options
     
     /// The strategy to use for decoding `Date` values.

--- a/Sources/AWSSDKSwiftCore/Encoder/QueryEncoder.swift
+++ b/Sources/AWSSDKSwiftCore/Encoder/QueryEncoder.swift
@@ -16,7 +16,7 @@ extension Dictionary : _QueryDictionaryEncodableMarker where Value: Decodable { 
 extension Array : _QueryArrayEncodableMarker where Element: Decodable { }
 
 /// The wrapper class for encoding Codable classes to Query dictionary
-public class QueryEncoder {
+class QueryEncoder {
 
     /// The strategy to use for encoding Arrays
     open var arrayEncodingStrategy: XMLContainerCoding = .array(entry:nil)

--- a/Sources/AWSSDKSwiftCore/Encoder/XMLDecoder.swift
+++ b/Sources/AWSSDKSwiftCore/Encoder/XMLDecoder.swift
@@ -37,24 +37,14 @@ public protocol XMLCodable: Codable {
 }
 
 /// A marker protocols used to determine whether a value is a `Dictionary` or an `Array`
-///
-/// NOTE: The architecture and environment check is due to a bug in the current (2018-08-08) Swift 4.2
-/// runtime when running on i386 simulator. The issue is tracked in https://bugs.swift.org/browse/SR-8276
-/// Making the protocol `internal` instead of `fileprivate` works around this issue.
-/// Once SR-8276 is fixed, this check can be removed and the protocol always be made fileprivate.
-#if arch(i386) || arch(arm)
-internal protocol _XMLDictionaryDecodableMarker { }
-internal protocol _XMLArrayDecodableMarker { }
-#else
 fileprivate protocol _XMLDictionaryDecodableMarker { }
 fileprivate protocol _XMLArrayDecodableMarker { }
-#endif
 
 extension Dictionary : _XMLDictionaryDecodableMarker where Value: Decodable { }
 extension Array : _XMLArrayDecodableMarker where Element: Decodable { }
 
 /// The wrapper class for decoding Codable classes from XMLNodes
-public class XMLDecoder {
+class XMLDecoder {
     
     /// The strategy to use for decoding `Date` values.
     public enum DateDecodingStrategy {

--- a/Sources/AWSSDKSwiftCore/Encoder/XMLEncoder.swift
+++ b/Sources/AWSSDKSwiftCore/Encoder/XMLEncoder.swift
@@ -18,24 +18,14 @@ import class  Foundation.NSDate
 import class  Foundation.NSData
 
 /// A marker protocols used to determine whether a value is a `Dictionary` or an `Array`
-///
-/// NOTE: The architecture and environment check is due to a bug in the current (2018-08-08) Swift 4.2
-/// runtime when running on i386 simulator. The issue is tracked in https://bugs.swift.org/browse/SR-8276
-/// Making the protocol `internal` instead of `fileprivate` works around this issue.
-/// Once SR-8276 is fixed, this check can be removed and the protocol always be made fileprivate.
-#if arch(i386) || arch(arm)
-internal protocol _XMLDictionaryEncodableMarker { }
-internal protocol _XMLArrayEncodableMarker { }
-#else
 fileprivate protocol _XMLDictionaryEncodableMarker { }
 fileprivate protocol _XMLArrayEncodableMarker { }
-#endif
 
 extension Dictionary : _XMLDictionaryEncodableMarker where Value: Decodable { }
 extension Array : _XMLArrayEncodableMarker where Element: Decodable { }
 
 /// The wrapper class for encoding Codable classes to XMLElements
-public class XMLEncoder {
+class XMLEncoder {
     
     /// The strategy to use for encoding `Date` values.
     public enum DateEncodingStrategy {

--- a/Sources/AWSSDKSwiftCore/Message/AWSMiddleware.swift
+++ b/Sources/AWSSDKSwiftCore/Message/AWSMiddleware.swift
@@ -26,8 +26,8 @@ public extension AWSServiceMiddleware {
     }
 }
 
-/// Middleware class that outputs the contents of requests being sent to AWS and the bodies of the responses received
-public class AWSLoggingMiddleware : AWSServiceMiddleware {
+/// Middleware struct that outputs the contents of requests being sent to AWS and the bodies of the responses received
+public struct AWSLoggingMiddleware : AWSServiceMiddleware {
     
     /// initialize AWSLoggingMiddleware class
     /// - parameters:

--- a/Sources/AWSSDKSwiftCore/XML.swift
+++ b/Sources/AWSSDKSwiftCore/XML.swift
@@ -5,7 +5,6 @@
 //  Created by Adam Fowler on 2019/06/15
 //
 
-// Implemented to replace the XML Foundation classes. This was initially required as there is no implementation of the Foundation XMLNode classes in iOS. This is also here because the implementation of XMLNode in Linux Swift 4.2 was causing crashes. Whenever an XMLDocument was deleted all the underlying CoreFoundation objects were deleted. This meant if you still had a reference to a XMLElement from that document, while it was still valid the underlying CoreFoundation object had been deleted.
 
 import struct   Foundation.Data
 import class    Foundation.NSObject
@@ -18,8 +17,10 @@ import protocol Foundation.XMLParserDelegate
 
 
 
-// I have placed everything inside a holding XML class to avoid name clashes with the Foundation version. Otherwise this class reflects the behaviour of the Foundation classes as close as possible with the exceptions of, I haven't implemented queries, DTD, also XMLNodes do not contain an object reference. Also the node creation function in XMLNode return XMLNode instead of Any.
-public class XML {
+/// Implemented to replace the XML Foundation classes. This was initially required as there is no implementation of the Foundation XMLNode classes in iOS. This is also here because the implementation of XMLNode in Linux Swift 4.2 was causing crashes. Whenever an XMLDocument was deleted all the underlying CoreFoundation objects were deleted. This meant if you still had a reference to a XMLElement from that document, while it was still valid the underlying CoreFoundation object had been deleted.
+///
+/// I have placed everything inside a holding XML enumeration to avoid name clashes with the Foundation version. Otherwise this class reflects the behaviour of the Foundation classes as close as possible with the exceptions of, I haven't implemented queries, DTD, also XMLNodes do not contain an object reference. Also the node creation function in XMLNode return XMLNode instead of Any.
+public enum XML {
     /// base class for all types of XML.Node
     public class Node {
 


### PR DESCRIPTION
- Removed `public` from the encoders
- Removed `URL.hostWithPost` as it is unnecessary
- `XML` is now an `enum`
- `AWSLoggingMiddleware` is now a `struct`