### PR TITLE
Add specialization for EC2 Query generation

### DIFF
--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -501,7 +501,7 @@ extension AWSClient {
             }
 
         case .ec2:
-            var params = try input.encodeAsQuery()
+            var params = try input.encodeAsQueryForEC2()
             params["Action"] = operationName
             params["Version"] = serviceConfig.apiVersion
             if let urlEncodedQueryParams = urlEncodeQueryParams(fromDictionary: params) {

--- a/Sources/AWSSDKSwiftCore/Doc/AWSShape+Encoder.swift
+++ b/Sources/AWSSDKSwiftCore/Doc/AWSShape+Encoder.swift
@@ -30,12 +30,19 @@ internal extension AWSEncodableShape {
         }
         return xml
     }
-
+    
     /// Encode AWSShape as a query array
     /// - Parameter flattenArrays: should all arrays be flattened
     func encodeAsQuery() throws -> [String : Any] {
         let encoder = QueryEncoder()
         return try encoder.encode(self)
     }
-
+    
+    /// Encode AWSShape as a query array
+    /// - Parameter flattenArrays: should all arrays be flattened
+    func encodeAsQueryForEC2() throws -> [String : Any] {
+        let encoder = QueryEncoder()
+        encoder.ec2 = true
+        return try encoder.encode(self)
+    }
 }

--- a/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
@@ -1029,7 +1029,7 @@ class AWSClientTests: XCTestCase {
         do {
             let input = Input(array: ["entry1", "entry2"])
             let request = try ec2Client.createAWSRequest(operation: "Test", path: "/", httpMethod: "GET", input: input)
-            XCTAssertEqual(request.body.asString(), "Action=Test&Version=2013-12-02&array.1=entry1&array.2=entry2")
+            XCTAssertEqual(request.body.asString(), "Action=Test&Array.1=entry1&Array.2=entry2&Version=2013-12-02")
         } catch {
             XCTFail("\(error)")
         }

--- a/Tests/AWSSDKSwiftCoreTests/QueryEncoderTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/QueryEncoderTests.swift
@@ -223,6 +223,28 @@ class QueryEncoderTests: XCTestCase {
         let result = queryString(dictionary: ["a": data.base64EncodedString()])!
         testQuery(test, query: result)
     }
+    
+    func testEC2Encode() {
+        struct Test2 : AWSEncodableShape {
+            let data : String
+        }
+        struct Test : AWSEncodableShape {
+            let object : Test2
+        }
+        do {
+            let value = Test(object: Test2(data: "Hello"))
+            let queryEncoder = QueryEncoder()
+            queryEncoder.ec2 = true
+            let queryDict = try queryEncoder.encode(value)
+            let queryAsString = queryString(dictionary: queryDict)
+            
+            XCTAssertEqual(queryAsString, "Object.Data=Hello")
+        } catch {
+            XCTFail("\(error)")
+        }
+
+        
+    }
 
     static var allTests : [(String, (QueryEncoderTests) -> () throws -> Void)] {
         return [
@@ -236,7 +258,8 @@ class QueryEncoderTests: XCTestCase {
             ("testArrayEncodingEncode", testArrayEncodingEncode),
             ("testDictionaryEncodingEncode", testDictionaryEncodingEncode),
             ("testDictionaryEncodingEncode2", testDictionaryEncodingEncode2),
-            ("testDataBlobEncode", testDataBlobEncode)
+            ("testDataBlobEncode", testDataBlobEncode),
+            ("testEC2Encode", testEC2Encode)
         ]
     }
 }


### PR DESCRIPTION
Add code to capitalize query variables when outputting for EC2
Can't do this in the shapes as some of the same shapes are used in response generation and sometimes in that situation the variables are required to be lowercase.