### PR TITLE
AWSClient.init credentialProvider parameter changes

### DIFF
--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -73,7 +73,7 @@ public final class AWSClient {
     ///     - middlewares: Array of middlewares to apply to requests and responses
     ///     - httpClientProvider: HTTPClient to use. Use `.createNew` if you want the client to manage its own HTTPClient.
     public init(
-        credentialProvider credentialProviderFactory: CredentialProviderFactory = .runtime,
+        credentialProvider credentialProviderFactory: CredentialProviderFactory = .default,
         retryPolicy: RetryPolicy = JitterRetry(),
         middlewares: [AWSServiceMiddleware] = [],
         httpClientProvider: HTTPClientProvider

--- a/Sources/AWSSDKSwiftCore/Credential/CredentialProvider.swift
+++ b/Sources/AWSSDKSwiftCore/Credential/CredentialProvider.swift
@@ -51,6 +51,11 @@ public struct CredentialProviderFactory {
 
 extension CredentialProviderFactory {
     
+    /// The default CredentialProvider used to access credentials
+    public static var `default`: CredentialProviderFactory {
+        return .runtime
+    }
+    
     /// Use this method to initialize your custom `CredentialProvider`
     public static func custom(_ factory: @escaping (Context) -> CredentialProvider) -> CredentialProviderFactory {
         Self(cb: factory)

--- a/Sources/AWSTestUtils/TestUtils.swift
+++ b/Sources/AWSTestUtils/TestUtils.swift
@@ -33,7 +33,7 @@ import Foundation
 }
 
 public func createAWSClient(
-    credentialProvider: CredentialProviderFactory = .runtime,
+    credentialProvider: CredentialProviderFactory = .default,
     retryPolicy: RetryPolicy = NoRetry(),
     middlewares: [AWSServiceMiddleware] = [],
     httpClientProvider: AWSClient.HTTPClientProvider = .createNew

--- a/Sources/AWSTestUtils/TestUtils.swift
+++ b/Sources/AWSTestUtils/TestUtils.swift
@@ -39,7 +39,7 @@ public func createAWSClient(
     httpClientProvider: AWSClient.HTTPClientProvider = .createNew
 ) -> AWSClient {
     return AWSClient(
-        credentialProviderFactory: credentialProvider,
+        credentialProvider: credentialProvider,
         retryPolicy: retryPolicy,
         middlewares: middlewares,
         httpClientProvider: httpClientProvider


### PR DESCRIPTION
Can we keep the parameter name as `credentialProvider`. No one is going to thank us for the extra 7 letters. 
Also can we keep the parameter as an optional. 
1) the default provider is part of the public function signature so we can't change it
2) eventually `runtime` is being replaced with `group` containing a list of providers, which changes per platform, which as a default parameter will be a pain, also we wouldnt be able to change that list with going up a major version. 