### PR TITLE
Don't check if we can import Crypto, check for linux

### DIFF
--- a/Sources/AWSCrypto/ByteArray.swift
+++ b/Sources/AWSCrypto/ByteArray.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 // Replicating the CryptoKit framework interface for < macOS 10.15
-#if !canImport(Crypto)
+#if !os(Linux)
 
 import protocol Foundation.ContiguousBytes
 

--- a/Sources/AWSCrypto/Digest.swift
+++ b/Sources/AWSCrypto/Digest.swift
@@ -14,7 +14,7 @@
 
 // Replicating the CryptoKit framework interface for < macOS 10.15
 
-#if !canImport(Crypto)
+#if !os(Linux)
 
 import protocol Foundation.ContiguousBytes
 

--- a/Sources/AWSCrypto/HMAC.swift
+++ b/Sources/AWSCrypto/HMAC.swift
@@ -14,7 +14,7 @@
 
 // Replicating the CryptoKit framework interface for < macOS 10.15
 
-#if !canImport(Crypto)
+#if !os(Linux)
 
 import CommonCrypto
 import protocol Foundation.DataProtocol

--- a/Sources/AWSCrypto/HashFunction.swift
+++ b/Sources/AWSCrypto/HashFunction.swift
@@ -14,7 +14,7 @@
 
 // Replicating the CryptoKit framework interface for < macOS 10.15
 
-#if !canImport(Crypto)
+#if !os(Linux)
 
 import CommonCrypto
 import protocol Foundation.DataProtocol

--- a/Sources/AWSCrypto/Insecure.swift
+++ b/Sources/AWSCrypto/Insecure.swift
@@ -14,7 +14,7 @@
 
 // Replicating the CryptoKit framework interface for < macOS 10.15
 
-#if !canImport(Crypto)
+#if !os(Linux)
 
 public enum Insecure {}
 

--- a/Sources/AWSCrypto/MD5.swift
+++ b/Sources/AWSCrypto/MD5.swift
@@ -14,7 +14,7 @@
 
 // Replicating the CryptoKit framework interface for < macOS 10.15
 
-#if !canImport(Crypto)
+#if !os(Linux)
 
 import CommonCrypto
 

--- a/Sources/AWSCrypto/SHA2.swift
+++ b/Sources/AWSCrypto/SHA2.swift
@@ -14,7 +14,7 @@
 
 // Replicating the CryptoKit framework interface for < macOS 10.15
 
-#if !canImport(Crypto)
+#if !os(Linux)
 
 import CommonCrypto
 

--- a/Sources/AWSCrypto/SymmetricKey.swift
+++ b/Sources/AWSCrypto/SymmetricKey.swift
@@ -14,7 +14,7 @@
 
 // Replicating the CryptoKit framework interface for < macOS 10.15
 
-#if !canImport(Crypto)
+#if !os(Linux)
 
 import protocol Foundation.ContiguousBytes
 

--- a/Sources/AWSCrypto/exports.swift
+++ b/Sources/AWSCrypto/exports.swift
@@ -14,6 +14,6 @@
 
 // Replicating the CryptoKit framework interface for < macOS 10.15
 
-#if canImport(Crypto)
+#if os(Linux)
 @_exported import Crypto
 #endif


### PR DESCRIPTION
Another package may have a Crypto dependency which will mess with this check