### PR TITLE
Remove AWSMemberEncoding.encoding, add payload flag raw

### DIFF
--- a/Sources/AWSSDKSwiftCore/Doc/AWSMemberEncoding.swift
+++ b/Sources/AWSSDKSwiftCore/Doc/AWSMemberEncoding.swift
@@ -12,14 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// Structure defining how to serialize member of AWSShape.
-/// Below is the list of possible encodings and how they are setup
-/// - Encode in header (label set to member name in json model, location set to .header(header name))
-/// - Encode as part of uri (label set to member name in json model, location set to .uri(uri part to replace))
-/// - Encode as uri query (label set to member name in json model, location set to .querystring(query string name))
-/// - While encoding a Collection as XML or query string define additional element names (label set to member name in json model,
-///     shapeEncoding set to one of collection encoding types, if codingkey is different to label then set it to .body(codingkey))
-/// - When encoding payload data blob (label set to member name in json model, shapeEncoding set to .blob)
+/// Structure defining where to serialize member of AWSShape.
 public struct AWSMemberEncoding {
     
     /// Location of AWSMemberEncoding.
@@ -31,24 +24,13 @@ public struct AWSMemberEncoding {
         case body(locationName: String)
     }
     
-    /// How the AWSMemberEncoding is serialized in XML and Query formats. Used for collection elements.
-    public enum ShapeEncoding {
-        /// default case, flat arrays and serializing dictionaries like all other codable structures
-        case `default`
-        /// shape is stored as data blob in body
-        case blob
-    }
-    
     /// name of member
     public let label: String
     /// where to find or place member
     public let location: Location?
-    /// How shape is serialized
-    public let shapeEncoding: ShapeEncoding
 
-    public init(label: String, location: Location? = nil, encoding: ShapeEncoding = .default) {
+    public init(label: String, location: Location? = nil) {
         self.label = label
         self.location = location
-        self.shapeEncoding = encoding
     }
 }

--- a/Sources/AWSSDKSwiftCore/Doc/AWSShape.swift
+++ b/Sources/AWSSDKSwiftCore/Doc/AWSShape.swift
@@ -176,15 +176,16 @@ public struct PayloadOptions: OptionSet {
     
     public static let allowStreaming = PayloadOptions(rawValue: 1<<0)
     public static let allowChunkedStreaming = PayloadOptions(rawValue: 1<<1)
+    public static let raw = PayloadOptions(rawValue: 1<<2)
 }
 
 /// Root AWSShape which include a payload
 public protocol AWSShapeWithPayload {
     /// The path to the object that is included in the request body
-    static var payloadPath: String { get }
-    static var options: PayloadOptions { get }
+    static var _payloadPath: String { get }
+    static var _payloadOptions: PayloadOptions { get }
 }
 
 extension AWSShapeWithPayload {
-    public static var options: PayloadOptions { return [] }
+    public static var _payloadOptions: PayloadOptions { return [] }
 }

--- a/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
@@ -64,7 +64,7 @@ class AWSClientTests: XCTestCase {
     }
 
     struct F: AWSEncodableShape & AWSShapeWithPayload {
-        public static let payloadPath: String = "fooParams"
+        public static let _payloadPath: String = "fooParams"
 
         public let fooParams: E?
 
@@ -249,7 +249,7 @@ class AWSClientTests: XCTestCase {
             let string: String
         }
         struct Object2: AWSEncodableShape & AWSShapeWithPayload {
-            static var payloadPath = "payload"
+            static var _payloadPath = "payload"
             let payload: AWSPayload
             private enum CodingKeys: CodingKey {}
         }
@@ -487,7 +487,7 @@ class AWSClientTests: XCTestCase {
             let number: Int
         }
         struct Input: AWSEncodableShape & AWSShapeWithPayload {
-            public static let payloadPath: String = "payload"
+            public static let _payloadPath: String = "payload"
             let payload: Payload
         }
         let xmlClient = createAWSClient(serviceProtocol: .restxml)
@@ -532,7 +532,7 @@ class AWSClientTests: XCTestCase {
     func testValidateXMLCodablePayloadResponse() {
         class Output : AWSDecodableShape & AWSShapeWithPayload {
             static let _encoding = [AWSMemberEncoding(label: "contentType", location: .header(locationName: "content-type"))]
-            static let payloadPath: String = "name"
+            static let _payloadPath: String = "name"
             let name : String
             let contentType: String
 
@@ -561,10 +561,8 @@ let response = AWSHTTPResponseImpl(
 
     func testValidateXMLRawPayloadResponse() {
         class Output : AWSDecodableShape, AWSShapeWithPayload {
-            static let payloadPath: String = "body"
-            public static var _encoding = [
-                AWSMemberEncoding(label: "body", encoding: .blob)
-            ]
+            static let _payloadPath: String = "body"
+            static let _payloadOptions: PayloadOptions = .raw
             let body : AWSPayload
         }
         let xmlClient = createAWSClient(serviceProtocol: .restxml)
@@ -647,7 +645,7 @@ let response = AWSHTTPResponseImpl(
             let name : String
         }
         struct Output : AWSDecodableShape & AWSShapeWithPayload {
-            static let payloadPath: String = "output2"
+            static let _payloadPath: String = "output2"
             let output2 : Output2
         }
         let jsonClient = createAWSClient(serviceProtocol: .json(version: "1.1"))
@@ -669,10 +667,10 @@ let response = AWSHTTPResponseImpl(
 
     func testValidateJSONRawPayloadResponse() {
         struct Output : AWSDecodableShape, AWSShapeWithPayload {
-            static let payloadPath: String = "body"
+            static let _payloadPath: String = "body"
+            static let _payloadOptions: PayloadOptions = .raw
             public static var _encoding = [
                 AWSMemberEncoding(label: "contentType", location: .header(locationName: "content-type")),
-                AWSMemberEncoding(label: "body", encoding: .blob)
             ]
             let body : AWSPayload
         }
@@ -753,7 +751,7 @@ let response = AWSHTTPResponseImpl(
             let data: Data
         }
         struct J: AWSEncodableShape & AWSShapeWithPayload {
-            public static let payloadPath: String = "dataContainer"
+            public static let _payloadPath: String = "dataContainer"
             let dataContainer: DataContainer
         }
         let jsonClient = createAWSClient(serviceProtocol: .json(version: "1.1"))
@@ -775,10 +773,8 @@ let response = AWSHTTPResponseImpl(
 
     func testPayloadDataInResponse() {
         struct Response: AWSDecodableShape, AWSShapeWithPayload {
-            public static let payloadPath: String = "payload"
-            public static var _encoding = [
-                AWSMemberEncoding(label: "payload", encoding: .blob),
-            ]
+            public static let _payloadPath: String = "payload"
+            public static let _payloadOptions: PayloadOptions = .raw
             let payload: AWSPayload
         }
         let jsonClient = createAWSClient(serviceProtocol: .json(version: "1.1"))
@@ -951,8 +947,8 @@ let response = AWSHTTPResponseImpl(
 
     func testRequestStreaming(client: AWSClient, server: AWSTestServer, bufferSize: Int, blockSize: Int) throws {
         struct Input : AWSEncodableShape & AWSShapeWithPayload {
-            static var payloadPath: String = "payload"
-            static var options: PayloadOptions = [.allowStreaming]
+            static var _payloadPath: String = "payload"
+            static var _payloadOptions: PayloadOptions = [.allowStreaming, .raw]
             let payload: AWSPayload
             private enum CodingKeys: CodingKey {}
         }
@@ -1015,8 +1011,8 @@ let response = AWSHTTPResponseImpl(
 
     func testRequestStreamingTooMuchData() {
         struct Input : AWSEncodableShape & AWSShapeWithPayload {
-            static var payloadPath: String = "payload"
-            static var options: PayloadOptions = [.allowStreaming]
+            static var _payloadPath: String = "payload"
+            static var _payloadOptions: PayloadOptions = [.allowStreaming]
             let payload: AWSPayload
             private enum CodingKeys: CodingKey {}
         }
@@ -1049,8 +1045,8 @@ let response = AWSHTTPResponseImpl(
 
     func testRequestStreamingFile() {
         struct Input : AWSEncodableShape & AWSShapeWithPayload {
-            static var payloadPath: String = "payload"
-            static var options: PayloadOptions = [.allowStreaming]
+            static var _payloadPath: String = "payload"
+            static var _payloadOptions: PayloadOptions = [.allowStreaming]
             let payload: AWSPayload
             private enum CodingKeys: CodingKey {}
         }
@@ -1103,8 +1099,8 @@ let response = AWSHTTPResponseImpl(
 
     func testRequestChunkedStreaming() {
         struct Input : AWSEncodableShape & AWSShapeWithPayload {
-            static var payloadPath: String = "payload"
-            static var options: PayloadOptions = [.allowStreaming, .allowChunkedStreaming]
+            static var _payloadPath: String = "payload"
+            static var _payloadOptions: PayloadOptions = [.allowStreaming, .allowChunkedStreaming, .raw]
             let payload: AWSPayload
             private enum CodingKeys: CodingKey {}
         }

--- a/Tests/AWSSDKSwiftCoreTests/PayloadTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/PayloadTests.swift
@@ -21,7 +21,7 @@ class PayloadTests: XCTestCase {
 
     func testRequestPayload(_ payload: AWSPayload, expectedResult: String) {
         struct DataPayload: AWSEncodableShape & AWSShapeWithPayload {
-            static var payloadPath: String = "data"
+            static var _payloadPath: String = "data"
             let data: AWSPayload
 
             private enum CodingKeys: CodingKey {}
@@ -74,10 +74,8 @@ class PayloadTests: XCTestCase {
 
     func testResponsePayload() {
         struct Output : AWSDecodableShape, AWSShapeWithPayload {
-            static let payloadPath: String = "payload"
-            public static var _encoding = [
-                AWSMemberEncoding(label: "payload", encoding: .blob)
-            ]
+            static let _payloadPath: String = "payload"
+            static let _payloadOptions: PayloadOptions = .raw
             let payload: AWSPayload
         }
         do {

--- a/Tests/AWSSDKSwiftCoreTests/PerformanceTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/PerformanceTests.swift
@@ -42,7 +42,7 @@ struct StandardRequest: AWSEncodableShape {
 }
 
 struct PayloadRequest: AWSEncodableShape & AWSShapeWithPayload {
-    public static let payloadPath: String = "payload"
+    public static let _payloadPath: String = "payload"
 
     let payload: StandardRequest
 }


### PR DESCRIPTION
Removed `AWSShapeEncoding.encoding`. It was only ever used for raw payloads.
Added `PayloadOptions.raw` for raw payloads
Also rename payloadPath to _payloadPath and options to _payloadOptions to avoid name clashes