### PR TITLE
Added `on eventLoop: EventLoop` parameter to send() functions

### DIFF
--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -140,17 +140,16 @@ public final class AWSClient {
             self.httpClient = AWSClient.createHTTPClient()
         }
 
-        let eventLoopGroup = self.httpClient.eventLoopGroup
         // create credentialProvider
         if let accessKey = accessKeyId, let secretKey = secretAccessKey {
             let credential = StaticCredential(accessKeyId: accessKey, secretAccessKey: secretKey, sessionToken: sessionToken)
-            self.credentialProvider = StaticCredentialProvider(credential: credential, eventLoopGroup: eventLoopGroup)
+            self.credentialProvider = StaticCredentialProvider(credential: credential)
         } else if let ecredential = EnvironmentCredential() {
             let credential = ecredential
-            self.credentialProvider = StaticCredentialProvider(credential: credential, eventLoopGroup: eventLoopGroup)
+            self.credentialProvider = StaticCredentialProvider(credential: credential)
         } else if let scredential = try? SharedCredential() {
             let credential = scredential
-            self.credentialProvider = StaticCredentialProvider(credential: credential, eventLoopGroup: eventLoopGroup)
+            self.credentialProvider = StaticCredentialProvider(credential: credential)
         } else {
             self.credentialProvider = MetaDataCredentialProvider(httpClient: self.httpClient)
         }

--- a/Sources/AWSSDKSwiftCore/HTTP/AWSHTTPClient.swift
+++ b/Sources/AWSSDKSwiftCore/HTTP/AWSHTTPClient.swift
@@ -34,7 +34,7 @@ public protocol AWSHTTPResponse {
 /// Protocol defining requirements for a HTTPClient
 public protocol AWSHTTPClient {
     /// Execute HTTP request and return a future holding a HTTP Response
-    func execute(request: AWSHTTPRequest, timeout: TimeAmount) -> EventLoopFuture<AWSHTTPResponse>
+    func execute(request: AWSHTTPRequest, timeout: TimeAmount, on eventLoop: EventLoop?) -> EventLoopFuture<AWSHTTPResponse>
     
     /// This should be called before an HTTP Client can be de-initialised
     func syncShutdown() throws

--- a/Sources/AWSSDKSwiftCore/HTTP/AsyncHTTPClient.swift
+++ b/Sources/AWSSDKSwiftCore/HTTP/AsyncHTTPClient.swift
@@ -27,6 +27,7 @@ extension AsyncHTTPClient.HTTPClient: AWSHTTPClient {
         }
         do {
             let eventLoop = eventLoop ?? eventLoopGroup.next()
+            precondition(self.eventLoopGroup.makeIterator().contains { $0 === eventLoop }, "EventLoop provided to AWSClient must be part of HTTPClient's EventLoopGroup.")
             let asyncRequest = try AsyncHTTPClient.HTTPClient.Request(url: request.url, method: request.method, headers: request.headers, body: requestBody)
             return execute(request: asyncRequest, eventLoop: .delegate(on: eventLoop), deadline: .now() + timeout).map { $0 }
         } catch {

--- a/Sources/AWSSDKSwiftCore/HTTP/NIOTSHTTPClient.swift
+++ b/Sources/AWSSDKSwiftCore/HTTP/NIOTSHTTPClient.swift
@@ -245,6 +245,9 @@ public final class NIOTSHTTPClient {
 extension NIOTSHTTPClient: AWSHTTPClient {
 
     public func execute(request: AWSHTTPRequest, timeout: TimeAmount, on eventLoop: EventLoop?) -> EventLoopFuture<AWSHTTPResponse> {
+        if let eventLoop = eventLoop {
+            precondition(self.eventLoopGroup.makeIterator().contains { $0 === eventLoop }, "EventLoop provided to AWSClient must be part of the HTTPClient's EventLoopGroup.")
+        }
         var head = HTTPRequestHead(
           version: HTTPVersion(major: 1, minor: 1),
           method: request.method,

--- a/Tests/AWSSDKSwiftCoreTests/HTTPClientTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/HTTPClientTests.swift
@@ -51,7 +51,7 @@ class NIOTSHTTPClientTests: XCTestCase {
     func testInitWithInvalidURL() {
       do {
         let request = AWSHTTPRequest(url: URL(string:"no_protocol.com")!, method: .GET, headers: HTTPHeaders(), body: nil)
-        _ = try client.execute(request: request, timeout: .seconds(5)).wait()
+        _ = try client.execute(request: request, timeout: .seconds(5), on: client.eventLoopGroup.next()).wait()
         XCTFail("Should throw malformedURL error")
       } catch {
         if case NIOTSHTTPClient.HTTPError.malformedURL = error {}
@@ -64,7 +64,7 @@ class NIOTSHTTPClientTests: XCTestCase {
     func testConnectGet() {
         do {
             let request = AWSHTTPRequest(url: awsServer.addressURL, method: .GET, headers: HTTPHeaders(), body: nil)
-            let future = client.execute(request: request, timeout: .seconds(5))
+            let future = client.execute(request: request, timeout: .seconds(5), on: client.eventLoopGroup.next())
             try awsServer.httpBin()
             _ = try future.wait()
         } catch {
@@ -75,7 +75,7 @@ class NIOTSHTTPClientTests: XCTestCase {
     func testConnectPost() {
         do {
             let request = AWSHTTPRequest(url: awsServer.addressURL, method: .POST, headers: HTTPHeaders(), body: nil)
-            let future = client.execute(request: request, timeout: .seconds(5))
+            let future = client.execute(request: request, timeout: .seconds(5), on: client.eventLoopGroup.next())
             try awsServer.httpBin()
             _ = try future.wait()
         } catch {
@@ -147,7 +147,7 @@ class HTTPClientTests {
     }
 
     func execute(_ request: AWSHTTPRequest) -> EventLoopFuture<AWSTestServer.HTTPBinResponse> {
-        return client.execute(request: request, timeout: .seconds(5))
+        return client.execute(request: request, timeout: .seconds(5), on: client.eventLoopGroup.next())
             .flatMapThrowing { response in
                 print(String(data: response.bodyData ?? Data(), encoding: .utf8)!)
                 return try JSONDecoder().decode(AWSTestServer.HTTPBinResponse.self, from: response.bodyData ?? Data())

--- a/Tests/AWSSDKSwiftCoreTests/MetaDataServiceTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/MetaDataServiceTests.swift
@@ -74,7 +74,7 @@ class MetaDataServiceTests: XCTestCase {
         if ProcessInfo.processInfo.environment["TEST_EC2_METADATA"] != nil {
             do {
                 let httpClient = HTTPClient(eventLoopGroupProvider: .createNew)
-                _ = try MetaDataService.getCredential(httpClient: httpClient).wait()
+                _ = try MetaDataService.getCredential(httpClient: httpClient, on: httpClient.eventLoopGroup.next()).wait()
             } catch {
                 XCTFail("Unexpected error: \(error)")
             }


### PR DESCRIPTION
Added `on eventLoop: EventLoop` parameter to send() functions and then pass this eventLoop through all the systems.

This allows users of aws-sdk-swift more control over which eventloop their requests run on. 