### PR TITLE
Sanity.sh updates

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   sanity-check:
-    runs-on: macOS-latest
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v1


### PR DESCRIPTION
Remove .build from exceptions as it is ignored later
Run on Ubuntu
Add additional call to head so only first so many lines are checked