### PR TITLE
Edited query allowed characters to be in line with AWS docs

### DIFF
--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -547,7 +547,8 @@ extension AWSClient {
         ).applyMiddlewares(serviceConfig.middlewares + middlewares)
     }
 
-    static let queryAllowedCharacters = CharacterSet(charactersIn:"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~:/")
+    // this list of query allowed characters comes from https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html
+    static let queryAllowedCharacters = CharacterSet(charactersIn:"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~")
 
     fileprivate func urlEncodeQueryParam(_ value: String) -> String {
         return value.addingPercentEncoding(withAllowedCharacters: AWSClient.queryAllowedCharacters) ?? value


### PR DESCRIPTION
Found adding a '/' to a query parameter broke signing. Lookup documentation to find the list of allowed characters. 

Don't know why I haven't hit this before.