### PR TITLE
Add support for streaming request payload

### DIFF
--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -387,7 +387,7 @@ extension AWSClient {
     }
 
     internal func verifyStream(operation: String, payload: AWSPayload, input: AWSShapeWithPayload.Type) {
-        guard case .stream(let size,_,_) = payload.payload else { return }
+        guard case .stream(let size,_) = payload.payload else { return }
         precondition(input.options.contains(.allowStreaming), "\(operation) does not allow streaming of data")
         precondition(size != nil || input.options.contains(.allowChunkedStreaming), "\(operation) does not allow chunked streaming of data. Please supply a data size.")
     }

--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -33,6 +33,7 @@ public final class AWSClient {
 
     public enum ClientError: Swift.Error {
         case invalidURL(String)
+        case tooMuchData
     }
 
     enum InternalError: Swift.Error {
@@ -442,7 +443,7 @@ extension AWSClient {
                 if let payloadBody = mirror.getAttribute(forKey: payload) {
                     switch payloadBody {
                     case let awsPayload as AWSPayload:
-                        body = .buffer(awsPayload.byteBuffer)
+                        body = .raw(awsPayload)
                     case let shape as AWSEncodableShape:
                         body = .json(try shape.encodeAsJSON())
                     default:
@@ -478,7 +479,7 @@ extension AWSClient {
                 if let payloadBody = mirror.getAttribute(forKey: payload) {
                     switch payloadBody {
                     case let awsPayload as AWSPayload:
-                        body = .buffer(awsPayload.byteBuffer)
+                        body = .raw(awsPayload)
                     case let shape as AWSEncodableShape:
                         var rootName: String? = nil
                         // extract custom payload name
@@ -633,7 +634,7 @@ extension AWSClient {
             }
             return try XMLDecoder().decode(Output.self, from: outputNode)
 
-        case .buffer(let byteBuffer):
+        case .raw(let payload):
             if let payloadKey = payloadKey {
                 outputDict[payloadKey] = AWSPayload.byteBuffer(byteBuffer)
             }
@@ -788,6 +789,8 @@ extension AWSClient.ClientError: CustomStringConvertible {
             The request url \(urlString) is invalid format.
             This error is internal. So please make a issue on https://github.com/swift-aws/aws-sdk-swift/issues to solve it.
             """
+        case .tooMuchData:
+            return "You have supplied too much data for the Request."
         }
     }
 }

--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -636,7 +636,7 @@ extension AWSClient {
 
         case .raw(let payload):
             if let payloadKey = payloadKey {
-                outputDict[payloadKey] = AWSPayload.byteBuffer(byteBuffer)
+                outputDict[payloadKey] = payload
             }
 
         default:

--- a/Sources/AWSSDKSwiftCore/AWSShapes/Payload.swift
+++ b/Sources/AWSSDKSwiftCore/AWSShapes/Payload.swift
@@ -45,20 +45,33 @@ public enum AWSPayload {
 
     /// return payload as Data
     public func asData() -> Data? {
-        return byteBuffer.getData(at: byteBuffer.readerIndex, length: byteBuffer.readableBytes, byteTransferStrategy: .noCopy)
+        switch self {
+        case .byteBuffer(let byteBuffer):
+            return byteBuffer.getData(at: byteBuffer.readerIndex, length: byteBuffer.readableBytes, byteTransferStrategy: .noCopy)
+        default:
+            return nil
+        }
     }
 
     /// return payload as String
     public func asString() -> String? {
-        return byteBuffer.getString(at: byteBuffer.readerIndex, length: byteBuffer.readableBytes, encoding: .utf8)
+        switch self {
+        case .byteBuffer(let byteBuffer):
+            return byteBuffer.getString(at: byteBuffer.readerIndex, length: byteBuffer.readableBytes, encoding: .utf8)
+        default:
+            return nil
+        }
     }
 
     /// return payload as ByteBuffer
-    public func asBytebuffer() -> ByteBuffer {
-        return byteBuffer
+    public func asByteBuffer() -> ByteBuffer? {
+        switch self {
+        case .byteBuffer(let byteBuffer):
+            return byteBuffer
+        default:
+            return nil
+        }
     }
-
-    let byteBuffer: ByteBuffer
 }
 
 extension AWSPayload: Decodable {

--- a/Sources/AWSSDKSwiftCore/AWSShapes/Payload.swift
+++ b/Sources/AWSSDKSwiftCore/AWSShapes/Payload.swift
@@ -33,7 +33,8 @@ public struct AWSPayload {
         return AWSPayload(payload: .byteBuffer(buffer))
     }
     
-    /// construct a payload from a stream function
+    /// construct a payload from a stream function. If you supply a size the stream function will be called repeated until you supply the number of bytes specified. If you
+    /// don't supply a size the stream function will be called repeatedly until you supply an empty `ByteBuffer`
     public static func stream(size: Int? = nil, stream: @escaping (EventLoop)->EventLoopFuture<ByteBuffer>) -> Self {
         return AWSPayload(payload: .stream(size: size, stream: stream))
     }

--- a/Sources/AWSSDKSwiftCore/AWSShapes/Payload.swift
+++ b/Sources/AWSSDKSwiftCore/AWSShapes/Payload.swift
@@ -35,7 +35,7 @@ public enum AWSPayload {
         return .byteBuffer(byteBuffer)
     }
 
-    /// Construct a payload from a NIOFileHandle
+    /// Construct a stream payload from a NIOFileHandle
     public static func fileHandle(_ fileHandle: NIOFileHandle, size: Int, fileIO: NonBlockingFileIO, byteBufferAllocator: ByteBufferAllocator = ByteBufferAllocator()) -> Self {
         let blockSize = 64*1024
         var leftToRead = size
@@ -76,7 +76,7 @@ public enum AWSPayload {
     public func asString() -> String? {
         switch self {
         case .byteBuffer(let byteBuffer):
-            return byteBuffer.getString(at: byteBuffer.readerIndex, length: byteBuffer.readableBytes, encoding: .utf8)
+            return byteBuffer.getString(at: byteBuffer.readerIndex, length: byteBuffer.readableBytes)
         default:
             return nil
         }

--- a/Sources/AWSSDKSwiftCore/AWSShapes/Payload.swift
+++ b/Sources/AWSSDKSwiftCore/AWSShapes/Payload.swift
@@ -24,6 +24,7 @@ public struct AWSPayload {
     enum Payload {
         case byteBuffer(ByteBuffer)
         case stream(size: Int?, stream: (EventLoop)->EventLoopFuture<ByteBuffer>)
+        case empty
     }
     
     internal let payload: Payload
@@ -37,6 +38,11 @@ public struct AWSPayload {
     /// don't supply a size the stream function will be called repeatedly until you supply an empty `ByteBuffer`
     public static func stream(size: Int? = nil, stream: @escaping (EventLoop)->EventLoopFuture<ByteBuffer>) -> Self {
         return AWSPayload(payload: .stream(size: size, stream: stream))
+    }
+    
+    /// construct an empty payload
+    public static var empty: Self {
+        return AWSPayload(payload: .empty)
     }
     
     /// Construct a payload from `Data`
@@ -85,6 +91,8 @@ public struct AWSPayload {
             return byteBuffer.readableBytes
         case .stream(let size, _):
             return size
+        case .empty:
+            return 0
         }
     }
 
@@ -115,6 +123,18 @@ public struct AWSPayload {
             return byteBuffer
         default:
             return nil
+        }
+    }
+    
+    /// does payload consist of zero bytes
+    public var isEmpty: Bool {
+        switch payload {
+        case .byteBuffer(let buffer):
+            return buffer.readableBytes == 0
+        case .stream:
+            return false
+        case .empty:
+            return true
         }
     }
 }

--- a/Sources/AWSSDKSwiftCore/AWSShapes/Payload.swift
+++ b/Sources/AWSSDKSwiftCore/AWSShapes/Payload.swift
@@ -23,7 +23,7 @@ public struct AWSPayload {
     /// Internal enum
     enum Payload {
         case byteBuffer(ByteBuffer)
-        case stream(size: Int?, stream: (EventLoop)->EventLoopFuture<ByteBuffer>)
+        case stream(size: Int?, byteBufferAllocator: ByteBufferAllocator, stream: (EventLoop)->EventLoopFuture<ByteBuffer>)
         case empty
     }
     
@@ -36,8 +36,8 @@ public struct AWSPayload {
     
     /// construct a payload from a stream function. If you supply a size the stream function will be called repeated until you supply the number of bytes specified. If you
     /// don't supply a size the stream function will be called repeatedly until you supply an empty `ByteBuffer`
-    public static func stream(size: Int? = nil, stream: @escaping (EventLoop)->EventLoopFuture<ByteBuffer>) -> Self {
-        return AWSPayload(payload: .stream(size: size, stream: stream))
+    public static func stream(size: Int? = nil, byteBufferAllocator: ByteBufferAllocator = ByteBufferAllocator(), stream: @escaping (EventLoop)->EventLoopFuture<ByteBuffer>) -> Self {
+        return AWSPayload(payload: .stream(size: size, byteBufferAllocator: byteBufferAllocator, stream: stream))
     }
     
     /// construct an empty payload
@@ -81,7 +81,7 @@ public struct AWSPayload {
             return futureByteBuffer
         }
         
-        return AWSPayload(payload: .stream(size: size, stream: stream))
+        return AWSPayload(payload: .stream(size: size, byteBufferAllocator: byteBufferAllocator, stream: stream))
     }
     
     /// Return the size of the payload. If the payload is a stream it is always possible to return a size
@@ -89,7 +89,7 @@ public struct AWSPayload {
         switch payload {
         case .byteBuffer(let byteBuffer):
             return byteBuffer.readableBytes
-        case .stream(let size, _):
+        case .stream(let size,_,_):
             return size
         case .empty:
             return 0

--- a/Sources/AWSSDKSwiftCore/AWSShapes/Payload.swift
+++ b/Sources/AWSSDKSwiftCore/AWSShapes/Payload.swift
@@ -40,15 +40,15 @@ public struct AWSPayload {
     }
     
     /// Construct a payload from `Data`
-    public static func data(_ data: Data) -> Self {
-        var byteBuffer = ByteBufferAllocator().buffer(capacity: data.count)
+    public static func data(_ data: Data, byteBufferAllocator: ByteBufferAllocator = ByteBufferAllocator()) -> Self {
+        var byteBuffer = byteBufferAllocator.buffer(capacity: data.count)
         byteBuffer.writeBytes(data)
         return AWSPayload(payload: .byteBuffer(byteBuffer))
     }
 
     /// Construct a payload from a `String`
-    public static func string(_ string: String) -> Self {
-        var byteBuffer = ByteBufferAllocator().buffer(capacity: string.utf8.count)
+    public static func string(_ string: String, byteBufferAllocator: ByteBufferAllocator = ByteBufferAllocator()) -> Self {
+        var byteBuffer = byteBufferAllocator.buffer(capacity: string.utf8.count)
         byteBuffer.writeString(string)
         return AWSPayload(payload: .byteBuffer(byteBuffer))
     }

--- a/Sources/AWSSDKSwiftCore/AWSShapes/Payload.swift
+++ b/Sources/AWSSDKSwiftCore/AWSShapes/Payload.swift
@@ -23,7 +23,7 @@ public struct AWSPayload {
     /// Internal enum
     enum Payload {
         case byteBuffer(ByteBuffer)
-        case stream(size: Int?, byteBufferAllocator: ByteBufferAllocator, stream: (EventLoop)->EventLoopFuture<ByteBuffer>)
+        case stream(size: Int?, stream: (EventLoop)->EventLoopFuture<ByteBuffer>)
         case empty
     }
     
@@ -36,8 +36,8 @@ public struct AWSPayload {
     
     /// construct a payload from a stream function. If you supply a size the stream function will be called repeated until you supply the number of bytes specified. If you
     /// don't supply a size the stream function will be called repeatedly until you supply an empty `ByteBuffer`
-    public static func stream(size: Int? = nil, byteBufferAllocator: ByteBufferAllocator = ByteBufferAllocator(), stream: @escaping (EventLoop)->EventLoopFuture<ByteBuffer>) -> Self {
-        return AWSPayload(payload: .stream(size: size, byteBufferAllocator: byteBufferAllocator, stream: stream))
+    public static func stream(size: Int? = nil, stream: @escaping (EventLoop)->EventLoopFuture<ByteBuffer>) -> Self {
+        return AWSPayload(payload: .stream(size: size, stream: stream))
     }
     
     /// construct an empty payload
@@ -81,7 +81,7 @@ public struct AWSPayload {
             return futureByteBuffer
         }
         
-        return AWSPayload(payload: .stream(size: size, byteBufferAllocator: byteBufferAllocator, stream: stream))
+        return AWSPayload(payload: .stream(size: size, stream: stream))
     }
     
     /// Return the size of the payload. If the payload is a stream it is always possible to return a size
@@ -89,7 +89,7 @@ public struct AWSPayload {
         switch payload {
         case .byteBuffer(let byteBuffer):
             return byteBuffer.readableBytes
-        case .stream(let size,_,_):
+        case .stream(let size,_):
             return size
         case .empty:
             return 0

--- a/Sources/AWSSDKSwiftCore/Doc/AWSShape.swift
+++ b/Sources/AWSSDKSwiftCore/Doc/AWSShape.swift
@@ -106,10 +106,14 @@ public extension AWSEncodableShape {
         guard value.count <= max else { throw AWSClientError(.validationError, message: "Length of \(parent).\(name) (\(value.count)) is greater than the maximum allowed value \(max).") }
     }
     func validate(_ value: AWSPayload, name: String, parent: String, min: Int) throws {
-        guard value.size >= min else { throw AWSClientError(.validationError, message: "Length of \(parent).\(name) (\(value.size)) is less than minimum allowed value \(min).") }
+        if let size = value.size {
+            guard size >= min else { throw AWSClientError(.validationError, message: "Length of \(parent).\(name) (\(size)) is less than minimum allowed value \(min).") }
+        }
     }
     func validate(_ value: AWSPayload, name: String, parent: String, max: Int) throws {
-        guard value.size <= max else { throw AWSClientError(.validationError, message: "Length of \(parent).\(name) (\(value.size)) is greater than the maximum allowed value \(max).") }
+        if let size = value.size {
+            guard size <= max else { throw AWSClientError(.validationError, message: "Length of \(parent).\(name) (\(size)) is greater than the maximum allowed value \(max).") }
+        }
     }
     func validate(_ value: String, name: String, parent: String, pattern: String) throws {
         let regularExpression = try NSRegularExpression(pattern: pattern, options: [])

--- a/Sources/AWSSDKSwiftCore/Doc/AWSShape.swift
+++ b/Sources/AWSSDKSwiftCore/Doc/AWSShape.swift
@@ -107,12 +107,16 @@ public extension AWSEncodableShape {
     }
     func validate(_ value: AWSPayload, name: String, parent: String, min: Int) throws {
         if let size = value.size {
-            guard size >= min else { throw AWSClientError(.validationError, message: "Length of \(parent).\(name) (\(size)) is less than minimum allowed value \(min).") }
+            guard size >= min else {
+                throw AWSClientError(.validationError, message: "Length of \(parent).\(name) (\(size)) is less than minimum allowed value \(min).")
+            }
         }
     }
     func validate(_ value: AWSPayload, name: String, parent: String, max: Int) throws {
         if let size = value.size {
-            guard size <= max else { throw AWSClientError(.validationError, message: "Length of \(parent).\(name) (\(size)) is greater than the maximum allowed value \(max).") }
+            guard size <= max else {
+                throw AWSClientError(.validationError, message: "Length of \(parent).\(name) (\(size)) is greater than the maximum allowed value \(max).")
+            }
         }
     }
     func validate(_ value: String, name: String, parent: String, pattern: String) throws {

--- a/Sources/AWSSDKSwiftCore/Doc/AWSShape.swift
+++ b/Sources/AWSSDKSwiftCore/Doc/AWSShape.swift
@@ -186,5 +186,5 @@ public protocol AWSShapeWithPayload {
 }
 
 extension AWSShapeWithPayload {
-    static var options: PayloadOptions { return [] }
+    public static var options: PayloadOptions { return [] }
 }

--- a/Sources/AWSSDKSwiftCore/Doc/AWSShape.swift
+++ b/Sources/AWSSDKSwiftCore/Doc/AWSShape.swift
@@ -106,10 +106,10 @@ public extension AWSEncodableShape {
         guard value.count <= max else { throw AWSClientError(.validationError, message: "Length of \(parent).\(name) (\(value.count)) is greater than the maximum allowed value \(max).") }
     }
     func validate(_ value: AWSPayload, name: String, parent: String, min: Int) throws {
-        guard value.byteBuffer.readableBytes >= min else { throw AWSClientError(.validationError, message: "Length of \(parent).\(name) (\(value.byteBuffer.readableBytes)) is less than minimum allowed value \(min).") }
+        guard value.size >= min else { throw AWSClientError(.validationError, message: "Length of \(parent).\(name) (\(value.size)) is less than minimum allowed value \(min).") }
     }
     func validate(_ value: AWSPayload, name: String, parent: String, max: Int) throws {
-        guard value.byteBuffer.readableBytes <= max else { throw AWSClientError(.validationError, message: "Length of \(parent).\(name) (\(value.byteBuffer.readableBytes)) is greater than the maximum allowed value \(max).") }
+        guard value.size <= max else { throw AWSClientError(.validationError, message: "Length of \(parent).\(name) (\(value.size)) is greater than the maximum allowed value \(max).") }
     }
     func validate(_ value: String, name: String, parent: String, pattern: String) throws {
         let regularExpression = try NSRegularExpression(pattern: pattern, options: [])

--- a/Sources/AWSSDKSwiftCore/Doc/AWSShape.swift
+++ b/Sources/AWSSDKSwiftCore/Doc/AWSShape.swift
@@ -166,8 +166,25 @@ public extension AWSEncodableShape {
 /// AWSShape that can be decoded
 public protocol AWSDecodableShape: AWSShape & Decodable {}
 
+/// AWSShapeWithPayload options.
+public struct PayloadOptions: OptionSet {
+    public var rawValue: Int
+    
+    public init(rawValue: Int) {
+        self.rawValue = rawValue
+    }
+    
+    public static let allowStreaming = PayloadOptions(rawValue: 1<<0)
+    public static let allowChunkedStreaming = PayloadOptions(rawValue: 1<<1)
+}
+
 /// Root AWSShape which include a payload
 public protocol AWSShapeWithPayload {
     /// The path to the object that is included in the request body
     static var payloadPath: String { get }
+    static var options: PayloadOptions { get }
+}
+
+extension AWSShapeWithPayload {
+    static var options: PayloadOptions { return [] }
 }

--- a/Sources/AWSSDKSwiftCore/HTTP/AWSHTTPClient.swift
+++ b/Sources/AWSSDKSwiftCore/HTTP/AWSHTTPClient.swift
@@ -21,9 +21,9 @@ public struct AWSHTTPRequest {
     public let url: URL
     public let method: HTTPMethod
     public let headers: HTTPHeaders
-    public let body: ByteBuffer?
+    public let body: AWSPayload?
 
-    public init(url: URL, method: HTTPMethod, headers: HTTPHeaders = [:], body: ByteBuffer? = nil) {
+    public init(url: URL, method: HTTPMethod, headers: HTTPHeaders = [:], body: AWSPayload? = nil) {
         self.url = url
         self.method = method
         self.headers = headers

--- a/Sources/AWSSDKSwiftCore/HTTP/AWSHTTPClient.swift
+++ b/Sources/AWSSDKSwiftCore/HTTP/AWSHTTPClient.swift
@@ -21,9 +21,9 @@ public struct AWSHTTPRequest {
     public let url: URL
     public let method: HTTPMethod
     public let headers: HTTPHeaders
-    public let body: AWSPayload?
+    public let body: AWSPayload
 
-    public init(url: URL, method: HTTPMethod, headers: HTTPHeaders = [:], body: AWSPayload? = nil) {
+    public init(url: URL, method: HTTPMethod, headers: HTTPHeaders = [:], body: AWSPayload = .empty) {
         self.url = url
         self.method = method
         self.headers = headers

--- a/Sources/AWSSDKSwiftCore/HTTP/AWSHTTPClient.swift
+++ b/Sources/AWSSDKSwiftCore/HTTP/AWSHTTPClient.swift
@@ -22,7 +22,7 @@ public struct AWSHTTPRequest {
     public let method: HTTPMethod
     public let headers: HTTPHeaders
     public let body: ByteBuffer?
-    
+
     public init(url: URL, method: HTTPMethod, headers: HTTPHeaders = [:], body: ByteBuffer? = nil) {
         self.url = url
         self.method = method
@@ -42,10 +42,10 @@ public protocol AWSHTTPResponse {
 public protocol AWSHTTPClient {
     /// Execute HTTP request and return a future holding a HTTP Response
     func execute(request: AWSHTTPRequest, timeout: TimeAmount, on eventLoop: EventLoop?) -> EventLoopFuture<AWSHTTPResponse>
-    
+
     /// This should be called before an HTTP Client can be de-initialised
     func syncShutdown() throws
-    
+
     /// Event loop group used by client
     var eventLoopGroup: EventLoopGroup { get }
 }

--- a/Sources/AWSSDKSwiftCore/HTTP/AsyncHTTPClient.swift
+++ b/Sources/AWSSDKSwiftCore/HTTP/AsyncHTTPClient.swift
@@ -31,11 +31,9 @@ extension AsyncHTTPClient.HTTPClient.Body.StreamWriter {
         // use end of header for tail
         let tailByteBuffer = headerByteBuffer.getSlice(at: headerByteBuffer.readerIndex + chunkHeaderLength - 2, length: 2)!
 
-        return write(.byteBuffer(headerByteBuffer)).flatMap { _ in
-            self.write(.byteBuffer(chunk))
-        }.flatMap { _ in
-            self.write(.byteBuffer(tailByteBuffer))
-        }
+        _ = write(.byteBuffer(headerByteBuffer))
+        _ = write(.byteBuffer(chunk))
+        return write(.byteBuffer(tailByteBuffer))
     }
     
     /// Write empty chunk for end of chunked stream

--- a/Sources/AWSSDKSwiftCore/HTTP/AsyncHTTPClient.swift
+++ b/Sources/AWSSDKSwiftCore/HTTP/AsyncHTTPClient.swift
@@ -37,7 +37,7 @@ extension AsyncHTTPClient.HTTPClient: AWSHTTPClient {
                         if newAmountLeft == 0 {
                             promise.succeed(())
                         } else if newAmountLeft < 0 {
-                            promise.fail(AWSClient.RequestError.tooMuchData)
+                            promise.fail(AWSClient.ClientError.tooMuchData)
                         } else {
                             _writeToStreamWriter(newAmountLeft)
                         }
@@ -49,7 +49,7 @@ extension AsyncHTTPClient.HTTPClient: AWSHTTPClient {
         return promise.futureResult
     }
 
-    func execute(request: AWSHTTPRequest, timeout: TimeAmount, on eventLoop: EventLoop?) -> EventLoopFuture<AWSHTTPResponse> {
+    public func execute(request: AWSHTTPRequest, timeout: TimeAmount, on eventLoop: EventLoop?) -> EventLoopFuture<AWSHTTPResponse> {
         if let eventLoop = eventLoop {
             precondition(self.eventLoopGroup.makeIterator().contains { $0 === eventLoop }, "EventLoop provided to AWSClient must be part of the HTTPClient's EventLoopGroup.")
         }        

--- a/Sources/AWSSDKSwiftCore/HTTP/AsyncHTTPClient.swift
+++ b/Sources/AWSSDKSwiftCore/HTTP/AsyncHTTPClient.swift
@@ -18,13 +18,53 @@ import NIO
 
 /// comply with AWSHTTPClient protocol
 extension AsyncHTTPClient.HTTPClient: AWSHTTPClient {
-    public func execute(request: AWSHTTPRequest, timeout: TimeAmount, on eventLoop: EventLoop?) -> EventLoopFuture<AWSHTTPResponse> {
+
+    /// write stream to StreamWriter
+    private func writeToStreamWriter(
+        writer: HTTPClient.Body.StreamWriter,
+        size: Int,
+        on eventLoop: EventLoop,
+        closure: @escaping (EventLoop)->EventLoopFuture<ByteBuffer>) -> EventLoopFuture<Void> {
+        let promise = eventLoop.makePromise(of: Void.self)
+
+        func _writeToStreamWriter(_ amountLeft: Int) {
+            // get byte buffer from closure, write to StreamWriter, if there are still bytes to write then call
+            // _writeToStreamWriter again.
+            _ = closure(eventLoop)
+                .map { byteBuffer in
+                    let newAmountLeft = amountLeft - byteBuffer.readableBytes
+                    _ = writer.write(.byteBuffer(byteBuffer)).flatMap { ()->EventLoopFuture<Void> in
+                        if newAmountLeft == 0 {
+                            promise.succeed(())
+                        } else if newAmountLeft < 0 {
+                            promise.fail(AWSClient.RequestError.tooMuchData)
+                        } else {
+                            _writeToStreamWriter(newAmountLeft)
+                        }
+                        return promise.futureResult
+                    }.cascadeFailure(to: promise)
+            }.cascadeFailure(to: promise)
+        }
+        _writeToStreamWriter(size)
+        return promise.futureResult
+    }
+
+    func execute(request: AWSHTTPRequest, timeout: TimeAmount, on eventLoop: EventLoop?) -> EventLoopFuture<AWSHTTPResponse> {
         if let eventLoop = eventLoop {
             precondition(self.eventLoopGroup.makeIterator().contains { $0 === eventLoop }, "EventLoop provided to AWSClient must be part of the HTTPClient's EventLoopGroup.")
-        }
+        }        
         let requestBody: AsyncHTTPClient.HTTPClient.Body?
         if let body = request.body {
-            requestBody = .byteBuffer(body)
+            switch body {
+            case .byteBuffer(let byteBuffer):
+                requestBody = .byteBuffer(byteBuffer)
+
+            case .stream(let size, let closure):
+                let eventLoop = eventLoopGroup.next()
+                requestBody = .stream(length: size) { writer in
+                    return self.writeToStreamWriter(writer: writer, size: size, on: eventLoop, closure: closure)
+                }
+            }
         } else {
             requestBody = nil
         }

--- a/Sources/AWSSDKSwiftCore/HTTP/AsyncHTTPClient.swift
+++ b/Sources/AWSSDKSwiftCore/HTTP/AsyncHTTPClient.swift
@@ -66,7 +66,7 @@ extension AsyncHTTPClient.HTTPClient: AWSHTTPClient {
         let requestBody: AsyncHTTPClient.HTTPClient.Body?
         var requestHeaders = request.headers
         
-        switch request.body {
+        switch request.body?.payload {
         case .some(.byteBuffer(let byteBuffer)):
             requestBody = .byteBuffer(byteBuffer)
         case .some(.stream(let size, let closure)):

--- a/Sources/AWSSDKSwiftCore/HTTP/AsyncHTTPClient.swift
+++ b/Sources/AWSSDKSwiftCore/HTTP/AsyncHTTPClient.swift
@@ -67,10 +67,10 @@ extension AsyncHTTPClient.HTTPClient: AWSHTTPClient {
         let requestBody: AsyncHTTPClient.HTTPClient.Body?
         var requestHeaders = request.headers
         
-        switch request.body?.payload {
-        case .some(.byteBuffer(let byteBuffer)):
+        switch request.body.payload {
+        case .byteBuffer(let byteBuffer):
             requestBody = .byteBuffer(byteBuffer)
-        case .some(.stream(let size, let getData)):
+        case .stream(let size, let getData):
             // add "Transfer-Encoding" header if streaming with unknown size
             if size == nil {
                 requestHeaders.add(name: "Transfer-Encoding", value: "chunked")
@@ -78,7 +78,7 @@ extension AsyncHTTPClient.HTTPClient: AWSHTTPClient {
             requestBody = .stream(length: size) { writer in
                 return self.writeToStreamWriter(writer: writer, size: size, on: eventLoop, getData: getData)
             }
-        case .none:
+        case .empty:
             requestBody = nil
         }
         do {

--- a/Sources/AWSSDKSwiftCore/HTTP/NIOTSHTTPClient.swift
+++ b/Sources/AWSSDKSwiftCore/HTTP/NIOTSHTTPClient.swift
@@ -254,7 +254,18 @@ extension NIOTSHTTPClient: AWSHTTPClient {
           uri: request.url.absoluteString
         )
         head.headers = request.headers
-        let request = Request(head: head, body: request.body)
+        let requestBody: ByteBuffer?
+        if let body = request.body {
+            switch body {
+            case .byteBuffer(let byteBuffer):
+                requestBody = byteBuffer
+            case .stream:
+                preconditionFailure("Request streaming isnt supported")
+            }
+        } else {
+            requestBody = nil
+        }
+        let request = Request(head: head, body: requestBody)
 
         return connect(request, timeout: timeout, on: eventLoop).map { return $0 }
     }

--- a/Sources/AWSSDKSwiftCore/HTTP/NIOTSHTTPClient.swift
+++ b/Sources/AWSSDKSwiftCore/HTTP/NIOTSHTTPClient.swift
@@ -254,15 +254,14 @@ extension NIOTSHTTPClient: AWSHTTPClient {
           uri: request.url.absoluteString
         )
         head.headers = request.headers
+
         let requestBody: ByteBuffer?
-        if let body = request.body {
-            switch body {
-            case .byteBuffer(let byteBuffer):
-                requestBody = byteBuffer
-            case .stream:
-                preconditionFailure("Request streaming isnt supported")
-            }
-        } else {
+        switch request.body?.payload {
+        case .some(.byteBuffer(let byteBuffer)):
+            requestBody = byteBuffer
+        case .some(.stream):
+            preconditionFailure("Request streaming isnt supported")
+        case .none:
             requestBody = nil
         }
         let request = Request(head: head, body: requestBody)

--- a/Sources/AWSSDKSwiftCore/HTTP/NIOTSHTTPClient.swift
+++ b/Sources/AWSSDKSwiftCore/HTTP/NIOTSHTTPClient.swift
@@ -157,9 +157,7 @@ public final class NIOTSHTTPClient {
 
             head.headers.replaceOrAdd(name: "Host", value: hostname)
             head.headers.replaceOrAdd(name: "User-Agent", value: "AWS SDK Swift Core")
-            if let body = request.body {
-                head.headers.replaceOrAdd(name: "Content-Length", value: body.readableBytes.description)
-            }
+            head.headers.replaceOrAdd(name: "Content-Length", value: request.body?.readableBytes.description ?? "0")
             head.headers.replaceOrAdd(name: "Connection", value: "Close")
 
 

--- a/Sources/AWSSDKSwiftCore/HTTP/NIOTSHTTPClient.swift
+++ b/Sources/AWSSDKSwiftCore/HTTP/NIOTSHTTPClient.swift
@@ -256,12 +256,12 @@ extension NIOTSHTTPClient: AWSHTTPClient {
         head.headers = request.headers
 
         let requestBody: ByteBuffer?
-        switch request.body?.payload {
-        case .some(.byteBuffer(let byteBuffer)):
+        switch request.body.payload {
+        case .byteBuffer(let byteBuffer):
             requestBody = byteBuffer
-        case .some(.stream):
+        case .stream:
             preconditionFailure("Request streaming isnt supported")
-        case .none:
+        case .empty:
             requestBody = nil
         }
         let request = Request(head: head, body: requestBody)

--- a/Sources/AWSSDKSwiftCore/Message/AWSMiddleware.swift
+++ b/Sources/AWSSDKSwiftCore/Message/AWSMiddleware.swift
@@ -52,7 +52,7 @@ public struct AWSLoggingMiddleware : AWSServiceMiddleware {
             output += "\n  "
             output += String(data: data, encoding: .utf8) ?? "Failed to convert JSON response to UTF8"
         case .raw(let payload):
-            output += "raw (\(payload.size) bytes)"
+            output += "raw (\(payload.size?.description ?? "unknown") bytes)"
         case .text(let string):
             output += "\n  \(string)"
         case .empty:

--- a/Sources/AWSSDKSwiftCore/Message/AWSMiddleware.swift
+++ b/Sources/AWSSDKSwiftCore/Message/AWSMiddleware.swift
@@ -51,8 +51,8 @@ public struct AWSLoggingMiddleware : AWSServiceMiddleware {
         case .json(let data):
             output += "\n  "
             output += String(data: data, encoding: .utf8) ?? "Failed to convert JSON response to UTF8"
-        case .buffer(let byteBuffer):
-            output += "data (\(byteBuffer.readableBytes) bytes)"
+        case .raw(let payload):
+            output += "raw (\(payload.size) bytes)"
         case .text(let string):
             output += "\n  \(string)"
         case .empty:

--- a/Sources/AWSSDKSwiftCore/Message/AWSRequest.swift
+++ b/Sources/AWSSDKSwiftCore/Message/AWSRequest.swift
@@ -108,12 +108,12 @@ public struct AWSRequest {
         let method = HTTPMethod(rawValue: httpMethod)
         let payload = self.body.asPayload()
         let bodyDataForSigning: AWSSigner.BodyData?
-        switch payload?.payload {
-        case .some(.byteBuffer(let buffer)):
+        switch payload.payload {
+        case .byteBuffer(let buffer):
             bodyDataForSigning = .byteBuffer(buffer)
-        case .some(.stream(size: _, stream: _)):
+        case .stream(size: _, stream: _):
             bodyDataForSigning = .unsignedPayload
-        case .none:
+        case .empty:
             bodyDataForSigning = nil
         }
         let signedURL = signer.signURL(url: url, method: method, body: bodyDataForSigning, date: Date(), expires: 86400)
@@ -125,12 +125,12 @@ public struct AWSRequest {
         let method = HTTPMethod(rawValue: httpMethod)
         let payload = self.body.asPayload()
         let bodyDataForSigning: AWSSigner.BodyData?
-        switch payload?.payload {
-        case .some(.byteBuffer(let buffer)):
+        switch payload.payload {
+        case .byteBuffer(let buffer):
             bodyDataForSigning = .byteBuffer(buffer)
-        case .some(.stream(size: _, stream: _)):
+        case .stream(size: _, stream: _):
             bodyDataForSigning = .unsignedPayload
-        case .none:
+        case .empty:
             bodyDataForSigning = nil
         }
         let signedHeaders = signer.signHeaders(url: url, method: method, headers: getHttpHeaders(), body: bodyDataForSigning, date: Date())

--- a/Sources/AWSSDKSwiftCore/Message/AWSRequest.swift
+++ b/Sources/AWSSDKSwiftCore/Message/AWSRequest.swift
@@ -111,7 +111,7 @@ public struct AWSRequest {
         switch payload.payload {
         case .byteBuffer(let buffer):
             bodyDataForSigning = .byteBuffer(buffer)
-        case .stream(size: _, stream: _):
+        case .stream:
             bodyDataForSigning = .unsignedPayload
         case .empty:
             bodyDataForSigning = nil
@@ -128,7 +128,7 @@ public struct AWSRequest {
         switch payload.payload {
         case .byteBuffer(let buffer):
             bodyDataForSigning = .byteBuffer(buffer)
-        case .stream(size: _, stream: _):
+        case .stream:
             bodyDataForSigning = .unsignedPayload
         case .empty:
             bodyDataForSigning = nil

--- a/Sources/AWSSDKSwiftCore/Message/AWSRequest.swift
+++ b/Sources/AWSSDKSwiftCore/Message/AWSRequest.swift
@@ -108,11 +108,12 @@ public struct AWSRequest {
         let method = HTTPMethod(rawValue: httpMethod)
         let payload = self.body.asPayload()
         let bodyDataForSigning: AWSSigner.BodyData?
-        if let body = payload?.asByteBuffer() {
-            bodyDataForSigning = .byteBuffer(body)
-        } else if case .stream = payload {
+        switch payload?.payload {
+        case .some(.byteBuffer(let buffer)):
+            bodyDataForSigning = .byteBuffer(buffer)
+        case .some(.stream(size: _, stream: _)):
             bodyDataForSigning = .unsignedPayload
-        } else {
+        case .none:
             bodyDataForSigning = nil
         }
         let signedURL = signer.signURL(url: url, method: method, body: bodyDataForSigning, date: Date(), expires: 86400)
@@ -124,11 +125,12 @@ public struct AWSRequest {
         let method = HTTPMethod(rawValue: httpMethod)
         let payload = self.body.asPayload()
         let bodyDataForSigning: AWSSigner.BodyData?
-        if let body = payload?.asByteBuffer() {
-            bodyDataForSigning = .byteBuffer(body)
-        } else if case .stream = payload {
+        switch payload?.payload {
+        case .some(.byteBuffer(let buffer)):
+            bodyDataForSigning = .byteBuffer(buffer)
+        case .some(.stream(size: _, stream: _)):
             bodyDataForSigning = .unsignedPayload
-        } else {
+        case .none:
             bodyDataForSigning = nil
         }
         let signedHeaders = signer.signHeaders(url: url, method: method, headers: getHttpHeaders(), body: bodyDataForSigning, date: Date())

--- a/Sources/AWSSDKSwiftCore/Message/AWSRequest.swift
+++ b/Sources/AWSSDKSwiftCore/Message/AWSRequest.swift
@@ -110,6 +110,8 @@ public struct AWSRequest {
         let bodyDataForSigning: AWSSigner.BodyData?
         if let body = payload?.asByteBuffer() {
             bodyDataForSigning = .byteBuffer(body)
+        } else if case .stream = payload {
+            bodyDataForSigning = .unsignedPayload
         } else {
             bodyDataForSigning = nil
         }
@@ -124,6 +126,8 @@ public struct AWSRequest {
         let bodyDataForSigning: AWSSigner.BodyData?
         if let body = payload?.asByteBuffer() {
             bodyDataForSigning = .byteBuffer(body)
+        } else if case .stream = payload {
+            bodyDataForSigning = .unsignedPayload
         } else {
             bodyDataForSigning = nil
         }

--- a/Sources/AWSSDKSwiftCore/Message/AWSRequest.swift
+++ b/Sources/AWSSDKSwiftCore/Message/AWSRequest.swift
@@ -76,7 +76,7 @@ public struct AWSRequest {
         }
         return HTTPHeaders(headers.map { ($0, $1) })
     }
-  
+
     func createHTTPRequest(signer: AWSSigner) -> AWSHTTPRequest {
         // if credentials are empty don't sign request
         if signer.credentials.isEmpty() {
@@ -100,23 +100,35 @@ public struct AWSRequest {
 
     /// Create HTTP Client request from AWSRequest
     func toHTTPRequest() -> AWSHTTPRequest {
-        return AWSHTTPRequest.init(url: url, method: HTTPMethod(rawValue: httpMethod), headers: getHttpHeaders(), body: body.asByteBuffer())
+        return AWSHTTPRequest.init(url: url, method: HTTPMethod(rawValue: httpMethod), headers: getHttpHeaders(), body: body.asPayload())
     }
 
     /// Create HTTP Client request with signed URL from AWSRequest
     func toHTTPRequestWithSignedURL(signer: AWSSigner) -> AWSHTTPRequest {
         let method = HTTPMethod(rawValue: httpMethod)
-        let bodyData = body.asByteBuffer()
-        let signedURL = signer.signURL(url: url, method: method, body: bodyData != nil ? .byteBuffer(bodyData!) : nil, date: Date(), expires: 86400)
-        return AWSHTTPRequest.init(url: signedURL, method: method, headers: getHttpHeaders(), body: bodyData)
+        let body = self.body.asPayload()
+        let bodyDataForSigning: AWSSigner.BodyData?
+        if case .byteBuffer(let byteBuffer) = body {
+            bodyDataForSigning = .byteBuffer(byteBuffer)
+        } else {
+            bodyDataForSigning = nil
+        }
+        let signedURL = signer.signURL(url: url, method: method, body: bodyDataForSigning, date: Date(), expires: 86400)
+        return AWSHTTPRequest.init(url: signedURL, method: method, headers: getHttpHeaders(), body: body)
     }
 
     /// Create HTTP Client request with signed headers from AWSRequest
     func toHTTPRequestWithSignedHeader(signer: AWSSigner) -> AWSHTTPRequest {
         let method = HTTPMethod(rawValue: httpMethod)
-        let bodyData = body.asByteBuffer()
-        let signedHeaders = signer.signHeaders(url: url, method: method, headers: getHttpHeaders(), body: bodyData != nil ? .byteBuffer(bodyData!) : nil, date: Date())
-        return AWSHTTPRequest.init(url: url, method: method, headers: signedHeaders, body: bodyData)
+        let body = self.body.asPayload()
+        let bodyDataForSigning: AWSSigner.BodyData?
+        if case .byteBuffer(let byteBuffer) = body {
+            bodyDataForSigning = .byteBuffer(byteBuffer)
+        } else {
+            bodyDataForSigning = nil
+        }
+        let signedHeaders = signer.signHeaders(url: url, method: method, headers: getHttpHeaders(), body: bodyDataForSigning, date: Date())
+        return AWSHTTPRequest.init(url: url, method: method, headers: signedHeaders, body: body)
     }
 
     // return new request with middleware applied

--- a/Sources/AWSSDKSwiftCore/Message/AWSResponse.swift
+++ b/Sources/AWSSDKSwiftCore/Message/AWSResponse.swift
@@ -42,14 +42,18 @@ public struct AWSResponse {
 
         // body
         guard let body = response.body,
-            body.readableBytes > 0,
-            let data = body.getData(at: body.readerIndex, length: body.readableBytes, byteTransferStrategy: .noCopy) else {
-                self.body = .empty
-                return
+            body.readableBytes > 0 else {
+            self.body = .empty
+            return
         }
 
         if raw {
-            self.body = .buffer(body)
+            self.body = .raw(.byteBuffer(body))
+            return
+        }
+
+        guard let data = body.getData(at: body.readerIndex, length: body.readableBytes, byteTransferStrategy: .noCopy) else {
+            self.body = .empty
             return
         }
 

--- a/Sources/AWSSDKSwiftCore/Message/Body.swift
+++ b/Sources/AWSSDKSwiftCore/Message/Body.swift
@@ -58,7 +58,7 @@ extension Body {
     }
 
     /// return as payload
-    public func asPayload() -> AWSPayload? {
+    public func asPayload() -> AWSPayload {
         switch self {
         case .text(let text):
             var buffer = ByteBufferAllocator().buffer(capacity: text.utf8.count)
@@ -70,7 +70,7 @@ extension Body {
 
         case .json(let data):
             if data.isEmpty {
-                return nil
+                return .empty
             } else {
                 var buffer = ByteBufferAllocator().buffer(capacity: data.count)
                 buffer.writeBytes(data)
@@ -85,12 +85,12 @@ extension Body {
             return .byteBuffer(buffer)
 
         case .empty:
-            return nil
+            return .empty
         }
     }
     
     // return as ByteBuffer
     public func asByteBuffer() -> ByteBuffer? {
-        return asPayload()?.asByteBuffer()
+        return asPayload().asByteBuffer()
     }
 }

--- a/Sources/AWSSDKSwiftCore/Message/Body.swift
+++ b/Sources/AWSSDKSwiftCore/Message/Body.swift
@@ -39,7 +39,7 @@ extension Body {
             return text
 
         case .raw(let payload):
-            if case .byteBuffer(let byteBuffer) = payload {
+            if let byteBuffer = payload.asByteBuffer() {
                 return byteBuffer.getString(at: byteBuffer.readerIndex, length: byteBuffer.readableBytes, encoding: .utf8)
             } else {
                 return nil

--- a/Sources/AWSSDKSwiftCore/Message/Body.swift
+++ b/Sources/AWSSDKSwiftCore/Message/Body.swift
@@ -57,7 +57,7 @@ extension Body {
         }
     }
 
-    /// return as bytebuffer
+    /// return as payload
     public func asPayload() -> AWSPayload? {
         switch self {
         case .text(let text):

--- a/Sources/AWSSDKSwiftCore/Message/Body.swift
+++ b/Sources/AWSSDKSwiftCore/Message/Body.swift
@@ -88,4 +88,9 @@ extension Body {
             return nil
         }
     }
+    
+    // return as ByteBuffer
+    public func asByteBuffer() -> ByteBuffer? {
+        return asPayload()?.asByteBuffer()
+    }
 }

--- a/Sources/AWSSDKSwiftCore/MetaDataService.swift
+++ b/Sources/AWSSDKSwiftCore/MetaDataService.swift
@@ -63,7 +63,7 @@ extension MetaDataServiceProvider {
 
     /// make HTTP request
     func request(url: String, method: HTTPMethod = .GET, headers: [String:String] = [:], timeout: TimeInterval, httpClient: AWSHTTPClient, on eventLoop: EventLoop) -> EventLoopFuture<AWSHTTPResponse> {
-        let request = AWSHTTPRequest(url: URL(string: url)!, method: method, headers: HTTPHeaders(headers.map {($0.key, $0.value) }), body: nil)
+        let request = AWSHTTPRequest(url: URL(string: url)!, method: method, headers: HTTPHeaders(headers.map {($0.key, $0.value) }))
         let futureResponse = httpClient.execute(request: request, timeout: TimeAmount.seconds(2), on: eventLoop)
         return futureResponse
     }

--- a/Sources/AWSSignerV4/signer.swift
+++ b/Sources/AWSSignerV4/signer.swift
@@ -48,6 +48,7 @@ public struct AWSSigner {
         case string(String)
         case data(Data)
         case byteBuffer(ByteBuffer)
+        case unsignedPayload
     }
 
     /// Generate signed headers, for a HTTP request
@@ -202,6 +203,8 @@ public struct AWSSigner {
             hash = byteBufferView.withContiguousStorageIfAvailable { bytes in
                 return SHA256.hash(data: bytes).hexDigest()
             }
+        case .unsignedPayload:
+            return "UNSIGNED-PAYLOAD"
         }
         if let hash = hash {
             return hash

--- a/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
@@ -246,7 +246,7 @@ class AWSClientTests: XCTestCase {
             XCTAssertEqual(awsRequest.url.absoluteString, "https://s3.ca-central-1.amazonaws.com/Bucket?list-type=2")
             let nioRequest: AWSHTTPRequest = awsRequest.toHTTPRequest()
             XCTAssertEqual(nioRequest.method, HTTPMethod.GET)
-            XCTAssertNil(nioRequest.body)
+            XCTAssertTrue(nioRequest.body.isEmpty)
         } catch {
             XCTFail(error.localizedDescription)
         }
@@ -315,7 +315,7 @@ class AWSClientTests: XCTestCase {
             let request = KeywordRequest(repeat: "Repeat")
             let awsRequest = try s3Client.createAWSRequest(operation: "Keyword", path: "/", httpMethod: "POST", input: request)
             XCTAssertEqual(awsRequest.httpHeaders["repeat"] as? String, "Repeat")
-            XCTAssertNil(awsRequest.body.asPayload())
+            XCTAssertTrue(awsRequest.body.asPayload().isEmpty)
         } catch {
             XCTFail(error.localizedDescription)
         }

--- a/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
@@ -332,7 +332,7 @@ class AWSClientTests: XCTestCase {
             let request = KeywordRequest(self: "KeywordRequest")
             let awsRequest = try s3Client.createAWSRequest(operation: "Keyword", path: "/", httpMethod: "POST", input: request)
             XCTAssertEqual(awsRequest.url, URL(string:"https://s3.ca-central-1.amazonaws.com/?self=KeywordRequest")!)
-            XCTAssertEqual(awsRequest.body.asPayload()?.asByteBuffer(), nil)
+            XCTAssertEqual(awsRequest.body.asByteBuffer(), nil)
         } catch {
             XCTFail(error.localizedDescription)
         }

--- a/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
@@ -1015,6 +1015,7 @@ class AWSClientTests: XCTestCase {
     func testRequestStreaming() {
         struct Input : AWSEncodableShape & AWSShapeWithPayload {
             static var payloadPath: String = "payload"
+            static var options: PayloadOptions = [.allowStreaming]
             let payload: AWSPayload
             private enum CodingKeys: CodingKey {}
         }
@@ -1059,6 +1060,7 @@ class AWSClientTests: XCTestCase {
     func testRequestStreamingTooMuchData() {
         struct Input : AWSEncodableShape & AWSShapeWithPayload {
             static var payloadPath: String = "payload"
+            static var options: PayloadOptions = [.allowStreaming]
             let payload: AWSPayload
             private enum CodingKeys: CodingKey {}
         }
@@ -1090,6 +1092,7 @@ class AWSClientTests: XCTestCase {
     func testRequestStreamingFile() {
         struct Input : AWSEncodableShape & AWSShapeWithPayload {
             static var payloadPath: String = "payload"
+            static var options: PayloadOptions = [.allowStreaming]
             let payload: AWSPayload
             private enum CodingKeys: CodingKey {}
         }
@@ -1143,6 +1146,7 @@ class AWSClientTests: XCTestCase {
     func testRequestChunkedStreaming() {
         struct Input : AWSEncodableShape & AWSShapeWithPayload {
             static var payloadPath: String = "payload"
+            static var options: PayloadOptions = [.allowStreaming, .allowChunkedStreaming]
             let payload: AWSPayload
             private enum CodingKeys: CodingKey {}
         }

--- a/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
@@ -1120,28 +1120,9 @@ class AWSClientTests: XCTestCase {
                 XCTAssertNoThrow(try fileHandle.close())
                 XCTAssertNoThrow(try threadPool.syncShutdownGracefully())
             }
-            // upload without file size
-            let input = Input(payload: .fileHandle(fileHandle, fileIO: fileIO))
+
+            let input = Input(payload: .fileHandle(fileHandle, size: bufferSize, fileIO: fileIO))
             let response = client.send(operation: "test", path: "/", httpMethod: "POST", input: input)
-
-            try awsServer.process { request in
-                XCTAssertEqual(request.headers["transfer-encoding"], "chunked")
-                XCTAssertNil(request.headers["Content-Size"])
-                let requestData = request.body.getData(at: 0, length: request.body.readableBytes)
-                XCTAssertEqual(requestData, data)
-                let response = AWSTestServer.Response(httpStatus: .ok, headers: [:], body: nil)
-                return AWSTestServer.Result(output: response, continueProcessing: false)
-            }
-
-            try response.wait()
-
-            // upload with file size
-            let fileHandle2 = try fileIO.openFile(path: filename, mode: .read, eventLoop: httpClient.eventLoopGroup.next()).wait()
-            defer {
-                XCTAssertNoThrow(try fileHandle2.close())
-            }
-            let input2 = Input(payload: .fileHandle(fileHandle2, size: bufferSize, fileIO: fileIO))
-            let response2 = client.send(operation: "test", path: "/", httpMethod: "POST", input: input2)
 
             try awsServer.process { request in
                 XCTAssertNil(request.headers["transfer-encoding"])
@@ -1152,7 +1133,7 @@ class AWSClientTests: XCTestCase {
                 return AWSTestServer.Result(output: response, continueProcessing: false)
             }
 
-            try response2.wait()
+            try response.wait()
         } catch AWSClient.ClientError.tooMuchData {
         } catch {
             XCTFail("Unexpected error: \(error)")

--- a/Tests/AWSSDKSwiftCoreTests/HTTPClientTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/HTTPClientTests.swift
@@ -50,7 +50,7 @@ class NIOTSHTTPClientTests: XCTestCase {
 
     func testInitWithInvalidURL() {
       do {
-        let request = AWSHTTPRequest(url: URL(string:"no_protocol.com")!, method: .GET, headers: HTTPHeaders(), body: nil)
+        let request = AWSHTTPRequest(url: URL(string:"no_protocol.com")!, method: .GET, headers: HTTPHeaders())
         _ = try client.execute(request: request, timeout: .seconds(5), on: client.eventLoopGroup.next()).wait()
         XCTFail("Should throw malformedURL error")
       } catch {
@@ -63,7 +63,7 @@ class NIOTSHTTPClientTests: XCTestCase {
 
     func testConnectGet() {
         do {
-            let request = AWSHTTPRequest(url: awsServer.addressURL, method: .GET, headers: HTTPHeaders(), body: nil)
+            let request = AWSHTTPRequest(url: awsServer.addressURL, method: .GET, headers: HTTPHeaders())
             let future = client.execute(request: request, timeout: .seconds(5), on: client.eventLoopGroup.next())
             try awsServer.httpBin()
             _ = try future.wait()
@@ -74,7 +74,7 @@ class NIOTSHTTPClientTests: XCTestCase {
 
     func testConnectPost() {
         do {
-            let request = AWSHTTPRequest(url: awsServer.addressURL, method: .POST, headers: HTTPHeaders(), body: nil)
+            let request = AWSHTTPRequest(url: awsServer.addressURL, method: .POST, headers: HTTPHeaders())
             let future = client.execute(request: request, timeout: .seconds(5), on: client.eventLoopGroup.next())
             try awsServer.httpBin()
             _ = try future.wait()
@@ -153,7 +153,7 @@ class HTTPClientTests {
                 XCTAssertNoThrow(try awsServer.stop())
             }
             let headers: HTTPHeaders = [:]
-            let request = AWSHTTPRequest(url: URL(string: "\(awsServer.address)/get?test=2")!, method: .GET, headers: headers, body: nil)
+            let request = AWSHTTPRequest(url: URL(string: "\(awsServer.address)/get?test=2")!, method: .GET, headers: headers, body: .empty)
             let responseFuture = execute(request)
 
             try awsServer.httpBin()
@@ -170,7 +170,7 @@ class HTTPClientTests {
     func testHTTPS() {
         do {
             let headers: HTTPHeaders = [:]
-            let request = AWSHTTPRequest(url: URL(string:"https://httpbin.org/get")!, method: .GET, headers: headers, body: nil)
+            let request = AWSHTTPRequest(url: URL(string:"https://httpbin.org/get")!, method: .GET, headers: headers)
             let response = try execute(request).wait()
 
             XCTAssertEqual(response.url, "https://httpbin.org/get")
@@ -188,7 +188,7 @@ class HTTPClientTests {
             let headers: HTTPHeaders = [
                 "Test-Header": "testValue"
             ]
-            let request = AWSHTTPRequest(url: awsServer.addressURL, method: .POST, headers: headers, body: nil)
+            let request = AWSHTTPRequest(url: awsServer.addressURL, method: .POST, headers: headers, body: .empty)
             let responseFuture = execute(request)
 
             try awsServer.httpBin()

--- a/Tests/AWSSDKSwiftCoreTests/HTTPClientTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/HTTPClientTests.swift
@@ -216,7 +216,7 @@ class HTTPClientTests {
             let text = "thisisatest"
             var body = ByteBufferAllocator().buffer(capacity: text.utf8.count)
             body.writeString(text)
-            let request = AWSHTTPRequest(url: awsServer.addressURL, method: .POST, headers: headers, body: body)
+            let request = AWSHTTPRequest(url: awsServer.addressURL, method: .POST, headers: headers, body: .byteBuffer(body))
             let responseFuture = execute(request)
 
             try awsServer.httpBin()

--- a/Tests/AWSSDKSwiftCoreTests/TestServer.swift
+++ b/Tests/AWSSDKSwiftCoreTests/TestServer.swift
@@ -28,6 +28,7 @@ class AWSTestServer {
         case notEnd
         case emptyBody
         case noXMLBody
+        case corruptChunkedData
     }
     // what are we returning
     enum ServiceProtocol {
@@ -222,18 +223,112 @@ extension AWSTestServer {
         return result.continueProcessing
     }
 
+    enum ReadChunkStatus {
+        case none
+        case readingSize(String)
+        case readingChunk(Int)
+        case readingEnd(String)
+        case finishing(String)
+        case finished
+    }
+
+    /// read chunked data see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Transfer-Encoding
+    func readChunkedData(status: ReadChunkStatus, input: inout ByteBuffer, output: inout ByteBuffer) throws -> ReadChunkStatus {
+        var status = status
+        
+        func _readChunkSize(chunkSize: String, input: inout ByteBuffer) throws -> ReadChunkStatus {
+            var chunkSize = chunkSize
+            while(input.readableBytes > 0) {
+                guard let char = input.readString(length: 1) else { throw Error.corruptChunkedData }
+                chunkSize += char
+                if chunkSize.hasSuffix("\r\n") {
+                    // "\r\n" is considered one character apparently
+                    let hexChunkSize = String(chunkSize.dropLast(1))
+                    guard let chunkSize = Int(hexChunkSize, radix: 16) else { throw Error.corruptChunkedData }
+                    if chunkSize == 0 {
+                        return .finishing("")
+                    } else {
+                        return .readingChunk(chunkSize)
+                    }
+                }
+            }
+            return .readingSize(chunkSize)
+        }
+        
+        func _readChunkEnd(chunkEnd: String, input: inout ByteBuffer) throws -> ReadChunkStatus {
+            var chunkEnd = chunkEnd
+            while(input.readableBytes > 0) {
+                guard let char = input.readString(length: 1) else { throw Error.corruptChunkedData }
+                chunkEnd += char
+                if chunkEnd == "\r\n" {
+                    return .none
+                } else if chunkEnd.count > 2 {
+                    throw Error.corruptChunkedData
+                }
+            }
+            return .readingEnd(chunkEnd)
+        }
+        
+        while(input.readableBytes > 0) {
+            switch status {
+            case .none:
+                status = try _readChunkSize(chunkSize: "", input: &input)
+                
+            case .readingSize(let chunkSize):
+                status = try _readChunkSize(chunkSize: chunkSize, input: &input)
+
+            case .readingChunk(let size):
+                let blockSize = min(size, input.readableBytes)
+                var slice = input.readSlice(length: blockSize)!
+                output.writeBuffer(&slice)
+                if blockSize == size {
+                    status = .readingEnd("")
+                } else {
+                    status = .readingChunk(size - blockSize)
+                }
+                
+            case .readingEnd(let chunkEnd):
+                status = try _readChunkEnd(chunkEnd: chunkEnd, input: &input)
+
+            case .finishing(let chunkEnd):
+                status = try _readChunkEnd(chunkEnd: chunkEnd, input: &input)
+                if case .none = status {
+                    status = .finished
+                }
+
+            case .finished:
+                throw Error.corruptChunkedData
+            }
+        }
+        return status
+    }
+    
     /// read inbound request
     func readRequest() throws -> Request {
         var byteBuffer = byteBufferAllocator.buffer(capacity: 0)
 
         // read inbound
         guard case .head(let head) = try web.readInbound() else {throw Error.notHead}
+        let isChunked = head.headers["transfer-encoding"].filter { $0 == "chunked" }.count > 0
+        var chunkStatus: ReadChunkStatus = .none
         // read body
         while(true) {
             let inbound = try web.readInbound()
             if case .body(var buffer) = inbound {
-                byteBuffer.writeBuffer(&buffer)
+                if isChunked == true {
+                    chunkStatus = try readChunkedData(status: chunkStatus, input: &buffer, output: &byteBuffer)
+                } else {
+                    byteBuffer.writeBuffer(&buffer)
+                }
             } else if case .end(_) = inbound {
+                if isChunked == true {
+                    switch chunkStatus {
+                    case .finished:
+                        break
+                    default:
+                        throw Error.corruptChunkedData
+                    }
+                }
                 break
             } else {
                 throw Error.notEnd

--- a/Tests/AWSSDKSwiftCoreTests/TestUtils.swift
+++ b/Tests/AWSSDKSwiftCoreTests/TestUtils.swift
@@ -23,7 +23,7 @@ import Foundation
         self.defaultValue = `default`
         self.variableName = variableName
     }
-    
+
     public var wrappedValue: Value {
         get {
             guard let value = Environment[variableName] else { return defaultValue }
@@ -70,4 +70,22 @@ func createAWSClient(
         possibleErrorTypes: possibleErrorTypes,
         httpClientProvider: httpClientProvider
     )
+}
+
+// create a buffer of random values. Will always create the same given you supply the same z and w values
+// Random number generator from https://www.codeproject.com/Articles/25172/Simple-Random-Number-Generation
+func createRandomBuffer(_ w: UInt, _ z: UInt, size: Int) -> [UInt8] {
+    var z = z
+    var w = w
+    func getUInt8() -> UInt8
+    {
+        z = 36969 * (z & 65535) + (z >> 16);
+        w = 18000 * (w & 65535) + (w >> 16);
+        return UInt8(((z << 16) + w) & 0xff);
+    }
+    var data = Array<UInt8>(repeating: 0, count: size)
+    for i in 0..<size {
+        data[i] = getUInt8()
+    }
+    return data
 }


### PR DESCRIPTION
AWSPayload is now an enum and has a `.stream` case which has parameters `size` and `closure`. `closure` supplies `EventLoopFuture<ByteBuffer>`. It is repeatedly called until enough data has been supplied.

Internally `Body.buffer` is now `Body.raw` and has a AWSPayload as a parameter. As with the streaming response PR this functionality is only available with AsyncHTTPClient.

TODO:
- [x] Check what to do for signing of requests that aren't S3 