### PR TITLE
Paginate token with associated type

### DIFF
--- a/Sources/AWSSDKSwiftCore/AWSClient+Paginate.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient+Paginate.swift
@@ -8,18 +8,13 @@
 import NIO
 
 /// protocol for all AWSShapes that can be paginated.
-/// Adds an initialiser that does a copy but inserts a new string based pagination token
-public protocol AWSPaginateStringToken: AWSShape {
-    func usingPaginationToken(_ token: String) -> Self
-}
-
-/// protocol for all AWSShapes that can be paginated.
 /// Adds an initialiser that does a copy but inserts a new integer based pagination token
-public protocol AWSPaginateIntToken: AWSShape {
-    func usingPaginationToken(_ token: Int) -> Self
+public protocol AWSPaginateToken: AWSShape {
+    associatedtype Token
+    func usingPaginationToken(_ token: Token) -> Self
 }
 
-public extension AWSClient {
+extension AWSClient {
     
     /// If an AWS command is returning an arbituary sized array sometimes it adds support for paginating this array
     /// ie it will return the array in blocks of a defined size, each block also includes a token which can be used to access
@@ -28,57 +23,12 @@ public extension AWSClient {
     /// - Parameters:
     ///   - input: Input for request
     ///   - command: Command to be paginated
-    ///   - resultKey: The keypath to the list of objects to be paginated
     ///   - tokenKey: The name of token in the response object to continue pagination
     ///   - onPage: closure called with each block of entries
-    func paginate<Input: AWSPaginateStringToken, Output: AWSShape>(
+    public func paginate<Input: AWSPaginateToken, Output: AWSShape>(
         input: Input,
         command: @escaping (Input)->EventLoopFuture<Output>,
-        tokenKey: KeyPath<Output, String?>,
-        onPage: @escaping (Output, EventLoop)->EventLoopFuture<Bool>
-    ) -> EventLoopFuture<Void> {
-        let eventLoop = self.eventLoopGroup.next()
-        let promise = eventLoop.makePromise(of: Void.self)
-
-        func paginatePart(input: Input) {
-            let responseFuture = command(input)
-                .flatMap { response in
-                    return onPage(response, eventLoop)
-                        .map { (rt)->Void in
-                            guard rt == true else { return promise.succeed(Void()) }
-                            // get next block token and construct a new input with this token
-                            guard let token = response[keyPath: tokenKey] else { return promise.succeed(Void()) }
-
-                            let input = input.usingPaginationToken(token)
-                            paginatePart(input: input)
-                    }
-            }
-            responseFuture.whenFailure { error in
-                promise.fail(error)
-            }
-        }
-
-        paginatePart(input: input)
-        
-        return promise.futureResult
-    }
-
-    /// If an AWS command is returning an arbituary sized array sometimes it adds support for paginating this array
-    /// ie it will return the array in blocks of a defined size, each block also includes a token which can be used to access
-    /// the next block. This function loads each block and calls a closure with each block as parameter.
-    ///
-    /// This version uses an Int instead of a String for the token
-    ///
-    /// - Parameters:
-    ///   - input: Input for request
-    ///   - command: Command to be paginated
-    ///   - resultKey: The keypath to the list of objects to be paginated
-    ///   - tokenKey: The name of token in the response object to continue pagination
-    ///   - onPage: closure called with each block of entries
-    func paginate<Input: AWSPaginateIntToken, Output: AWSShape>(
-        input: Input,
-        command: @escaping (Input)->EventLoopFuture<Output>,
-        tokenKey: KeyPath<Output, Int?>,
+        tokenKey: KeyPath<Output, Input.Token?>,
         onPage: @escaping (Output, EventLoop)->EventLoopFuture<Bool>
     ) -> EventLoopFuture<Void> {
         let eventLoop = self.eventLoopGroup.next()
@@ -107,4 +57,3 @@ public extension AWSClient {
         return promise.futureResult
     }
 }
-

--- a/Tests/AWSSDKSwiftCoreTests/PaginateTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/PaginateTests.swift
@@ -38,7 +38,7 @@ class PaginateTests: XCTestCase {
     }
     
     // test structures/functions
-    struct CounterInput: AWSShape, AWSPaginateIntToken {
+    struct CounterInput: AWSShape, AWSPaginateToken {
         let inputToken: Int?
         let pageSize: Int
         
@@ -105,7 +105,7 @@ class PaginateTests: XCTestCase {
     }
     
     // test structures/functions
-    struct StringListInput: AWSShape, AWSPaginateStringToken {
+    struct StringListInput: AWSShape, AWSPaginateToken {
         let inputToken: String?
         let pageSize: Int
         


### PR DESCRIPTION
Associated PR in aws-sdk-swift is https://github.com/swift-aws/aws-sdk-swift/pull/263

Replace `AWSPaginateStringToken` and `AWSPaginateIntToken` with `AWSPaginateToken` which has an associated type `Token`. This allows us to generalize all the paginate code and allow for tokens that are not strings or integers.