### PR TITLE
Removed `AWSClient.signURL`

### DIFF
--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -341,17 +341,6 @@ extension AWSClient {
         }
         return recordMetrics(future, service: serviceConfig.service, operation: operationName)
     }
-
-    /// generate a signed URL
-    /// - parameters:
-    ///     - url : URL to sign
-    ///     - httpMethod: HTTP method to use ("GET", "PUT", "PUSH" etc)
-    ///     - expires: How long before the signed URL expires
-    /// - returns:
-    ///     A signed URL
-    public func signURL(url: URL, httpMethod: String, expires: Int = 86400) -> EventLoopFuture<URL> {
-        return signer.map { signer in signer.signURL(url: url, method: HTTPMethod(rawValue: httpMethod), expires: expires) }
-    }
 }
 
 // request creator

--- a/Sources/AWSSDKSwiftCore/Message/AWSRequest.swift
+++ b/Sources/AWSSDKSwiftCore/Message/AWSRequest.swift
@@ -16,7 +16,6 @@ import NIO
 import NIOHTTP1
 import struct Foundation.URL
 import struct Foundation.Date
-import struct Foundation.Data
 
 /// Object encapsulating all the information needed to generate a raw HTTP request to AWS
 public struct AWSRequest {


### PR DESCRIPTION
Removed `AWSClient.signURL` that is just a proxy to the `AWSSigner`. Keep the API clean. With 5.0.0 we can remove it!