### PR TITLE
Remove @_implementationOnly import of AWSXML

### DIFF
--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_implementationOnly import AWSXML
+import AWSXML
 import AsyncHTTPClient
 import Dispatch
 import Metrics

--- a/Sources/AWSSDKSwiftCore/Doc/AWSShape+Encoder.swift
+++ b/Sources/AWSSDKSwiftCore/Doc/AWSShape+Encoder.swift
@@ -14,7 +14,7 @@
 
 import struct Foundation.Data
 import class  Foundation.JSONEncoder
-@_implementationOnly import AWSXML
+import AWSXML
 
 internal extension AWSEncodableShape {
 

--- a/Sources/AWSSDKSwiftCore/Message/AWSResponse.swift
+++ b/Sources/AWSSDKSwiftCore/Message/AWSResponse.swift
@@ -14,7 +14,7 @@
 
 import NIO
 import NIOHTTP1
-@_implementationOnly import AWSXML
+import AWSXML
 
 /// Structure encapsulating a processed HTTP Response
 public struct AWSResponse {

--- a/Sources/AWSSDKSwiftCore/Message/Body.swift
+++ b/Sources/AWSSDKSwiftCore/Message/Body.swift
@@ -14,8 +14,7 @@
 
 import NIO
 import NIOFoundationCompat
-@_implementationOnly import AWSXML
-@_exported import enum AWSXML.XML
+import enum AWSXML.XML
 import struct Foundation.Data
 import class  Foundation.InputStream
 

--- a/Sources/AWSTestUtils/TestServer.swift
+++ b/Sources/AWSTestUtils/TestServer.swift
@@ -17,7 +17,7 @@ import NIOFoundationCompat
 import NIOHTTP1
 import NIOTestUtils
 import XCTest
-@_implementationOnly import AWSXML
+import AWSXML
 @testable import AWSSDKSwiftCore
 
 /// Test server for AWSClient. Input and Output shapes are defined by process function


### PR DESCRIPTION
It causes warning "'AWSXML' inconsistently imported as implementation-only".
It is undefined what is happening here, so I'm removing it.