### PR TITLE
AWSRequest uses HTTPHeaders instead of dictionary

### DIFF
--- a/Sources/AWSSDKSwiftCore/Message/AWSMiddleware.swift
+++ b/Sources/AWSSDKSwiftCore/Message/AWSMiddleware.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import NIOHTTP1
+
 /// Middleware protocol. Gives ability to process requests before they are sent to AWS and process responses before they are converted into output shapes
 public protocol AWSServiceMiddleware {
     
@@ -61,13 +63,13 @@ public struct AWSLoggingMiddleware : AWSServiceMiddleware {
         return output
     }
 
-    func getHeadersOutput(_ headers: [String: Any?]) -> String {
+    func getHeadersOutput(_ headers: HTTPHeaders) -> String {
         if headers.count == 0 {
             return "[]"
         }
         var output = "["
         for header in headers {
-            output += "\n    \(header.key) : \(header.value ?? "nil")"
+            output += "\n    \(header.name) : \(header.value)"
         }
         return output + "\n  ]"
     }
@@ -86,7 +88,7 @@ public struct AWSLoggingMiddleware : AWSServiceMiddleware {
     public func chain(response: AWSResponse) throws -> AWSResponse {
         log("Response:")
         log("  Status : \(response.status.code)")
-        log("  Headers: " + getHeadersOutput(response.headers))
+        log("  Headers: " + getHeadersOutput(HTTPHeaders(response.headers.map { ($0,"\($1)") })))
         log("  Body: " + getBodyOutput(response.body))
         return response
     }

--- a/Sources/AWSSDKSwiftCore/Message/AWSRequest.swift
+++ b/Sources/AWSSDKSwiftCore/Message/AWSRequest.swift
@@ -27,59 +27,8 @@ public struct AWSRequest {
     public let serviceProtocol: ServiceProtocol
     public let operation: String
     public let httpMethod: String
-    public var httpHeaders: [String: Any] = [:]
+    public var httpHeaders: HTTPHeaders
     public var body: Body
-
-    /// Initialize AWSRequest struct
-    /// - parameters:
-    ///     - region: Region of AWS server
-    ///     - url : Request URL
-    ///     - serviceProtocol: protocol of service (.json, .xml, .query etc)
-    ///     - operation: Name of AWS operation
-    ///     - httpMethod: HTTP method to use ("GET", "PUT", "PUSH" etc)
-    ///     - httpHeaders: HTTP request headers
-    ///     - body: HTTP Request body
-    public init(region: Region = .useast1, url: URL, serviceProtocol: ServiceProtocol, operation: String, httpMethod: String, httpHeaders: [String: Any] = [:], body: Body = .empty) {
-        self.region = region
-        self.url = url
-        self.serviceProtocol = serviceProtocol
-        self.operation = operation
-        self.httpMethod = httpMethod
-        self.httpHeaders = httpHeaders
-        self.body = body
-    }
-
-    /// Add a header value
-    /// - parameters:
-    ///     - value : value
-    ///     - forHTTPHeaderField: name of header
-    public mutating func addValue(_ value: String, forHTTPHeaderField field: String) {
-        httpHeaders[field] = value
-    }
-
-    func getHttpHeaders() -> HTTPHeaders {
-        var headers: [String:String] = [:]
-        for (key, value) in httpHeaders {
-            //guard let value = value else { continue }
-            headers[key] = "\(value)"
-        }
-
-        if headers["Content-Type"] == nil {
-            switch httpMethod {
-            case "GET","HEAD":
-                break
-            default:
-                if case .restjson = serviceProtocol, case .raw(_) = body {
-                    headers["Content-Type"] = "binary/octet-stream"
-                } else {
-                    headers["Content-Type"] = serviceProtocol.contentType
-                }
-            }
-        }
-        headers["User-Agent"] = "AWSSDKSwift/5.0"
-        
-        return HTTPHeaders(headers.map { ($0, $1) })
-    }
 
     /// Create HTTP Client request from AWSRequest.
     /// If the signer's credentials are available the request will be sigend. Otherweise defaults to an unsinged request
@@ -94,7 +43,7 @@ public struct AWSRequest {
 
     /// Create HTTP Client request from AWSRequest
     func toHTTPRequest() -> AWSHTTPRequest {
-        return AWSHTTPRequest.init(url: url, method: HTTPMethod(rawValue: httpMethod), headers: getHttpHeaders(), body: body.asPayload())
+        return AWSHTTPRequest.init(url: url, method: HTTPMethod(rawValue: httpMethod), headers: httpHeaders, body: body.asPayload())
     }
 
     /// Create HTTP Client request with signed headers from AWSRequest
@@ -108,7 +57,7 @@ public struct AWSRequest {
         case .stream(let reader):
             if signer.name == "s3" {
                 assert(reader.size != nil, "S3 stream requires size")
-                var headers = getHttpHeaders()
+                var headers = httpHeaders
                 // need to add this header here as it needs to be included in the signed headers
                 headers.add(name: "x-amz-decoded-content-length", value: reader.size!.description)
                 let (signedHeaders, seedSigningData) = signer.startSigningChunks(url: url, method: method, headers: headers, date: Date())
@@ -126,7 +75,7 @@ public struct AWSRequest {
         case .empty:
             bodyDataForSigning = nil
         }
-        let signedHeaders = signer.signHeaders(url: url, method: method, headers: getHttpHeaders(), body: bodyDataForSigning, date: Date())
+        let signedHeaders = signer.signHeaders(url: url, method: method, headers: httpHeaders, body: bodyDataForSigning, date: Date())
         return AWSHTTPRequest.init(url: url, method: method, headers: signedHeaders, body: payload)
     }
 
@@ -144,7 +93,7 @@ public struct AWSRequest {
 extension AWSRequest {
     
     internal init(operation operationName: String, path: String, httpMethod: String, configuration: ServiceConfig) throws {
-        var headers: [String: Any] = [:]
+        var headers = HTTPHeaders()
 
         guard let url = URL(string: "\(configuration.endpoint)\(path)"), let _ = url.host else {
             throw AWSClient.ClientError.invalidURL("\(configuration.endpoint)\(path) must specify url host and scheme")
@@ -152,7 +101,7 @@ extension AWSRequest {
 
         // set x-amz-target header
         if let target = configuration.amzTarget {
-            headers["x-amz-target"] = "\(target).\(operationName)"
+            headers.replaceOrAdd(name: "x-amz-target", value: "\(target).\(operationName)")
         }
         
         self.region = configuration.region
@@ -162,6 +111,8 @@ extension AWSRequest {
         self.httpMethod = httpMethod
         self.httpHeaders = headers
         self.body = .empty
+        
+        addStandardHeaders()
     }
     
     internal init<Input: AWSEncodableShape>(
@@ -171,7 +122,7 @@ extension AWSRequest {
         input: Input,
         configuration: ServiceConfig) throws
     {
-        var headers: [String: Any] = [:]
+        var headers = HTTPHeaders()
         var path = path
         var body: Body = .empty
         var queryParams: [(key:String, value:Any)] = []
@@ -185,7 +136,7 @@ extension AWSRequest {
 
         // set x-amz-target header
         if let target = configuration.amzTarget {
-            headers["x-amz-target"] = "\(target).\(operationName)"
+            headers.replaceOrAdd(name: "x-amz-target", value: "\(target).\(operationName)")
         }
 
         // TODO should replace with Encodable
@@ -197,7 +148,7 @@ extension AWSRequest {
             if let value = mirror.getAttribute(forKey: encoding.label) {
                 switch encoding.location {
                 case .header(let location):
-                    headers[location] = value
+                    headers.replaceOrAdd(name: location, value: "\(value)")
 
                 case .querystring(let location):
                     switch value {
@@ -326,8 +277,26 @@ extension AWSRequest {
         self.httpMethod = httpMethod
         self.httpHeaders = headers
         self.body = body
+        
+        addStandardHeaders()
     }
-    
+
+    private mutating func addStandardHeaders() {
+        if httpHeaders["content-type"].first == nil {
+            switch httpMethod {
+            case "GET","HEAD":
+                break
+            default:
+                if case .restjson = serviceProtocol, case .raw(_) = body {
+                    httpHeaders.replaceOrAdd(name: "content-type", value: "binary/octet-stream")
+                } else {
+                    httpHeaders.replaceOrAdd(name: "content-type", value: serviceProtocol.contentType)
+                }
+            }
+        }
+        httpHeaders.replaceOrAdd(name: "user-agent", value: "AWSSDKSwift/5.0")
+    }
+
     // this list of query allowed characters comes from https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html
     static let queryAllowedCharacters = CharacterSet(charactersIn:"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~")
 

--- a/Sources/AWSSDKSwiftCore/Message/AWSRequest.swift
+++ b/Sources/AWSSDKSwiftCore/Message/AWSRequest.swift
@@ -288,19 +288,19 @@ extension AWSRequest {
     }
 
     private mutating func addStandardHeaders() {
-        if httpHeaders["content-type"].first == nil {
-            switch httpMethod {
-            case "GET","HEAD":
-                break
-            default:
-                if case .restjson = serviceProtocol, case .raw(_) = body {
-                    httpHeaders.replaceOrAdd(name: "content-type", value: "binary/octet-stream")
-                } else {
-                    httpHeaders.replaceOrAdd(name: "content-type", value: serviceProtocol.contentType)
-                }
-            }
-        }
         httpHeaders.replaceOrAdd(name: "user-agent", value: "AWSSDKSwift/5.0")
+        guard httpHeaders["content-type"].first == nil else {
+            return
+        }
+        guard httpMethod != "GET", httpMethod != "HEAD" else {
+            return
+        }
+
+        if case .restjson = serviceProtocol, case .raw(_) = body {
+            httpHeaders.replaceOrAdd(name: "content-type", value: "binary/octet-stream")
+        } else {
+            httpHeaders.replaceOrAdd(name: "content-type", value: serviceProtocol.contentType)
+        }
     }
 
     // this list of query allowed characters comes from https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html

--- a/Sources/AWSSDKSwiftCore/Message/AWSRequest.swift
+++ b/Sources/AWSSDKSwiftCore/Message/AWSRequest.swift
@@ -18,7 +18,6 @@ import struct Foundation.URL
 import struct Foundation.Date
 import struct Foundation.Data
 import struct Foundation.CharacterSet
-import class Foundation.JSONEncoder
 import struct Foundation.URLComponents
 
 /// Object encapsulating all the information needed to generate a raw HTTP request to AWS

--- a/Sources/AWSSDKSwiftCore/Message/AWSResponse+HAL.swift
+++ b/Sources/AWSSDKSwiftCore/Message/AWSResponse+HAL.swift
@@ -19,7 +19,7 @@ extension AWSResponse {
     /// process hal+json date. Extract properties from HAL
     func getHypertextApplicationLanguageBody() throws -> Body {
         guard case .json(let data) = self.body,
-            let contentType = self.headers["Content-Type"] as? String,
+            let contentType = self.headers["content-type"] as? String,
             contentType.contains("hal+json") else {
                 return self.body
         }

--- a/Sources/AWSSDKSwiftCore/Message/AWSResponse.swift
+++ b/Sources/AWSSDKSwiftCore/Message/AWSResponse.swift
@@ -39,7 +39,8 @@ public struct AWSResponse {
         // headers
         var responseHeaders: [String: String] = [:]
         for (key, value) in response.headers {
-            responseHeaders[key] = value
+            // use lowercase for all headers
+            responseHeaders[key.lowercased()] = value
         }
         self.headers = responseHeaders
 
@@ -204,7 +205,7 @@ public struct AWSResponse {
             guard case .json(let data) = self.body else { break }
             apiError = try? JSONDecoder().decode(RESTJSONError.self, from: data)
             if apiError?.code == nil {
-                apiError?.code = self.headers["x-amzn-ErrorType"] as? String
+                apiError?.code = self.headers["x-amzn-errortype"] as? String
             }
 
         case .json:

--- a/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
@@ -79,12 +79,12 @@ class AWSClientTests: XCTestCase {
         XCTAssertNoThrow(httpBinResponse = try response.wait())
         let httpHeaders = httpBinResponse.map { HTTPHeaders($0.headers.map { ($0, $1) }) }
 
-        XCTAssertEqual(httpHeaders?["Content-Length"].first, "0")
-        XCTAssertEqual(httpHeaders?["Content-Type"].first, "application/x-amz-json-1.1")
-        XCTAssertNotNil(httpHeaders?["Authorization"].first)
-        XCTAssertNotNil(httpHeaders?["X-Amz-Date"].first)
-        XCTAssertEqual(httpHeaders?["User-Agent"].first, "AWSSDKSwift/5.0")
-        XCTAssertEqual(httpHeaders?["Host"].first, "localhost:\(awsServer.serverPort)")
+        XCTAssertEqual(httpHeaders?["content-length"].first, "0")
+        XCTAssertEqual(httpHeaders?["content-type"].first, "application/x-amz-json-1.1")
+        XCTAssertNotNil(httpHeaders?["authorization"].first)
+        XCTAssertNotNil(httpHeaders?["x-amz-date"].first)
+        XCTAssertEqual(httpHeaders?["user-agent"].first, "AWSSDKSwift/5.0")
+        XCTAssertEqual(httpHeaders?["host"].first, "localhost:\(awsServer.serverPort)")
     }
 
     func testClientNoInputNoOutput() {

--- a/Tests/AWSSDKSwiftCoreTests/AWSRequestTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/AWSRequestTests.swift
@@ -50,7 +50,7 @@ class AWSRequestTests: XCTestCase {
         let request = KeywordRequest(repeat: "Repeat")
         var awsRequest: AWSRequest?
         XCTAssertNoThrow(awsRequest = try AWSRequest(operation: "Keyword", path: "/", httpMethod: "POST", input: request, configuration: config))
-        XCTAssertEqual(awsRequest?.httpHeaders["repeat"] as? String, "Repeat")
+        XCTAssertEqual(awsRequest?.httpHeaders["repeat"].first, "Repeat")
         XCTAssertTrue(try XCTUnwrap(awsRequest).body.asPayload().isEmpty)
     }
 
@@ -158,30 +158,30 @@ class AWSRequestTests: XCTestCase {
         let config = createServiceConfig(serviceProtocol: .json(version: "1.1"))
         var request: AWSRequest?
         XCTAssertNoThrow(request = try AWSRequest(operation: "test", path: "/", httpMethod: "POST", input: object, configuration: config))
-        XCTAssertEqual(request?.getHttpHeaders()["content-type"].first, "application/x-amz-json-1.1")
+        XCTAssertEqual(request?.httpHeaders["content-type"].first, "application/x-amz-json-1.1")
 
         let config2 = createServiceConfig(serviceProtocol: .restjson)
         var request2: AWSRequest?
         XCTAssertNoThrow(request2 = try AWSRequest(operation: "test", path: "/", httpMethod: "POST", input: object, configuration: config2))
-        XCTAssertEqual(request2?.getHttpHeaders()["content-type"].first, "application/json")
+        XCTAssertEqual(request2?.httpHeaders["content-type"].first, "application/json")
         var rawRequest2: AWSRequest?
         XCTAssertNoThrow(rawRequest2 = try AWSRequest(operation: "test", path: "/", httpMethod: "POST", input: object2, configuration: config2))
-        XCTAssertEqual(rawRequest2?.getHttpHeaders()["content-type"].first, "binary/octet-stream")
+        XCTAssertEqual(rawRequest2?.httpHeaders["content-type"].first, "binary/octet-stream")
 
         let config3 = createServiceConfig(serviceProtocol: .query)
         var request3: AWSRequest?
         XCTAssertNoThrow(request3 = try AWSRequest(operation: "test", path: "/", httpMethod: "POST", input: object, configuration: config3))
-        XCTAssertEqual(request3?.getHttpHeaders()["content-type"].first, "application/x-www-form-urlencoded; charset=utf-8")
+        XCTAssertEqual(request3?.httpHeaders["content-type"].first, "application/x-www-form-urlencoded; charset=utf-8")
 
         let config4 = createServiceConfig(serviceProtocol: .ec2)
         var request4: AWSRequest?
         XCTAssertNoThrow(request4 = try AWSRequest(operation: "test", path: "/", httpMethod: "POST", input: object, configuration: config4))
-        XCTAssertEqual(request4?.getHttpHeaders()["content-type"].first, "application/x-www-form-urlencoded; charset=utf-8")
+        XCTAssertEqual(request4?.httpHeaders["content-type"].first, "application/x-www-form-urlencoded; charset=utf-8")
 
         let config5 = createServiceConfig(serviceProtocol: .restxml)
         var request5: AWSRequest?
         XCTAssertNoThrow(request5 = try AWSRequest(operation: "test", path: "/", httpMethod: "POST", input: object, configuration: config5))
-        XCTAssertEqual(request5?.getHttpHeaders()["content-type"].first, "application/octet-stream")
+        XCTAssertEqual(request5?.httpHeaders["content-type"].first, "application/octet-stream")
     }
 
     func testHeaderEncoding() {
@@ -193,7 +193,7 @@ class AWSRequestTests: XCTestCase {
         let config = createServiceConfig()
         var request: AWSRequest?
         XCTAssertNoThrow(request = try AWSRequest(operation: "Test", path: "/", httpMethod: "GET", input: input, configuration: config))
-        XCTAssertEqual(request?.httpHeaders["header-member"] as? String, "TestHeader")
+        XCTAssertEqual(request?.httpHeaders["header-member"].first, "TestHeader")
     }
 
     func testQueryEncoding() {


### PR DESCRIPTION
Also
- remove unused initialiser for `AWSRequest`
- apply content-type and user-agent headers at initialisation
- add support for encoding headers that are dictionaries. Uses pattern set by s3 `x-amz-meta-` headers.

I couldn't do the same for `AWSResponse` as it would have broken the decoding the `x-amz-meta-` headers. Will need to find another way to do this. But I did lowercase all the header names in AWSResponse so we get a consistent casing for response headers.