### PR TITLE
Add TimeStampCoders to enforce timestamp format

### DIFF
--- a/Sources/AWSSDKSwiftCore/Encoder/CodableProperties/TimeStampCoder.swift
+++ b/Sources/AWSSDKSwiftCore/Encoder/CodableProperties/TimeStampCoder.swift
@@ -1,0 +1,84 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the AWSSDKSwift open source project
+//
+// Copyright (c) 2020 the AWSSDKSwift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of AWSSDKSwift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import struct Foundation.Date
+import class Foundation.DateFormatter
+import struct Foundation.Locale
+import struct Foundation.TimeZone
+
+//MARK: TimeStamp Coders
+
+/// Protocol for time stamp coders that use a DateFormatter. Use this to enforce the timestamp format we require, or to set the timestamp format output
+public protocol TimeStampFormatterCoder: CustomDecoder, CustomEncoder where CodableValue == TimeStamp {
+    /// format used by DateFormatter
+    static var format: String { get }
+    /// Date formatter
+    static var dateFormatter: DateFormatter { get }
+}
+
+extension TimeStampFormatterCoder {
+    /// decode Date using DateFormatter
+    public static func decode(from decoder: Decoder) throws -> CodableValue {
+        let container = try decoder.singleValueContainer()
+        let value = try container.decode(String.self)
+        guard let date = Self.dateFormatter.date(from: value) else {
+            throw DecodingError.dataCorruptedError(in: container, debugDescription: "String is not the correct format for an ISO 8601 date")
+        }
+        return TimeStamp(date)
+    }
+    
+    /// encode Date using DateFormatter
+    public static func encode(value: CodableValue, to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(dateFormatter.string(from: value.dateValue))
+    }
+
+    /// create DateFormatter
+    static func createDateFormatter() -> DateFormatter {
+        let dateFormatter = DateFormatter()
+        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
+        dateFormatter.dateFormat = Self.format
+        dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
+        return dateFormatter
+    }
+}
+
+/// Date coder for ISO8601 format
+public struct ISO8601TimeStampCoder: TimeStampFormatterCoder {
+    public static let format = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
+    public static let dateFormatter = createDateFormatter()
+}
+
+/// Date coder for HTTP header format
+public struct HTTPHeaderTimeStampCoder: TimeStampFormatterCoder {
+    public static let format = "EEE, d MMM yyy HH:mm:ss z"
+    public static let dateFormatter = createDateFormatter()
+}
+
+/// Unix Epoch Date coder
+public struct UnixEpochTimeStampCoder: CustomDecoder, CustomEncoder {
+    public typealias CodableValue = TimeStamp
+
+    public static func decode(from decoder: Decoder) throws -> CodableValue {
+        let container = try decoder.singleValueContainer()
+        let value = try container.decode(Double.self)
+        return TimeStamp(value)
+    }
+    
+    public static func encode(value: CodableValue, to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(value.dateValue.timeIntervalSince1970)
+    }
+}
+

--- a/Tests/AWSSDKSwiftCoreTests/TimeStampTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/TimeStampTests.swift
@@ -23,6 +23,9 @@ class TimeStampTests: XCTestCase {
 
     func testDecodeISOFromJSON() {
         do {
+            struct A: Codable {
+                let date: TimeStamp
+            }
             let json = "{\"date\": \"2017-01-01T00:00:00.000Z\"}"
             if let json_data = json.data(using: .utf8) {
                 let a = try JSONDecoder().decode(A.self, from: json_data)
@@ -37,6 +40,9 @@ class TimeStampTests: XCTestCase {
     
     func testDecodeISOFromXML() {
         do {
+            struct A: Codable {
+                let date: TimeStamp
+            }
             let xml = "<A><date>2017-01-01T00:01:00.000Z</date></A>"
             let xmlElement = try XML.Element(xmlString: xml)
             let a = try XMLDecoder().decode(A.self, from: xmlElement)
@@ -48,6 +54,9 @@ class TimeStampTests: XCTestCase {
     
     func testDecodeHttpFormattedTimestamp() {
         do {
+            struct A: Codable {
+                let date: TimeStamp
+            }
             let xml = "<A><date>Tue, 15 Nov 1994 12:45:26 GMT</date></A>"
             let xmlElement = try XML.Element(xmlString: xml)
             let a = try XMLDecoder().decode(A.self, from: xmlElement)
@@ -60,6 +69,9 @@ class TimeStampTests: XCTestCase {
     
     func testDecodeUnixEpochTimestamp() {
         do {
+            struct A: Codable {
+                let date: TimeStamp
+            }
             let xml = "<A><date>1221382800</date></A>"
             let xmlElement = try XML.Element(xmlString: xml)
             let a = try XMLDecoder().decode(A.self, from: xmlElement)
@@ -71,10 +83,27 @@ class TimeStampTests: XCTestCase {
     
     func testEncodeToJSON() {
         do {
-            let a = A(date: TimeStamp("2019-05-01T00:00:00.001Z"))
+            struct A: Codable {
+                let date: TimeStamp
+            }
+            let a = A(date: TimeStamp("2019-05-01T00:00:00.001Z")!)
             let data = try JSONEncoder().encode(a)
             let jsonString = String(data: data, encoding: .utf8)
             XCTAssertEqual(jsonString, "{\"date\":\"2019-05-01T00:00:00.001Z\"}")
+        } catch {
+            XCTFail("\(error)")
+        }
+    }
+
+    func testEncodeUnixEpochToJSON() {
+        do {
+            struct A: Codable {
+                @Coding<UnixEpochTimeStampCoder> var date: TimeStamp
+            }
+            let a = A(date: TimeStamp(23983978378))
+            let data = try JSONEncoder().encode(a)
+            let jsonString = String(data: data, encoding: .utf8)
+            XCTAssertEqual(jsonString, "{\"date\":23983978378}")
         } catch {
             XCTFail("\(error)")
         }
@@ -87,6 +116,7 @@ class TimeStampTests: XCTestCase {
             ("testDecodeHttpFormattedTimestamp", testDecodeHttpFormattedTimestamp),
             ("testDecodeUnixEpochTimestamp", testDecodeUnixEpochTimestamp),
             ("testEncodeToJSON", testEncodeToJSON),
+            ("testEncodeUnixEpochToJSON", testEncodeUnixEpochToJSON)
         ]
     }
 }


### PR DESCRIPTION
Previously TimeStamp would load one of three formats: ISO8601, HTTP header and Unix Epoch. It would only ever output one format: ISO8601

This change, add a TimeStampCoder that will encode to a specified format and decode from a specified format. 