### PR TITLE
Support AWSPayload object in response

### DIFF
--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -626,15 +626,7 @@ extension AWSClient {
 
         case .buffer(let byteBuffer):
             if let payloadKey = payloadKey {
-                // convert ByteBuffer to Data
-                let data = byteBuffer.getData(at: byteBuffer.readerIndex, length: byteBuffer.readableBytes)
-                outputDict[payloadKey] = data
-            }
-            decoder.dataDecodingStrategy = .raw
-
-        case .text(let text):
-            if let payloadKey = payloadKey {
-                outputDict[payloadKey] = text
+                outputDict[payloadKey] = AWSPayload.byteBuffer(byteBuffer)
             }
 
         default:

--- a/Sources/AWSSDKSwiftCore/AWSShapes/Payload.swift
+++ b/Sources/AWSSDKSwiftCore/AWSShapes/Payload.swift
@@ -6,23 +6,43 @@
 //
 import struct Foundation.Data
 import NIO
+import NIOFoundationCompat
 
+/// Object storing request/response payload
 public struct AWSPayload {
 
+    /// Construct a payload from a ByteBuffer
     public static func byteBuffer(_ byteBuffer: ByteBuffer) -> Self {
         return Self(byteBuffer: byteBuffer)
     }
 
+    /// Construct a payload from a Data
     public static func data(_ data: Data) -> Self {
         var byteBuffer = ByteBufferAllocator().buffer(capacity: data.count)
         byteBuffer.writeBytes(data)
         return Self(byteBuffer: byteBuffer)
     }
 
+    /// Construct a payload from a String
     public static func string(_ string: String) -> Self {
         var byteBuffer = ByteBufferAllocator().buffer(capacity: string.utf8.count)
         byteBuffer.writeString(string)
         return Self(byteBuffer: byteBuffer)
+    }
+
+    /// return payload as Data
+    public func asData() -> Data? {
+        return byteBuffer.getData(at: byteBuffer.readerIndex, length: byteBuffer.readableBytes, byteTransferStrategy: .noCopy)
+    }
+
+    /// return payload as String
+    public func asString() -> String? {
+        return byteBuffer.getString(at: byteBuffer.readerIndex, length: byteBuffer.readableBytes, encoding: .utf8)
+    }
+
+    /// return payload as ByteBuffer
+    public func asBytebuffer() -> ByteBuffer {
+        return byteBuffer
     }
 
     let byteBuffer: ByteBuffer

--- a/Sources/AWSSDKSwiftCore/AWSShapes/Payload.swift
+++ b/Sources/AWSSDKSwiftCore/AWSShapes/Payload.swift
@@ -8,17 +8,17 @@ import struct Foundation.Data
 import NIO
 
 public struct AWSPayload {
-    
+
     public static func byteBuffer(_ byteBuffer: ByteBuffer) -> Self {
         return Self(byteBuffer: byteBuffer)
     }
-    
+
     public static func data(_ data: Data) -> Self {
         var byteBuffer = ByteBufferAllocator().buffer(capacity: data.count)
         byteBuffer.writeBytes(data)
         return Self(byteBuffer: byteBuffer)
     }
-    
+
     public static func string(_ string: String) -> Self {
         var byteBuffer = ByteBufferAllocator().buffer(capacity: string.utf8.count)
         byteBuffer.writeString(string)
@@ -26,4 +26,19 @@ public struct AWSPayload {
     }
 
     let byteBuffer: ByteBuffer
+}
+
+// The decode/encode functions are here temporarily until we merge in https://github.com/swift-aws/aws-sdk-swift-core/pull/214. After that we
+// should be able to remove them
+extension AWSPayload: Codable {
+
+    // AWSPayload has to comform to Codable so I can add it to AWSShape objects (which conform to Codable). But we don't want the
+    // Encoder/Decoder ever to process a AWSPayload
+    public init(from decoder: Decoder) throws {
+        preconditionFailure("Cannot decode an AWSPayload")
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        preconditionFailure("Cannot encode an AWSPayload")
+    }
 }

--- a/Sources/AWSSDKSwiftCore/AWSShapes/Payload.swift
+++ b/Sources/AWSSDKSwiftCore/AWSShapes/Payload.swift
@@ -48,17 +48,11 @@ public struct AWSPayload {
     let byteBuffer: ByteBuffer
 }
 
-// The decode/encode functions are here temporarily until we merge in https://github.com/swift-aws/aws-sdk-swift-core/pull/214. After that we
-// should be able to remove them
-extension AWSPayload: Codable {
+extension AWSPayload: Decodable {
 
-    // AWSPayload has to comform to Codable so I can add it to AWSShape objects (which conform to Codable). But we don't want the
+    // AWSPayload has to comform to Decodable so I can add it to AWSShape objects (which conform to Decodable). But we don't want the
     // Encoder/Decoder ever to process a AWSPayload
     public init(from decoder: Decoder) throws {
         preconditionFailure("Cannot decode an AWSPayload")
-    }
-
-    public func encode(to encoder: Encoder) throws {
-        preconditionFailure("Cannot encode an AWSPayload")
     }
 }

--- a/Sources/AWSSDKSwiftCore/Encoder/DictionaryDecoder.swift
+++ b/Sources/AWSSDKSwiftCore/Encoder/DictionaryDecoder.swift
@@ -1397,6 +1397,8 @@ extension __DictionaryDecoder {
             return try self.unbox(value, as: Date.self)
         } else if type == Data.self || type == NSData.self {
             return try self.unbox(value, as: Data.self)
+        } else if type == AWSPayload.self {
+            return value
         } else if type == URL.self || type == NSURL.self {
             guard let urlString = try self.unbox(value, as: String.self) else {
                 return nil

--- a/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
@@ -433,7 +433,7 @@ class AWSClientTests: XCTestCase {
             XCTFail(error.localizedDescription)
         }
     }
-    
+
     func testProtocolContentType() throws {
         struct Object: AWSEncodableShape {
             let string: String
@@ -445,11 +445,11 @@ class AWSClientTests: XCTestCase {
         }
         let object = Object(string: "Name")
         let object2 = Object2(payload: .string("Payload"))
-        
+
         let client = createAWSClient(serviceProtocol: .json(version: "1.1"))
         let request = try client.createAWSRequest(operation: "test", path: "/", httpMethod: "POST", input: object)
         XCTAssertEqual(request.getHttpHeaders()["content-type"].first, "application/x-amz-json-1.1")
-        
+
         let client2 = createAWSClient(serviceProtocol: .restjson)
         let request2 = try client2.createAWSRequest(operation: "test", path: "/", httpMethod: "POST", input: object)
         XCTAssertEqual(request2.getHttpHeaders()["content-type"].first, "application/json")
@@ -459,11 +459,11 @@ class AWSClientTests: XCTestCase {
         let client3 = createAWSClient(serviceProtocol: .query)
         let request3 = try client3.createAWSRequest(operation: "test", path: "/", httpMethod: "POST", input: object)
         XCTAssertEqual(request3.getHttpHeaders()["content-type"].first, "application/x-www-form-urlencoded; charset=utf-8")
-        
+
         let client4 = createAWSClient(serviceProtocol: .ec2)
         let request4 = try client4.createAWSRequest(operation: "test", path: "/", httpMethod: "POST", input: object)
         XCTAssertEqual(request4.getHttpHeaders()["content-type"].first, "application/x-www-form-urlencoded; charset=utf-8")
-        
+
         let client5 = createAWSClient(serviceProtocol: .restxml)
         let request5 = try client5.createAWSRequest(operation: "test", path: "/", httpMethod: "POST", input: object)
         XCTAssertEqual(request5.getHttpHeaders()["content-type"].first, "application/octet-stream")
@@ -689,7 +689,7 @@ class AWSClientTests: XCTestCase {
             public static var _encoding = [
                 AWSMemberEncoding(label: "body", encoding: .blob)
             ]
-            let body : Data
+            let body : AWSPayload
         }
         let response = AWSHTTPResponseImpl(
             status: .ok,
@@ -698,7 +698,7 @@ class AWSClientTests: XCTestCase {
         )
         do {
             let output : Output = try s3Client.validate(operation: "Output", response: response)
-            XCTAssertEqual(output.body, "{\"name\":\"hello\"}".data(using: .utf8))
+            XCTAssertEqual(output.body.asData(), "{\"name\":\"hello\"}".data(using: .utf8))
         } catch {
             XCTFail(error.localizedDescription)
         }
@@ -799,13 +799,7 @@ class AWSClientTests: XCTestCase {
                 AWSMemberEncoding(label: "contentType", location: .header(locationName: "content-type")),
                 AWSMemberEncoding(label: "body", encoding: .blob)
             ]
-            let body : Data
-            let contentType: String
-
-            private enum CodingKeys: String, CodingKey {
-                case body = "body"
-                case contentType = "content-type"
-            }
+            let body : AWSPayload
         }
         let response = AWSHTTPResponseImpl(
             status: .ok,
@@ -814,8 +808,7 @@ class AWSClientTests: XCTestCase {
         )
         do {
             let output : Output = try kinesisClient.validate(operation: "Output", response: response)
-            XCTAssertEqual(output.body, "{\"name\":\"hello\"}".data(using: .utf8))
-            XCTAssertEqual(output.contentType, "application/json")
+            XCTAssertEqual(output.body.asData(), "{\"name\":\"hello\"}".data(using: .utf8))
         } catch {
             XCTFail(error.localizedDescription)
         }
@@ -890,12 +883,12 @@ class AWSClientTests: XCTestCase {
     }
 
     func testPayloadDataInResponse() {
-        struct Response: AWSDecodableShape & AWSShapeWithPayload {
-            public static let payloadPath: String = "data"
+        struct Response: AWSDecodableShape {
+            public static let payloadPath: String? = "payload"
             public static var _encoding = [
-                AWSMemberEncoding(label: "data", encoding: .blob),
+                AWSMemberEncoding(label: "payload", encoding: .blob),
             ]
-            let data: Data
+            let payload: AWSPayload
         }
         var buffer = ByteBufferAllocator().buffer(capacity: 0)
         buffer.writeString("TestString")
@@ -907,7 +900,7 @@ class AWSClientTests: XCTestCase {
         )
         do {
             let output : Response = try kinesisClient.validate(operation: "Output", response: response)
-            XCTAssertEqual(String(data: output.data, encoding: .utf8), "TestString")
+            XCTAssertEqual(output.payload.asString(), "TestString")
         } catch {
             XCTFail(error.localizedDescription)
         }
@@ -1287,7 +1280,7 @@ class AWSClientTests: XCTestCase {
             XCTFail("Unexpected error: \(error)")
         }
     }
-    
+
     func testMiddlewareIsOnlyAppliedOnce() throws {
         struct URLAppendMiddleware: AWSServiceMiddleware {
             func chain(request: AWSRequest) throws -> AWSRequest {

--- a/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
@@ -883,8 +883,8 @@ class AWSClientTests: XCTestCase {
     }
 
     func testPayloadDataInResponse() {
-        struct Response: AWSDecodableShape {
-            public static let payloadPath: String? = "payload"
+        struct Response: AWSDecodableShape, AWSShapeWithPayload {
+            public static let payloadPath: String = "payload"
             public static var _encoding = [
                 AWSMemberEncoding(label: "payload", encoding: .blob),
             ]

--- a/Tests/AWSSDKSwiftCoreTests/PayloadTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/PayloadTests.swift
@@ -63,8 +63,8 @@ class PayloadTests: XCTestCase {
     }
 
     func testResponsePayload() {
-        struct Output : AWSDecodableShape {
-            static let payloadPath: String? = "payload"
+        struct Output : AWSDecodableShape, AWSShapeWithPayload {
+            static let payloadPath: String = "payload"
             public static var _encoding = [
                 AWSMemberEncoding(label: "payload", encoding: .blob)
             ]
@@ -77,11 +77,11 @@ class PayloadTests: XCTestCase {
                 secretAccessKey: "",
                 region: .useast1,
                 service:"TestClient",
-                serviceProtocol: ServiceProtocol(type: .json, version: ServiceProtocol.Version(major: 1, minor: 1)),
+                serviceProtocol: .json(version: "1.1"),
                 apiVersion: "2020-01-21",
                 endpoint: awsServer.address,
                 middlewares: [AWSLoggingMiddleware()],
-                eventLoopGroupProvider: .useAWSClientShared
+                httpClientProvider: .createNew
             )
             let response: EventLoopFuture<Output> = client.send(operation: "test", path: "/", httpMethod: "POST")
 

--- a/Tests/AWSSDKSwiftCoreTests/PayloadTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/PayloadTests.swift
@@ -16,10 +16,10 @@ class PayloadTests: XCTestCase {
         struct DataPayload: AWSEncodableShape & AWSShapeWithPayload {
             static var payloadPath: String = "data"
             let data: AWSPayload
-            
+
             private enum CodingKeys: CodingKey {}
         }
-        
+
         do {
             let awsServer = AWSTestServer(serviceProtocol: .json)
             let client = AWSClient(
@@ -47,22 +47,22 @@ class PayloadTests: XCTestCase {
             XCTFail("Unexpected error: \(error)")
         }
     }
-    
+
     func testDataRequestPayload() {
         testRequestPayload(.data(Data("testDataPayload".utf8)), expectedResult: "testDataPayload")
     }
-    
+
     func testStringRequestPayload() {
         testRequestPayload(.string("testStringPayload"), expectedResult: "testStringPayload")
     }
-    
+
     func testByteBufferRequestPayload() {
         var byteBuffer = ByteBufferAllocator().buffer(capacity: 32)
         byteBuffer.writeString("testByteBufferPayload")
         testRequestPayload(.byteBuffer(byteBuffer), expectedResult: "testByteBufferPayload")
     }
-    
-    
+
+
     static var allTests : [(String, (PayloadTests) -> () throws -> Void)] {
         return [
             ("testStringRequestPayload", testStringRequestPayload),

--- a/Tests/AWSSDKSwiftCoreTests/PayloadTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/PayloadTests.swift
@@ -94,7 +94,7 @@ class PayloadTests: XCTestCase {
 
             let output = try response.wait()
 
-            XCTAssertEqual(output.payload.byteBuffer.getString(at:0, length: output.payload.byteBuffer.readableBytes), "testResponsePayload")
+            XCTAssertEqual(output.payload.asString(), "testResponsePayload")
             //XCTAssertEqual(output.i, 547)
             try awsServer.stop()
         } catch {


### PR DESCRIPTION
`AWSPayload` conforms to `Decodable` so we can add it into `Decodable` responses, but the `init(from: Decoder)` should never be called. As it represents the body of a response, the only `Decoder` that will run on it is the  `DictionaryDecoder` which is used in the situations where the body is raw data. Added code to `DictionaryDecoder` to directly copy `AWSPayload` into output shape and not attempt to decode it.

Added `AWSPayload.asByteBuffer()`, `AWSPayload.asData()`, `AWSPayload.asString()` to convert to required format.