### PR TITLE
Remove unused/unnecessary code from the Encoders/Decoders

### DIFF
--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -26,7 +26,9 @@ import struct Foundation.URLComponents
 import struct Foundation.URLQueryItem
 import struct Foundation.CharacterSet
 
-/// This is the workhorse of aws-sdk-swift-core. You provide it with a `AWSShape` Input object, it converts it to `AWSRequest` which is then converted to a raw `HTTPClient` Request. This is then sent to AWS. When the response from AWS is received if it is successful it is converted to a `AWSResponse` which is then decoded to generate a `AWSShape` Output object. If it is not successful then `AWSClient` will throw an `AWSErrorType`.
+/// This is the workhorse of aws-sdk-swift-core. You provide it with a `AWSShape` Input object, it converts it to `AWSRequest` which is then converted
+/// to a raw `HTTPClient` Request. This is then sent to AWS. When the response from AWS is received if it is successful it is converted to a `AWSResponse`
+/// which is then decoded to generate a `AWSShape` Output object. If it is not successful then `AWSClient` will throw an `AWSErrorType`.
 public final class AWSClient {
 
     public enum ClientError: Swift.Error {

--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -496,7 +496,7 @@ extension AWSClient {
             }
 
         case .ec2:
-            var params = try input.encodeAsQuery(flattenArrays: true)
+            var params = try input.encodeAsQuery()
             params["Action"] = operationName
             params["Version"] = serviceConfig.apiVersion
             if let urlEncodedQueryParams = urlEncodeQueryParams(fromDictionary: params) {

--- a/Sources/AWSSDKSwiftCore/Doc/AWSShape+Encoder.swift
+++ b/Sources/AWSSDKSwiftCore/Doc/AWSShape+Encoder.swift
@@ -33,9 +33,8 @@ internal extension AWSEncodableShape {
 
     /// Encode AWSShape as a query array
     /// - Parameter flattenArrays: should all arrays be flattened
-    func encodeAsQuery(flattenArrays: Bool = false) throws -> [String : Any] {
+    func encodeAsQuery() throws -> [String : Any] {
         let encoder = QueryEncoder()
-        encoder.flattenContainers = flattenArrays
         return try encoder.encode(self)
     }
 

--- a/Sources/AWSSDKSwiftCore/Doc/AWSShape.swift
+++ b/Sources/AWSSDKSwiftCore/Doc/AWSShape.swift
@@ -64,21 +64,6 @@ extension AWSShape {
     }
 }
 
-/// extension to AWSShape that returns XML container encoding for members of it
-extension AWSShape {
-    /// return member for CodingKey
-    public static func getEncoding(forKey: CodingKey) -> AWSMemberEncoding? {
-        return _encoding.first {
-            if let location = $0.location, case .body(let name) = location {
-                return name == forKey.stringValue
-            } else {
-                return $0.label == forKey.stringValue
-            }
-        }
-    }
-
-}
-
 /// AWSShape that can be encoded
 public protocol AWSEncodableShape: AWSShape & Encodable {
     /// The XML namespace for the object

--- a/Sources/AWSSDKSwiftCore/Encoder/QueryEncoder.swift
+++ b/Sources/AWSSDKSwiftCore/Encoder/QueryEncoder.swift
@@ -18,22 +18,17 @@ import class Foundation.NSData
 /// The wrapper class for encoding Codable classes to Query dictionary
 class QueryEncoder {
 
-    /// override container encoding and flatten all the containers (needed for EC2, which reports unflattened containers when they are flattened)
-    open var flattenContainers : Bool = false
-
     /// Contextual user-provided information for use during encoding.
     open var userInfo: [CodingUserInfoKey : Any] = [:]
 
     /// Options set on the top-level encoder to pass down the encoding hierarchy.
     fileprivate struct _Options {
-        let flattenContainers: Bool
         let userInfo: [CodingUserInfoKey : Any]
     }
 
     /// The options set on the top-level encoder.
     fileprivate var options: _Options {
-        return _Options(flattenContainers: flattenContainers,
-                        userInfo: userInfo)
+        return _Options(userInfo: userInfo)
     }
 
     public init() {}

--- a/Sources/AWSSDKSwiftCore/Encoder/XMLDecoder.swift
+++ b/Sources/AWSSDKSwiftCore/Encoder/XMLDecoder.swift
@@ -16,12 +16,6 @@ import struct Foundation.Data
 import struct Foundation.Date
 import struct Foundation.URL
 import class  Foundation.DateFormatter
-import class  Foundation.ISO8601DateFormatter
-
-import class  Foundation.NSURL
-import class  Foundation.NSDate
-import class  Foundation.NSData
-
 
 /// The wrapper class for decoding Codable classes from XMLNodes
 class XMLDecoder {
@@ -667,18 +661,6 @@ fileprivate struct _XMLKey : CodingKey {
 
     fileprivate static let `super` = _XMLKey(stringValue: "super")!
 }
-
-//===----------------------------------------------------------------------===//
-// Shared ISO8601 Date Formatter
-//===----------------------------------------------------------------------===//
-
-// NOTE: This value is implicitly lazy and _must_ be lazy. We're compiled against the latest SDK (w/ ISO8601DateFormatter), but linked against whichever Foundation the user has. ISO8601DateFormatter might not exist, so we better not hit this code path on an older OS.
-@available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
-fileprivate var _iso8601Formatter: ISO8601DateFormatter = {
-    let formatter = ISO8601DateFormatter()
-    formatter.formatOptions = .withInternetDateTime
-    return formatter
-}()
 
 //===----------------------------------------------------------------------===//
 // Error Utilities

--- a/Sources/AWSSDKSwiftCore/Encoder/XMLDecoder.swift
+++ b/Sources/AWSSDKSwiftCore/Encoder/XMLDecoder.swift
@@ -26,33 +26,8 @@ import class  Foundation.NSData
 /// The wrapper class for decoding Codable classes from XMLNodes
 class XMLDecoder {
 
-    /// The strategy to use for decoding `Date` values.
-    public enum DateDecodingStrategy {
-        /// Defer to `Date` for decoding. This is the default strategy.
-        case deferredToDate
-
-        /// Decode the `Date` as a UNIX timestamp from a JSON number.
-        case secondsSince1970
-
-        /// Decode the `Date` as UNIX millisecond timestamp from a JSON number.
-        case millisecondsSince1970
-
-        /// Decode the `Date` as an ISO-8601-formatted string (in RFC 3339 format).
-        @available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
-        case iso8601
-
-        /// Decode the `Date` as a string parsed by the given formatter.
-        case formatted(DateFormatter)
-
-        /// Decode the `Date` as a custom value decoded by the given closure.
-        case custom((_ decoder: Decoder) throws -> Date)
-    }
-
     /// The strategy to use for decoding `Data` values.
     public enum DataDecodingStrategy {
-        /// Defer to `Data` for decoding.
-        case deferredToData
-
         /// Decode the `Data` from a Base64-encoded string.
         case base64
 
@@ -69,9 +44,6 @@ class XMLDecoder {
         case convertFromString(positiveInfinity: String, negativeInfinity: String, nan: String)
     }
 
-    /// The strategy to use in decoding dates. Defaults to `.deferredToDate`.
-    open var dateDecodingStrategy: DateDecodingStrategy = .deferredToDate
-
     /// The strategy to use in decoding binary data. Defaults to `.raw`.
     open var dataDecodingStrategy: DataDecodingStrategy = .base64
 
@@ -83,7 +55,6 @@ class XMLDecoder {
 
     /// Options set on the top-level encoder to pass down the decoding hierarchy.
     fileprivate struct _Options {
-        let dateDecodingStrategy: DateDecodingStrategy
         let dataDecodingStrategy: DataDecodingStrategy
         let nonConformingFloatDecodingStrategy: NonConformingFloatDecodingStrategy
         let userInfo: [CodingUserInfoKey : Any]
@@ -91,8 +62,7 @@ class XMLDecoder {
 
     /// The options set on the top-level decoder.
     fileprivate var options: _Options {
-        return _Options(dateDecodingStrategy: dateDecodingStrategy,
-                        dataDecodingStrategy: dataDecodingStrategy,
+        return _Options(dataDecodingStrategy: dataDecodingStrategy,
                         nonConformingFloatDecodingStrategy: nonConformingFloatDecodingStrategy,
                         userInfo: userInfo)
     }
@@ -630,57 +600,9 @@ fileprivate class _XMLDecoder : Decoder {
         return unboxValue
     }
 
-    /// get Date from XML.Node
-    func unbox(_ element : XML.Node, as type: Date.Type) throws -> Date {
-        switch self.options.dateDecodingStrategy {
-        case .deferredToDate:
-            self.storage.push(container: element)
-            defer { self.storage.popContainer() }
-            return try Date(from: self)
-
-        case .secondsSince1970:
-            let double = try self.unbox(element, as: Double.self)
-            return Date(timeIntervalSince1970: double)
-
-        case .millisecondsSince1970:
-            let double = try self.unbox(element, as: Double.self)
-            return Date(timeIntervalSince1970: double / 1000.0)
-
-        case .iso8601:
-            if #available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
-                let string = try self.unbox(element, as: String.self)
-                guard let date = _iso8601Formatter.date(from: string) else {
-                    throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Expected date string to be ISO8601-formatted."))
-                }
-
-                return date
-            } else {
-                fatalError("ISO8601DateFormatter is unavailable on this platform.")
-            }
-
-        case .formatted(let formatter):
-            let string = try self.unbox(element, as: String.self)
-            guard let date = formatter.date(from: string) else {
-                throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Date string does not match format expected by formatter."))
-            }
-
-            return date
-
-        case .custom(let closure):
-            self.storage.push(container: element)
-            defer { self.storage.popContainer() }
-            return try closure(self)
-        }
-    }
-
     /// get Data from XML.Node
     fileprivate func unbox(_ element : XML.Node, as type: Data.Type) throws -> Data {
         switch self.options.dataDecodingStrategy {
-        case .deferredToData:
-            self.storage.push(container: element)
-            defer { self.storage.popContainer() }
-            return try Data(from: self)
-
         case .base64:
             guard let string = element.stringValue else {
                 throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: element.stringValue ?? "nil")
@@ -699,26 +621,13 @@ fileprivate class _XMLDecoder : Decoder {
         }
     }
 
-    /// get URL from XML.Node
-    fileprivate func unbox(_ element : XML.Node, as type: URL.Type) throws -> URL {
-        let urlString = try self.unbox(element, as: String.self)
-        guard let url = URL(string: urlString) else {
-            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: element.stringValue ?? "nil")
-        }
-        return url
-    }
-
     func unbox<T>(_ element : XML.Node, as type: T.Type) throws -> T where T : Decodable {
         return try unbox_(element, as: T.self) as! T
     }
 
     func unbox_(_ element : XML.Node, as type: Decodable.Type) throws -> Any {
-        if type == Date.self || type == NSDate.self {
-            return try self.unbox(element, as: Date.self)
-        } else if type == Data.self || type == NSData.self {
+        if type == Data.self {
             return try self.unbox(element, as: Data.self)
-        } else if type == URL.self || type == NSURL.self {
-            return try self.unbox(element, as: URL.self)
         } else {
             self.storage.push(container:element)
             defer { self.storage.popContainer() }

--- a/Sources/AWSSDKSwiftCore/Encoder/XMLEncoder.swift
+++ b/Sources/AWSSDKSwiftCore/Encoder/XMLEncoder.swift
@@ -16,13 +16,6 @@ import struct Foundation.Data
 import struct Foundation.Date
 import struct Foundation.URL
 import class  Foundation.DateFormatter
-import class  Foundation.ISO8601DateFormatter
-
-import class  Foundation.NSNumber
-import class  Foundation.NSURL
-import class  Foundation.NSDate
-import class  Foundation.NSData
-
 
 /// The wrapper class for encoding Codable classes to XMLElements
 class XMLEncoder {
@@ -478,16 +471,16 @@ extension _XMLEncoder : SingleValueEncodingContainer {
 extension _XMLEncoder {
     /// Returns the given value boxed in a container appropriate for pushing onto the container stack.
     fileprivate func box(_ value: Bool)   -> String { return value.description }
-    fileprivate func box(_ value: Int)    -> String { return NSNumber(value: value).description }
-    fileprivate func box(_ value: Int8)   -> String { return NSNumber(value: value).description }
-    fileprivate func box(_ value: Int16)  -> String { return NSNumber(value: value).description }
-    fileprivate func box(_ value: Int32)  -> String { return NSNumber(value: value).description }
-    fileprivate func box(_ value: Int64)  -> String { return NSNumber(value: value).description }
-    fileprivate func box(_ value: UInt)   -> String { return NSNumber(value: value).description }
-    fileprivate func box(_ value: UInt8)  -> String { return NSNumber(value: value).description }
-    fileprivate func box(_ value: UInt16) -> String { return NSNumber(value: value).description }
-    fileprivate func box(_ value: UInt32) -> String { return NSNumber(value: value).description }
-    fileprivate func box(_ value: UInt64) -> String { return NSNumber(value: value).description }
+    fileprivate func box(_ value: Int)    -> String { return value.description }
+    fileprivate func box(_ value: Int8)   -> String { return value.description }
+    fileprivate func box(_ value: Int16)  -> String { return value.description }
+    fileprivate func box(_ value: Int32)  -> String { return value.description }
+    fileprivate func box(_ value: Int64)  -> String { return value.description }
+    fileprivate func box(_ value: UInt)   -> String { return value.description }
+    fileprivate func box(_ value: UInt8)  -> String { return value.description }
+    fileprivate func box(_ value: UInt16) -> String { return value.description }
+    fileprivate func box(_ value: UInt32) -> String { return value.description }
+    fileprivate func box(_ value: UInt64) -> String { return value.description }
     fileprivate func box(_ value: String) -> String { return value }
 
     fileprivate func box(_ float: Float) throws -> String {
@@ -507,7 +500,7 @@ extension _XMLEncoder {
             }
         }
 
-        return NSNumber(value: float).description
+        return float.description
     }
 
     fileprivate func box(_ double: Double) throws -> String {
@@ -527,7 +520,7 @@ extension _XMLEncoder {
             }
         }
 
-        return NSNumber(value: double).description
+        return double.description
     }
 
 
@@ -621,18 +614,6 @@ fileprivate struct _XMLKey : CodingKey {
 
     fileprivate static let `super` = _XMLKey(stringValue: "super")!
 }
-
-//===----------------------------------------------------------------------===//
-// Shared ISO8601 Date Formatter
-//===----------------------------------------------------------------------===//
-
-// NOTE: This value is implicitly lazy and _must_ be lazy. We're compiled against the latest SDK (w/ ISO8601DateFormatter), but linked against whichever Foundation the user has. ISO8601DateFormatter might not exist, so we better not hit this code path on an older OS.
-@available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
-fileprivate var _iso8601Formatter: ISO8601DateFormatter = {
-    let formatter = ISO8601DateFormatter()
-    formatter.formatOptions = .withInternetDateTime
-    return formatter
-}()
 
 //===----------------------------------------------------------------------===//
 // Error Utilities

--- a/Sources/AWSSDKSwiftCore/Encoder/XMLEncoder.swift
+++ b/Sources/AWSSDKSwiftCore/Encoder/XMLEncoder.swift
@@ -27,35 +27,8 @@ import class  Foundation.NSData
 /// The wrapper class for encoding Codable classes to XMLElements
 class XMLEncoder {
 
-    /// The strategy to use for encoding `Date` values.
-    public enum DateEncodingStrategy {
-        /// Defer to `Date` for choosing an encoding. This is the default strategy.
-        case deferredToDate
-
-        /// Encode the `Date` as a UNIX timestamp (as a JSON number).
-        case secondsSince1970
-
-        /// Encode the `Date` as UNIX millisecond timestamp (as a JSON number).
-        case millisecondsSince1970
-
-        /// Encode the `Date` as an ISO-8601-formatted string (in RFC 3339 format).
-        @available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
-        case iso8601
-
-        /// Encode the `Date` as a string formatted by the given formatter.
-        case formatted(DateFormatter)
-
-        /// Encode the `Date` as a custom value encoded by the given closure.
-        ///
-        /// If the closure fails to encode a value into the given encoder, the encoder will encode an empty automatic container in its place.
-        case custom((Date, Encoder) throws -> XML.Element)
-    }
-
     /// The strategy to use for encoding `Data` values.
     public enum DataEncodingStrategy {
-        /// Defer to `Data` for choosing an encoding.
-        case deferredToData
-
         /// Encoded the `Data` as a Base64-encoded string. This is the default strategy.
         case base64
 
@@ -74,9 +47,6 @@ class XMLEncoder {
         case convertToString(positiveInfinity: String, negativeInfinity: String, nan: String)
     }
 
-    /// The strategy to use in encoding dates. Defaults to `.deferredToDate`.
-    open var dateEncodingStrategy: DateEncodingStrategy = .deferredToDate
-
     /// The strategy to use in encoding binary data. Defaults to `.base64`.
     open var dataEncodingStrategy: DataEncodingStrategy = .base64
 
@@ -88,7 +58,6 @@ class XMLEncoder {
 
     /// Options set on the top-level encoder to pass down the encoding hierarchy.
     fileprivate struct _Options {
-        let dateEncodingStrategy: DateEncodingStrategy
         let dataEncodingStrategy: DataEncodingStrategy
         let nonConformingFloatEncodingStrategy: NonConformingFloatEncodingStrategy
         let userInfo: [CodingUserInfoKey : Any]
@@ -96,8 +65,7 @@ class XMLEncoder {
 
     /// The options set on the top-level encoder.
     fileprivate var options: _Options {
-        return _Options(dateEncodingStrategy: dateEncodingStrategy,
-                        dataEncodingStrategy: dataEncodingStrategy,
+        return _Options(dataEncodingStrategy: dataEncodingStrategy,
                         nonConformingFloatEncodingStrategy: nonConformingFloatEncodingStrategy,
                         userInfo: userInfo)
     }
@@ -563,45 +531,8 @@ extension _XMLEncoder {
     }
 
 
-    func box(_ date: Date) throws -> XML.Element {
-        switch self.options.dateEncodingStrategy {
-        case .deferredToDate:
-            // Must be called with a surrounding with(pushedKey:) call.
-            // Dates encode as single-value objects; this can't both throw and push a container, so no need to catch the error.
-            try date.encode(to: self)
-            return storage.popContainer()
-
-        case .secondsSince1970:
-            let node = XML.Element(name:currentKey, stringValue: date.timeIntervalSince1970.description)
-            return node
-
-        case .millisecondsSince1970:
-            let node = XML.Element(name:currentKey, stringValue: (1000.0 * date.timeIntervalSince1970).description)
-            return node
-
-        case .iso8601:
-            if #available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
-                let node = XML.Element(name:currentKey, stringValue:_iso8601Formatter.string(from: date))
-                return node
-            } else {
-                fatalError("ISO8601DateFormatter is unavailable on this platform.")
-            }
-
-        case .formatted(let formatter):
-            let node = XML.Element(name:currentKey, stringValue:formatter.string(from: date))
-            return node
-
-        case .custom(let closure):
-            return try closure(date, self)
-        }
-    }
-
     func box(_ data: Data) throws -> XML.Element {
         switch self.options.dataEncodingStrategy {
-        case .deferredToData:
-            try data.encode(to: self)
-            return storage.popContainer()
-
         case .base64:
             return XML.Element(name:currentKey, stringValue: data.base64EncodedString())
 
@@ -610,20 +541,11 @@ extension _XMLEncoder {
         }
     }
 
-    func box(_ url: URL) throws -> XML.Element {
-        let node = XML.Element(name:currentKey, stringValue: url.absoluteString)
-        return node
-    }
-
     func box(_ value: Encodable) throws -> XML.Element {
         let type = Swift.type(of: value)
 
-        if type == Date.self || type == NSDate.self {
-            return try self.box((value as! Date))
-        } else if type == Data.self || type == NSData.self {
+        if type == Data.self {
             return try self.box((value as! Data))
-        } else if type == URL.self || type == NSURL.self {
-            return try self.box((value as! URL))
         } else {
             try value.encode(to: self)
             return storage.popContainer()

--- a/Tests/AWSSDKSwiftCoreTests/DictionaryEncoderTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/DictionaryEncoderTests.swift
@@ -192,29 +192,7 @@ class DictionaryEncoderTests: XCTestCase {
         }
     }
     
-    func testDateDecodeEncode() {
-        struct Test : AWSDecodableShape {
-            let date : Date
-        }
-        let dictionary: [String:Any] = ["date":0]
-        testDecode(type: Test.self, dictionary: dictionary) {
-            XCTAssertEqual($0.date, Date(timeIntervalSinceReferenceDate: 0))
-        }
-
-        let dateFormatter = DateFormatter()
-        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
-        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
-        
-        let decoder = DictionaryDecoder()
-        decoder.dateDecodingStrategy = .formatted(dateFormatter)
-        
-        let dictionary2: [String:Any] = ["date":"2001-07-21T14:31:45.100Z"]
-        testDecode(type: Test.self, dictionary: dictionary2, decoder: decoder) {
-            XCTAssertEqual($0.date, dateFormatter.date(from: "2001-07-21T14:31:45.100Z"))
-        }
-    }
-    
-    func testDataDecodeEncode() {
+   func testDataDecodeEncode() {
         struct Test : AWSDecodableShape {
             let data : Data
         }
@@ -229,16 +207,6 @@ class DictionaryEncoderTests: XCTestCase {
         let dictionary2: [String:Any] = ["data":"Hello, world".data(using:.utf8)!]
         testDecode(type: Test.self, dictionary: dictionary2, decoder: decoder) {
             XCTAssertEqual($0.data, "Hello, world".data(using:.utf8)!)
-        }
-    }
-    
-    func testUrlDecodeEncode() {
-        struct Test : AWSDecodableShape {
-            let url : URL
-        }
-        let dictionary: [String:Any] = ["url":"www.google.com"]
-        testDecode(type: Test.self, dictionary: dictionary) {
-            XCTAssertEqual($0.url, URL(string: "www.google.com")!)
         }
     }
     
@@ -450,9 +418,7 @@ class DictionaryEncoderTests: XCTestCase {
             ("testArrayOfStructuresDecodeEncode", testArrayOfStructuresDecodeEncode),
             ("testDictionaryDecodeEncode", testDictionaryDecodeEncode),
             ("testEnumDictionaryDecodeEncode", testEnumDictionaryDecodeEncode),
-            ("testDateDecodeEncode", testDateDecodeEncode),
             ("testDataDecodeEncode", testDataDecodeEncode),
-            ("testUrlDecodeEncode", testUrlDecodeEncode),
             ("testFloatOverflowDecodeErrors", testFloatOverflowDecodeErrors),
             ("testInvalidValueDecodeErrors", testInvalidValueDecodeErrors),
             ("testMissingKeyDecodeErrors", testMissingKeyDecodeErrors),

--- a/Tests/AWSSDKSwiftCoreTests/XMLCoderTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/XMLCoderTests.swift
@@ -293,14 +293,6 @@ class XMLCoderTests: XCTestCase {
         XCTAssertEqual(value?.type, .yes)
     }
 
-    func testUrlDecodeEncode() {
-        struct Test : Codable {
-            let url : URL
-        }
-        let xml = "<Test><url>https://docs.aws.amazon.com/</url></Test>"
-        testDecodeEncode(type: Test.self, xml: xml)
-    }
-
     func testSerializeToXML() {
         let shape = testShape
         let node = try! XMLEncoder().encode(shape)
@@ -497,7 +489,6 @@ class XMLCoderTests: XCTestCase {
             ("testDictionaryDecodeEncode", testDictionaryDecodeEncode),
             ("testDateDecodeEncode", testDateDecodeEncode),
             ("testDataDecodeEncode", testDataDecodeEncode),
-            ("testUrlDecodeEncode", testUrlDecodeEncode),
             ("testSerializeToXML", testSerializeToXML),
             ("testDecodeExpandedContainers", testDecodeExpandedContainers),
             ("testArrayEncodingDecodeEncode", testArrayEncodingDecodeEncode),


### PR DESCRIPTION
Removed unnecessary code from `DictionaryDecoder`, `XMLEncoder` and `XMLDecoder`
removed encoder/decode NS Foundation objects. 
removed dateEncoding/Decoding strategy's as this is dealt with by TimeStamp
removed encode/decode URLs
removed some of the Data encoder strategies
removed `flattenContainers` from `QueryEncoder`
