### PR TITLE
Deal with unparsable errors better

### DIFF
--- a/Sources/AWSSDKSwiftCore/Errors/Error.swift
+++ b/Sources/AWSSDKSwiftCore/Errors/Error.swift
@@ -43,16 +43,16 @@ public struct AWSResponseError: AWSErrorType {
 /// Unrecognised error. Used when we cannot recognise the error code from the AWS response
 public struct AWSError: Error, CustomStringConvertible {
     public let message: String
-    public let rawBody: String
+    public let rawBody: String?
     public let statusCode: HTTPResponseStatus
 
-    init(statusCode: HTTPResponseStatus, message: String, rawBody: String){
+    init(statusCode: HTTPResponseStatus, message: String, rawBody: String?){
         self.statusCode = statusCode
         self.message = message
         self.rawBody = rawBody
     }
 
     public var description: String {
-        return "\(message)"
+        return "\(message), code: \(statusCode.code)\(rawBody.map {", body: \($0)"} ?? "")"
     }
 }

--- a/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
@@ -1011,7 +1011,7 @@ class AWSClientTests: XCTestCase {
             try response.wait()
             XCTFail("Shouldn't get here as the provided client doesn't follow redirects")
         } catch let error as AWSError {
-            XCTAssertEqual(error.message, "Unhandled Error. Response Code: 307")
+            XCTAssertEqual(error.message, "Unhandled Error")
         } catch {
             XCTFail("Unexpected error: \(error)")
         }


### PR DESCRIPTION
Previously if we were supplied with an error that is not in the expected format, we would throw an error about parsing the file, with no indication we have received an error back from AWS.

This change will throw an AWSError, with status code, message "Unhandled error" and message body