### PR TITLE
Add testing iOS build to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,6 @@ jobs:
       uses: actions/checkout@v1
       with:
         fetch-depth: 1
-    - name: SPM build
-      run: swift build
     - name: SPM tests
       run: swift test --enable-code-coverage
     - name: Convert coverage files
@@ -40,7 +38,7 @@ jobs:
       with:
         fetch-depth: 1
     - name: Xcodebuild
-      run: xcodebuild -sdk iphonesimulator13.4 -scheme aws-sdk-swift-core -quiet
+      run: xcodebuild test -scheme aws-sdk-swift-core -quiet -destination 'platform=iOS Simulator,name=iPhone 11'
 
   linux:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,9 @@ jobs:
       with:
         fetch-depth: 1
     - name: Xcodebuild
-      run: xcodebuild test -scheme aws-sdk-swift-core -quiet -destination 'platform=iOS Simulator,name=iPhone 11'
+      run: |
+        xcodebuild -scheme aws-sdk-swift-core -quiet -destination 'platform=iOS Simulator,name=iPhone 11'
+        xcodebuild test -scheme aws-sdk-swift-core -destination 'platform=iOS Simulator,name=iPhone 11'
 
   linux:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,16 @@ jobs:
     - name: Upload to codecov.io
       run: bash <(curl -s https://codecov.io/bash) -J 'aws-sdk-swift-core' -t ${{secrets.CODECOV_TOKEN}}
 
+  ios:
+    runs-on: macOS-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+      with:
+        fetch-depth: 1
+    - name: Xcodebuild
+      run: xcodebuild -sdk iphonesimulator13.4 -scheme aws-sdk-swift-core -quiet
+
   linux:
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
We say we support it so we should test it.

It shows a whole load of warnings compiling CNIOBoringSSL, but iOS never uses CNIOBoringSSL so shouldnt be an issue.