### PR TITLE
ServiceConfig object defining AWS service

### DIFF
--- a/Sources/AWSSDKSwiftCore/RetryController.swift
+++ b/Sources/AWSSDKSwiftCore/RetryController.swift
@@ -1,3 +1,17 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the AWSSDKSwift open source project
+//
+// Copyright (c) 2020 the AWSSDKSwift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of AWSSDKSwift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
 import NIO
 import NIOHTTP1
 

--- a/Sources/AWSSDKSwiftCore/ServiceConfig.swift
+++ b/Sources/AWSSDKSwiftCore/ServiceConfig.swift
@@ -1,0 +1,87 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the AWSSDKSwift open source project
+//
+// Copyright (c) 2020 the AWSSDKSwift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of AWSSDKSwift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import class Foundation.ProcessInfo
+
+/// Configuration class defining an AWS service
+public struct ServiceConfig {
+    /// Region where service is running
+    public let region: Region
+    /// The destination service of the request. Added as a header value, along with the operation name
+    public let amzTarget: String?
+    /// Name used to sign requests
+    public let signingName: String
+    /// Protocol used by service json/xml/query
+    public let serviceProtocol: ServiceProtocol
+    /// Version of the Service API, added as a header in query protocol based services
+    public let apiVersion: String
+    /// The url to use in requests
+    public let endpoint: String
+    /// An array of the possible error types returned by the service
+    public let possibleErrorTypes: [AWSErrorType.Type]
+    /// Middleware code specific to the service used to edit requests before they sent and responses before they are decoded
+    public let middlewares: [AWSServiceMiddleware]
+    
+    public init(
+        region givenRegion: Region?,
+        amzTarget: String? = nil,
+        service: String,
+        signingName: String? = nil,
+        serviceProtocol: ServiceProtocol,
+        apiVersion: String,
+        endpoint: String? = nil,
+        serviceEndpoints: [String: String] = [:],
+        partitionEndpoint: String? = nil,
+        possibleErrorTypes: [AWSErrorType.Type] = [],
+        middlewares: [AWSServiceMiddleware] = []
+    )
+    {
+        if let _region = givenRegion {
+            region = _region
+        }
+        else if let partitionEndpoint = partitionEndpoint {
+            if partitionEndpoint == "aws-global" {
+                region = .useast1
+            } else {
+                region = Region(rawValue: partitionEndpoint)
+            }
+        } else if let defaultRegion = ProcessInfo.processInfo.environment["AWS_DEFAULT_REGION"] {
+            region = Region(rawValue: defaultRegion)
+        } else {
+            region = .useast1
+        }
+
+        self.apiVersion = apiVersion
+        self.signingName = signingName ?? service
+        self.amzTarget = amzTarget
+        self.serviceProtocol = serviceProtocol
+        self.possibleErrorTypes = possibleErrorTypes
+        self.middlewares = middlewares
+
+        // work out endpoint, if provided use that otherwise
+        if let endpoint = endpoint {
+            self.endpoint = endpoint
+        } else {
+            let serviceHost: String
+            if let serviceEndpoint = serviceEndpoints[region.rawValue] {
+                serviceHost = serviceEndpoint
+            } else if let partitionEndpoint = partitionEndpoint, let globalEndpoint = serviceEndpoints[partitionEndpoint] {
+                serviceHost = globalEndpoint
+            } else {
+                serviceHost = "\(service).\(region.rawValue).amazonaws.com"
+            }
+            self.endpoint = "https://\(serviceHost)"
+        }
+    }
+}

--- a/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
@@ -219,7 +219,7 @@ class AWSClientTests: XCTestCase {
                 httpMethod: "POST",
                 input: input1
             )
-            XCTAssertEqual(awsRequest.url.absoluteString, "\(sesClient.endpoint)/")
+            XCTAssertEqual(awsRequest.url.absoluteString, "\(sesClient.serviceConfig.endpoint)/")
             let nioRequest: AWSHTTPRequest = awsRequest.toHTTPRequest()
             XCTAssertEqual(nioRequest.headers["value"][0], "<html><body><a href=\"https://redsox.com\">Test</a></body></html>")
             XCTAssertEqual(nioRequest.headers["Content-Type"][0], "application/x-www-form-urlencoded; charset=utf-8")
@@ -248,7 +248,7 @@ class AWSClientTests: XCTestCase {
                 httpMethod: "POST",
                 input: input2
             )
-            XCTAssertEqual(awsRequest.url.absoluteString, "\(kinesisClient.endpoint)/")
+            XCTAssertEqual(awsRequest.url.absoluteString, "\(kinesisClient.serviceConfig.endpoint)/")
 
             if case .json(let data) = awsRequest.body, let parsedBody = try JSONSerialization.jsonObject(with: data, options: []) as? [String:Any] {
                 if let member = parsedBody["Member"] as? [String:Any] {

--- a/Tests/AWSSDKSwiftCoreTests/TestUtils.swift
+++ b/Tests/AWSSDKSwiftCoreTests/TestUtils.swift
@@ -47,7 +47,7 @@ func createAWSClient(
     partitionEndpoint: String? = nil,
     retryController: RetryController = NoRetry(),
     middlewares: [AWSServiceMiddleware] = [],
-    possibleErrorTypes: [AWSErrorType.Type]? = nil,
+    possibleErrorTypes: [AWSErrorType.Type] = [],
     httpClientProvider: AWSClient.HTTPClientProvider = .createNew
 ) -> AWSClient {
     return AWSClient(


### PR DESCRIPTION
See https://github.com/swift-aws/aws-sdk-swift/issues/231 first

Based off #201 except I haven't added accessors to `AWSClient` where variables were internal. Also internally all accesses to the `ServiceConfig` are through the `serviceConfig` variable as this is how we will be accessing them when we move away from the client owning this data. 

Found a few variable we don't need to store. We only need them to construct the `endpoint` so I don't store them anymore.