### PR TITLE
Always sign request by adding Header fields

### DIFF
--- a/Sources/AWSSDKSwiftCore/Message/AWSRequest.swift
+++ b/Sources/AWSSDKSwiftCore/Message/AWSRequest.swift
@@ -77,25 +77,15 @@ public struct AWSRequest {
         return HTTPHeaders(headers.map { ($0, $1) })
     }
 
+    /// Create HTTP Client request from AWSRequest.
+    /// If the signer's credentials are available the request will be sigend. Otherweise defaults to an unsinged request
     func createHTTPRequest(signer: AWSSigner) -> AWSHTTPRequest {
         // if credentials are empty don't sign request
         if signer.credentials.isEmpty() {
             return self.toHTTPRequest()
         }
-
-        switch (self.httpMethod, self.serviceProtocol) {
-        case ("GET",  .restjson), ("HEAD", .restjson):
-            return self.toHTTPRequestWithSignedHeader(signer: signer)
-
-        case ("GET",  _), ("HEAD", _):
-            if self.httpHeaders.count > 0 {
-                return self.toHTTPRequestWithSignedHeader(signer: signer)
-            }
-            return self.toHTTPRequestWithSignedURL(signer: signer)
-
-        default:
-            return self.toHTTPRequestWithSignedHeader(signer: signer)
-        }
+        
+        return self.toHTTPRequestWithSignedHeader(signer: signer)
     }
 
     /// Create HTTP Client request from AWSRequest

--- a/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
@@ -406,6 +406,35 @@ class AWSClientTests: XCTestCase {
             XCTFail(error.localizedDescription)
         }
     }
+    
+    func testSignedClient() {
+        let input = E()
+        let client = AWSClient(
+            accessKeyId: "foo",
+            secretAccessKey: "bar",
+            region: .useast1,
+            service: "s3",
+            serviceProtocol: .restxml,
+            apiVersion: "2013-12-02",
+            middlewares: [],
+            httpClientProvider: .createNew
+        )
+
+        do {
+            let awsRequest = try client.createAWSRequest(
+                operation: "CopyObject",
+                path: "/",
+                httpMethod: "PUT",
+                input: input
+            )
+
+            let request: AWSHTTPRequest = awsRequest.createHTTPRequest(signer: try client.signer.wait())
+
+            XCTAssertNotNil(request.headers["Authorization"].first)
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
+    }
 
     func testProtocolContentType() throws {
         struct Object: AWSEncodableShape {

--- a/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
@@ -409,17 +409,9 @@ class AWSClientTests: XCTestCase {
     
     func testSignedClient() {
         let input = E()
-        let client = AWSClient(
-            accessKeyId: "foo",
-            secretAccessKey: "bar",
-            region: .useast1,
-            service: "s3",
-            serviceProtocol: .restxml,
-            apiVersion: "2013-12-02",
-            middlewares: [],
-            httpClientProvider: .createNew
-        )
-
+        
+        let client = createAWSClient(accessKeyId: "foo", secretAccessKey: "bar")
+        
         do {
             let awsRequest = try client.createAWSRequest(
                 operation: "CopyObject",

--- a/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
@@ -409,20 +409,21 @@ class AWSClientTests: XCTestCase {
     
     func testSignedClient() {
         let input = E()
-        
         let client = createAWSClient(accessKeyId: "foo", secretAccessKey: "bar")
         
         do {
-            let awsRequest = try client.createAWSRequest(
-                operation: "CopyObject",
-                path: "/",
-                httpMethod: "PUT",
-                input: input
-            )
-
-            let request: AWSHTTPRequest = awsRequest.createHTTPRequest(signer: try client.signer.wait())
-
-            XCTAssertNotNil(request.headers["Authorization"].first)
+            for httpMethod in ["GET","HEAD","PUT","DELETE","POST","PATCH"] {
+                let awsRequest = try client.createAWSRequest(
+                    operation: "Test",
+                    path: "/",
+                    httpMethod: httpMethod,
+                    input: input
+                )
+                
+                let request = awsRequest.createHTTPRequest(signer: try client.signer.wait())
+                
+                XCTAssertNotNil(request.headers["Authorization"].first)
+            }
         } catch {
             XCTFail(error.localizedDescription)
         }

--- a/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
@@ -380,52 +380,38 @@ class AWSClientTests: XCTestCase {
 
     func testUnsignedClient() {
         let input = E()
-        let client = AWSClient(
-            accessKeyId: "",
-            secretAccessKey: "",
-            region: .useast1,
-            service: "s3",
-            serviceProtocol: .restxml,
-            apiVersion: "2013-12-02",
-            middlewares: [],
-            httpClientProvider: .createNew
-        )
+        let client = createAWSClient(accessKeyId: "", secretAccessKey: "")
+        
+        var awsRequest: AWSRequest?
+        XCTAssertNoThrow(awsRequest = try client.createAWSRequest(
+            operation: "CopyObject",
+            path: "/",
+            httpMethod: "PUT",
+            input: input
+        ))
 
-        do {
-            let awsRequest = try client.createAWSRequest(
-                operation: "CopyObject",
-                path: "/",
-                httpMethod: "PUT",
-                input: input
-            )
-
-            let request: AWSHTTPRequest = awsRequest.createHTTPRequest(signer: try client.signer.wait())
-
-            XCTAssertNil(request.headers["Authorization"].first)
-        } catch {
-            XCTFail(error.localizedDescription)
-        }
+        var request: AWSHTTPRequest?
+        XCTAssertNoThrow(request = awsRequest?.createHTTPRequest(signer: try client.signer.wait()))
+        XCTAssertNil(request?.headers["Authorization"].first)
     }
     
     func testSignedClient() {
         let input = E()
         let client = createAWSClient(accessKeyId: "foo", secretAccessKey: "bar")
         
-        do {
-            for httpMethod in ["GET","HEAD","PUT","DELETE","POST","PATCH"] {
-                let awsRequest = try client.createAWSRequest(
-                    operation: "Test",
-                    path: "/",
-                    httpMethod: httpMethod,
-                    input: input
-                )
-                
-                let request = awsRequest.createHTTPRequest(signer: try client.signer.wait())
-                
-                XCTAssertNotNil(request.headers["Authorization"].first)
-            }
-        } catch {
-            XCTFail(error.localizedDescription)
+        for httpMethod in ["GET","HEAD","PUT","DELETE","POST","PATCH"] {
+            var awsRequest: AWSRequest?
+            
+            XCTAssertNoThrow( awsRequest = try client.createAWSRequest(
+                operation: "Test",
+                path: "/",
+                httpMethod: httpMethod,
+                input: input
+            ))
+            
+            var request: AWSHTTPRequest?
+            XCTAssertNoThrow(request = awsRequest?.createHTTPRequest(signer: try client.signer.wait()))
+            XCTAssertNotNil(request?.headers["Authorization"].first)
         }
     }
 


### PR DESCRIPTION
- Always sign requests by adding header fields instead of signing the url
- Added a test to check that a signed header is used