### PR TITLE
Support for streaming response payload

### DIFF
--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -362,12 +362,12 @@ extension AWSClient {
         return recordMetrics(future, service: serviceConfig.service, operation: operationName)
     }
 
-    public func send<Output: AWSDecodableShape, Input: AWSEncodableShape>(
+    public func send<Output: AWSDecodableShape, Payload: AWSHTTPClientStreamable, Input: AWSEncodableShape>(
         operation operationName: String,
         path: String,
         httpMethod: String,
         input: Input,
-        stream: @escaping (ByteBuffer, EventLoop)->EventLoopFuture<Void>
+        stream: @escaping (Payload, EventLoop)->EventLoopFuture<Void>
     ) -> EventLoopFuture<Output> {
 
         return credentialProvider.getCredential().flatMapThrowing { credential in

--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -37,7 +37,6 @@ public final class AWSClient {
         case alreadyShutdown
         case invalidURL(String)
         case tooMuchData
-        case streamingUnavailable
     }
 
     enum InternalError: Swift.Error {
@@ -200,7 +199,7 @@ public final class AWSClient {
 
 // invoker
 extension AWSClient {
-    
+
     fileprivate func invoke(_ request: @escaping () -> EventLoopFuture<AWSHTTPResponse>) -> EventLoopFuture<AWSHTTPResponse> {
         let eventloop = self.eventLoopGroup.next()
         let promise = eventloop.makePromise(of: AWSHTTPResponse.self)
@@ -233,14 +232,14 @@ extension AWSClient {
 
         return promise.futureResult
     }
-    
+
     /// invoke HTTP request
     fileprivate func invoke(_ httpRequest: AWSHTTPRequest, on eventLoop: EventLoop) -> EventLoopFuture<AWSHTTPResponse> {
         return invoke {
             return self.httpClient.execute(request: httpRequest, timeout: .seconds(20), on: eventLoop)
         }
     }
-    
+
     /// invoke HTTP request with response streaming
     fileprivate func invoke(_ httpRequest: AWSHTTPRequest, on eventLoop: EventLoop, stream: @escaping AWSHTTPClient.ResponseStream) -> EventLoopFuture<AWSHTTPResponse> {
         return invoke {
@@ -851,8 +850,6 @@ extension AWSClient.ClientError: CustomStringConvertible {
             """
         case .tooMuchData:
             return "You have supplied too much data for the Request."
-        case .streamingUnavailable:
-            return "Streaming is only available while using AsyncHTTPClient"
         }
     }
 }

--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -626,10 +626,6 @@ extension AWSClient {
         var raw: Bool = false
         var payloadKey: String? = (Output.self as? AWSShapeWithPayload.Type)?.payloadPath
 
-        // chunked payloads should be flagged as raw so service middleware can process them
-        if operationName == "SelectObjectContent" {
-            raw = true
-        }
         // if response has a payload with encoding info
         if let payloadPath = payloadKey, let encoding = Output.getEncoding(for: payloadPath) {
             // is payload raw

--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -236,7 +236,7 @@ extension AWSClient {
     }
 
     /// invoke HTTP request
-    fileprivate func invoke<Payload: AWSHTTPClientStreamable>(_ httpRequest: AWSHTTPRequest, stream: @escaping (Payload, EventLoop)->EventLoopFuture<Void>) -> EventLoopFuture<AWSHTTPResponse> {
+    fileprivate func invoke<Payload: AWSClientStreamable>(_ httpRequest: AWSHTTPRequest, stream: @escaping (Payload, EventLoop)->EventLoopFuture<Void>) -> EventLoopFuture<AWSHTTPResponse> {
         guard let httpClient = self.httpClient as? AsyncHTTPClient.HTTPClient else {
             return eventLoopGroup.next().makeFailedFuture(RequestError.streamingUnavailable)
         }
@@ -362,7 +362,7 @@ extension AWSClient {
         return recordMetrics(future, service: serviceConfig.service, operation: operationName)
     }
 
-    public func send<Output: AWSDecodableShape, Payload: AWSHTTPClientStreamable, Input: AWSEncodableShape>(
+    public func send<Output: AWSDecodableShape, Payload: AWSClientStreamable, Input: AWSEncodableShape>(
         operation operationName: String,
         path: String,
         httpMethod: String,

--- a/Sources/AWSSDKSwiftCore/HTTP/AWSHTTPClient.swift
+++ b/Sources/AWSSDKSwiftCore/HTTP/AWSHTTPClient.swift
@@ -43,9 +43,20 @@ public protocol AWSHTTPClient {
     /// Execute HTTP request and return a future holding a HTTP Response
     func execute(request: AWSHTTPRequest, timeout: TimeAmount, on eventLoop: EventLoop?) -> EventLoopFuture<AWSHTTPResponse>
 
+    /// Execute an HTTP request with a streamed response
+    func execute<Payload: AWSClientStreamable>(request: AWSHTTPRequest, timeout: TimeAmount, on eventLoop: EventLoop?, stream: @escaping (Payload, EventLoop)->EventLoopFuture<Void>) -> EventLoopFuture<AWSHTTPResponse>
+
     /// This should be called before an HTTP Client can be de-initialised
     func syncShutdown() throws
 
     /// Event loop group used by client
     var eventLoopGroup: EventLoopGroup { get }
+}
+
+extension AWSHTTPClient {
+    /// Execute an HTTP request with a streamed response
+    public func execute<Payload: AWSClientStreamable>(request: AWSHTTPRequest, timeout: TimeAmount, on eventLoop: EventLoop?, stream: @escaping (Payload, EventLoop)->EventLoopFuture<Void>) -> EventLoopFuture<AWSHTTPResponse> {
+        preconditionFailure("Response streaming isn't supported")
+    }
+
 }

--- a/Sources/AWSSDKSwiftCore/HTTP/AWSHTTPClient.swift
+++ b/Sources/AWSSDKSwiftCore/HTTP/AWSHTTPClient.swift
@@ -40,11 +40,13 @@ public protocol AWSHTTPResponse {
 
 /// Protocol defining requirements for a HTTPClient
 public protocol AWSHTTPClient {
+    typealias ResponseStream = (ByteBuffer, EventLoop)->EventLoopFuture<Void>
+
     /// Execute HTTP request and return a future holding a HTTP Response
     func execute(request: AWSHTTPRequest, timeout: TimeAmount, on eventLoop: EventLoop?) -> EventLoopFuture<AWSHTTPResponse>
 
     /// Execute an HTTP request with a streamed response
-    func execute<Payload: AWSClientStreamable>(request: AWSHTTPRequest, timeout: TimeAmount, on eventLoop: EventLoop?, stream: @escaping (Payload, EventLoop)->EventLoopFuture<Void>) -> EventLoopFuture<AWSHTTPResponse>
+    func execute(request: AWSHTTPRequest, timeout: TimeAmount, on eventLoop: EventLoop?, stream: @escaping ResponseStream) -> EventLoopFuture<AWSHTTPResponse>
 
     /// This should be called before an HTTP Client can be de-initialised
     func syncShutdown() throws
@@ -55,7 +57,7 @@ public protocol AWSHTTPClient {
 
 extension AWSHTTPClient {
     /// Execute an HTTP request with a streamed response
-    public func execute<Payload: AWSClientStreamable>(request: AWSHTTPRequest, timeout: TimeAmount, on eventLoop: EventLoop?, stream: @escaping (Payload, EventLoop)->EventLoopFuture<Void>) -> EventLoopFuture<AWSHTTPResponse> {
+    public func execute(request: AWSHTTPRequest, timeout: TimeAmount, on eventLoop: EventLoop?, stream: @escaping ResponseStream) -> EventLoopFuture<AWSHTTPResponse> {
         preconditionFailure("Response streaming isn't supported")
     }
 

--- a/Sources/AWSSDKSwiftCore/HTTP/AsyncHTTPClient.swift
+++ b/Sources/AWSSDKSwiftCore/HTTP/AsyncHTTPClient.swift
@@ -53,5 +53,29 @@ extension AsyncHTTPClient.HTTPClient: AWSHTTPClient {
     }
 }
 
+/// extend to include response streaming support
+extension AsyncHTTPClient.HTTPClient {
+    public func execute(request: AWSHTTPRequest, timeout: TimeAmount, on eventLoop: EventLoop?, stream: @escaping ResponseStream) -> EventLoopFuture<AWSHTTPResponse> {
+        if let eventLoop = eventLoop {
+            precondition(self.eventLoopGroup.makeIterator().contains { $0 === eventLoop }, "EventLoop provided to AWSClient must be part of the HTTPClient's EventLoopGroup.")
+        }
+        let requestBody: AsyncHTTPClient.HTTPClient.Body?
+        if let body = request.body {
+            requestBody = .byteBuffer(body)
+        } else {
+            requestBody = nil
+        }
+        do {
+            let eventLoop = eventLoop ?? eventLoopGroup.next()
+            let asyncRequest = try AsyncHTTPClient.HTTPClient.Request(url: request.url, method: request.method, headers: request.headers, body: requestBody)
+            let delegate = AWSHTTPClientResponseDelegate(host: asyncRequest.host, stream: stream)
+            return execute(request: asyncRequest, delegate: delegate, eventLoop: .delegate(on: eventLoop), deadline: .now() + timeout).futureResult
+        } catch {
+            return eventLoopGroup.next().makeFailedFuture(error)
+        }
+    }
+}
+
+
 extension AsyncHTTPClient.HTTPClient.Response: AWSHTTPResponse {}
 

--- a/Sources/AWSSDKSwiftCore/HTTP/AsyncHTTPClient.swift
+++ b/Sources/AWSSDKSwiftCore/HTTP/AsyncHTTPClient.swift
@@ -51,47 +51,7 @@ extension AsyncHTTPClient.HTTPClient: AWSHTTPClient {
             return eventLoopGroup.next().makeFailedFuture(error)
         }
     }
-
-    func execute(request: AWSHTTPRequest, delegate: AWSHTTPClientResponseDelegate, timeout: TimeAmount) -> Task<AWSHTTPResponse>? {
-        let requestBody: AsyncHTTPClient.HTTPClient.Body?
-        if let body = request.body {
-            requestBody = .byteBuffer(body)
-        } else {
-            requestBody = nil
-        }
-        do {
-            let asyncRequest = try AsyncHTTPClient.HTTPClient.Request(url: request.url, method: request.method, headers: request.headers, body: requestBody)
-            return execute(request: asyncRequest, delegate: delegate, deadline: .now() + timeout)
-        } catch {
-            return nil
-        }
-    }
 }
 
 extension AsyncHTTPClient.HTTPClient.Response: AWSHTTPResponse {}
-
-class AWSHTTPClientResponseDelegate: HTTPClientResponseDelegate {
-
-    init(_ stream: @escaping (ByteBuffer)->()) {
-        self.stream = stream
-        self.head = nil
-    }
-
-    func didReceiveHead(task: HTTPClient.Task<AWSHTTPResponse>, _ head: HTTPResponseHead) -> EventLoopFuture<Void> {
-        self.head = head
-        return task.eventLoop.makeSucceededFuture(())
-    }
-    
-    func didReceiveBodyPart(task: HTTPClient.Task<AWSHTTPResponse>, _ buffer: ByteBuffer) -> EventLoopFuture<Void> {
-        stream(buffer)
-        return task.eventLoop.makeSucceededFuture(())
-    }
-
-    func didFinishRequest(task: HTTPClient.Task<AWSHTTPResponse>) throws -> AWSHTTPResponse {
-        return AsyncHTTPClient.HTTPClient.Response(host: "me", status: head.status, headers: head.headers, body: nil)
-    }
-
-    let stream: (ByteBuffer)->()
-    var head: HTTPResponseHead!
-}
 

--- a/Sources/AWSSDKSwiftCore/HTTP/AsyncHTTPClient.swift
+++ b/Sources/AWSSDKSwiftCore/HTTP/AsyncHTTPClient.swift
@@ -60,7 +60,7 @@ extension AsyncHTTPClient.HTTPClient {
             precondition(self.eventLoopGroup.makeIterator().contains { $0 === eventLoop }, "EventLoop provided to AWSClient must be part of the HTTPClient's EventLoopGroup.")
         }
         let requestBody: AsyncHTTPClient.HTTPClient.Body?
-        if let body = request.body {
+        if case .byteBuffer(let body) = request.body.payload {
             requestBody = .byteBuffer(body)
         } else {
             requestBody = nil

--- a/Sources/AWSSDKSwiftCore/HTTP/ResponseDelegate.swift
+++ b/Sources/AWSSDKSwiftCore/HTTP/ResponseDelegate.swift
@@ -1,0 +1,81 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the AWSSDKSwift open source project
+//
+// Copyright (c) 2017-2020 the AWSSDKSwift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of AWSSDKSwift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import AsyncHTTPClient
+import Foundation
+import NIO
+import NIOHTTP1
+
+/// Protocol defining an object that can be streamed by aws-sdk-swift. It is required to be initialize copies of itself from byte buffers
+public protocol AWSHTTPClientStreamable {
+    static func consume(byteBuffer: ByteBuffer) throws -> Self?
+}
+
+extension ByteBuffer: AWSHTTPClientStreamable {
+    public static func consume(byteBuffer: ByteBuffer) throws -> Self? { return byteBuffer }
+}
+
+/// HTTP client delegate capturing the body parts received from AsyncHTTPClient.
+class AWSHTTPClientResponseDelegate<Payload: AWSHTTPClientStreamable>: HTTPClientResponseDelegate {
+
+    init(host: String, stream: @escaping (Payload, EventLoop)->EventLoopFuture<Void>) {
+        self.host = host
+        self.stream = stream
+        self.head = nil
+    }
+
+    func didReceiveHead(task: HTTPClient.Task<AWSHTTPResponse>, _ head: HTTPResponseHead) -> EventLoopFuture<Void> {
+        self.head = head
+        return task.eventLoop.makeSucceededFuture(())
+    }
+    
+    func didReceiveBodyPart(task: HTTPClient.Task<AWSHTTPResponse>, _ buffer: ByteBuffer) -> EventLoopFuture<Void> {
+        do {
+            if let payload = try Payload.consume(byteBuffer: buffer) {
+                return stream(payload, task.eventLoop)
+            }
+            return task.eventLoop.makeSucceededFuture(())
+        } catch {
+            return task.eventLoop.makeFailedFuture(error)
+        }
+    }
+
+    func didFinishRequest(task: HTTPClient.Task<AWSHTTPResponse>) throws -> AWSHTTPResponse {
+        return AsyncHTTPClient.HTTPClient.Response(host: host, status: head.status, headers: head.headers, body: nil)
+    }
+
+    let host: String
+    let stream: (Payload, EventLoop)->EventLoopFuture<Void>
+    var head: HTTPResponseHead!
+}
+
+/// extend to include delegate support
+extension AsyncHTTPClient.HTTPClient {
+    func execute<Payload: AWSHTTPClientStreamable>(request: AWSHTTPRequest, stream: @escaping (Payload, EventLoop)->EventLoopFuture<Void>, timeout: TimeAmount) -> Task<AWSHTTPResponse>? {
+        let requestBody: AsyncHTTPClient.HTTPClient.Body?
+        if let body = request.body {
+            requestBody = .byteBuffer(body)
+        } else {
+            requestBody = nil
+        }
+        do {
+            let asyncRequest = try AsyncHTTPClient.HTTPClient.Request(url: request.url, method: request.method, headers: request.headers, body: requestBody)
+            let delegate = AWSHTTPClientResponseDelegate(host: asyncRequest.host, stream: stream)
+            return execute(request: asyncRequest, delegate: delegate, deadline: .now() + timeout)
+        } catch {
+            return nil
+        }
+    }
+}
+

--- a/Sources/AWSSDKSwiftCore/HTTP/ResponseDelegate.swift
+++ b/Sources/AWSSDKSwiftCore/HTTP/ResponseDelegate.swift
@@ -95,23 +95,3 @@ class AWSHTTPClientResponseDelegate: HTTPClientResponseDelegate {
         }
     }
 }
-
-/// extend to include delegate support
-extension AsyncHTTPClient.HTTPClient {
-    public func execute(request: AWSHTTPRequest, timeout: TimeAmount, on eventLoop: EventLoop?, stream: @escaping ResponseStream) -> EventLoopFuture<AWSHTTPResponse> {
-        let requestBody: AsyncHTTPClient.HTTPClient.Body?
-        if let body = request.body {
-            requestBody = .byteBuffer(body)
-        } else {
-            requestBody = nil
-        }
-        do {
-            let asyncRequest = try AsyncHTTPClient.HTTPClient.Request(url: request.url, method: request.method, headers: request.headers, body: requestBody)
-            let delegate = AWSHTTPClientResponseDelegate(host: asyncRequest.host, stream: stream)
-            return execute(request: asyncRequest, delegate: delegate, deadline: .now() + timeout).futureResult
-        } catch {
-            return eventLoopGroup.next().makeFailedFuture(error)
-        }
-    }
-}
-

--- a/Sources/AWSSDKSwiftCore/HTTP/ResponseDelegate.swift
+++ b/Sources/AWSSDKSwiftCore/HTTP/ResponseDelegate.swift
@@ -24,7 +24,6 @@ class AWSHTTPClientResponseDelegate: HTTPClientResponseDelegate {
     enum State {
         case idle
         case head(HTTPResponseHead)
-        //case body(HTTPResponseHead, ByteBuffer)
         case end
         case error(Error)
     }
@@ -45,8 +44,6 @@ class AWSHTTPClientResponseDelegate: HTTPClientResponseDelegate {
             self.state = .head(head)
         case .head:
             preconditionFailure("head already set")
-        //case .body:
-        //    preconditionFailure("no head received before body")
         case .end:
             preconditionFailure("request already processed")
         case .error:
@@ -82,12 +79,6 @@ class AWSHTTPClientResponseDelegate: HTTPClientResponseDelegate {
             preconditionFailure("no head received before end")
         case .head(let head):
             return AsyncHTTPClient.HTTPClient.Response(host: host, status: head.status, headers: head.headers, body: nil)
-        /*case .body(let head, let body):
-            if (200..<300).contains(head.status.code) {
-                return AsyncHTTPClient.HTTPClient.Response(host: host, status: head.status, headers: head.headers, body: nil)
-            } else {
-                return AsyncHTTPClient.HTTPClient.Response(host: host, status: head.status, headers: head.headers, body: body)
-            }*/
         case .end:
             preconditionFailure("request already processed")
         case .error(let error):

--- a/Sources/AWSSDKSwiftCore/Message/AWSResponse.swift
+++ b/Sources/AWSSDKSwiftCore/Message/AWSResponse.swift
@@ -19,8 +19,6 @@ import AWSXML
 /// Structure encapsulating a processed HTTP Response
 public struct AWSResponse {
 
-    /// operation name
-    public let operationName: String
     /// response status
     public let status: HTTPResponseStatus
     /// response headers
@@ -33,8 +31,7 @@ public struct AWSResponse {
     ///     - from: Raw HTTP Response
     ///     - serviceProtocol: protocol of service (.json, .xml, .query etc)
     ///     - raw: Whether Body should be treated as raw data
-    init(operation: String, from response: AWSHTTPResponse, serviceProtocol: ServiceProtocol, raw: Bool = false) throws {
-        self.operationName = operation
+    init(from response: AWSHTTPResponse, serviceProtocol: ServiceProtocol, raw: Bool = false) throws {
         self.status = response.status
 
         // headers

--- a/Sources/AWSSDKSwiftCore/Message/AWSResponse.swift
+++ b/Sources/AWSSDKSwiftCore/Message/AWSResponse.swift
@@ -19,6 +19,8 @@ import AWSXML
 /// Structure encapsulating a processed HTTP Response
 public struct AWSResponse {
 
+    /// operation name
+    public let operationName: String
     /// response status
     public let status: HTTPResponseStatus
     /// response headers
@@ -31,7 +33,8 @@ public struct AWSResponse {
     ///     - from: Raw HTTP Response
     ///     - serviceProtocol: protocol of service (.json, .xml, .query etc)
     ///     - raw: Whether Body should be treated as raw data
-    init(from response: AWSHTTPResponse, serviceProtocol: ServiceProtocol, raw: Bool = false) throws {
+    init(operation: String, from response: AWSHTTPResponse, serviceProtocol: ServiceProtocol, raw: Bool = false) throws {
+        self.operationName = operation
         self.status = response.status
 
         // headers

--- a/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
@@ -1372,7 +1372,7 @@ let response = AWSHTTPResponseImpl(
                 eventLoopGroupProvider: .shared(MultiThreadedEventLoopGroup(numberOfThreads: 2))
             )
             var count = 0
-            let response: EventLoopFuture<Output> = client.send(operation: "test", path: "/", httpMethod: "GET", input: Input()) { (payload: ByteBuffer, eventLoop: EventLoop) in
+            let response: EventLoopFuture<Output> = client.send(operation: "test", path: "/", httpMethod: "GET", input: Input()) { payload, eventLoop in
                 let payloadSize = payload.readableBytes
                 let slice = Data(data[count..<(count+payloadSize)])
                 let payloadData = payload.getData(at: 0, length: payload.readableBytes)

--- a/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
@@ -1372,7 +1372,7 @@ let response = AWSHTTPResponseImpl(
                 eventLoopGroupProvider: .shared(MultiThreadedEventLoopGroup(numberOfThreads: 2))
             )
             var count = 0
-            let response: EventLoopFuture<Output> = client.send(operation: "test", path: "/", httpMethod: "GET", input: Input()) { payload, eventLoop in
+            let response: EventLoopFuture<Output> = client.send(operation: "test", path: "/", httpMethod: "GET", input: Input()) { (payload: ByteBuffer, eventLoop: EventLoop) in
                 let payloadSize = payload.readableBytes
                 let slice = Data(data[count..<(count+payloadSize)])
                 let payloadData = payload.getData(at: 0, length: payload.readableBytes)

--- a/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
@@ -1388,11 +1388,11 @@ let response = AWSHTTPResponseImpl(
                 return eventLoop.makeSucceededFuture(())
             }
 
-            try awsServer.process { request in
+            try awsServer.processRaw { request in
                 var byteBuffer = ByteBufferAllocator().buffer(capacity: 128*1024)
                 byteBuffer.writeBytes(data)
                 let response = AWSTestServer.Response(httpStatus: .ok, headers: ["test":"TestHeader"], body: byteBuffer)
-                return AWSTestServer.Result(output: response, continueProcessing: false)
+                return .result(response)
             }
 
             let result = try response.wait()


### PR DESCRIPTION
The sibling PR for this is https://github.com/swift-aws/aws-sdk-swift/pull/268

This is only supported for AsyncHTTPClient. I would need to restructure `NIOTSHTTPClient` a fair bit to support it and when NIOTS is supported by AsyncHTTPClient we we will be ditching `NIOTSHTTPClient`. So I'm not gonna waste my time.

Some commands eg `S3.getObject()` stream the payload in their response. This PR is to support this.

- Created a `AWSHTTPClientResponseDelegate` to process the response coming from `HTTPClient`. Send body `ByteBuffers` to a `stream` closure supplied at initialisation of `AWSHTTPClientResponseDelegate`.
- Added new `AWSClient.send` method which takes a `stream` closure.
- Added `AWSClientTests.testStreamingResponse` for testing of streaming a `ByteBuffer`