### PR TITLE
Refactor ServiceConfig

### DIFF
--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -52,7 +52,7 @@ public final class AWSClient {
     }
 
     /// AWS service configuration
-    public let serviceConfig: ServiceConfig
+    public let serviceConfig: AWSServiceConfig
     /// AWS credentials provider
     let credentialProvider: CredentialProvider
     /// middleware code to be applied to requests and responses
@@ -82,7 +82,7 @@ public final class AWSClient {
     ///     - httpClientProvider: HTTPClient to use. Use `.createNew` if you want the client to manage its own HTTPClient.
     public init(
         credentialProviderFactory: CredentialProviderFactory = .runtime,
-        serviceConfig: ServiceConfig,
+        serviceConfig: AWSServiceConfig,
         retryPolicy: RetryPolicy = JitterRetry(),
         middlewares: [AWSServiceMiddleware] = [],
         httpClientProvider: HTTPClientProvider

--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -198,15 +198,15 @@ extension AWSClient {
     public func send<Input: AWSEncodableShape>(operation operationName: String, path: String, httpMethod: String, serviceConfig: AWSServiceConfig, input: Input, on eventLoop: EventLoop? = nil) -> EventLoopFuture<Void> {
         let eventLoop = eventLoop ?? eventLoopGroup.next()
         let future: EventLoopFuture<Void> = credentialProvider.getCredential(on: eventLoop).flatMapThrowing { credential in
-            let signer = AWSSigner(credentials: credential, name: self.serviceConfig.signingName, region: self.serviceConfig.region.rawValue)
+            let signer = AWSSigner(credentials: credential, name: serviceConfig.signingName, region: serviceConfig.region.rawValue)
             let awsRequest = try AWSRequest(
                         operation: operationName,
                         path: path,
                         httpMethod: httpMethod,
                         input: input,
-                        configuration: self.serviceConfig)
+                        configuration: serviceConfig)
             return try awsRequest
-                .applyMiddlewares(self.serviceConfig.middlewares + self.middlewares)
+                .applyMiddlewares(serviceConfig.middlewares + self.middlewares)
                 .createHTTPRequest(signer: signer)
         }.flatMap { request in
             return self.invoke(request, on: eventLoop)
@@ -226,14 +226,14 @@ extension AWSClient {
     public func execute(operation operationName: String, path: String, httpMethod: String, serviceConfig: AWSServiceConfig, on eventLoop: EventLoop? = nil) -> EventLoopFuture<Void> {
         let eventLoop = eventLoop ?? eventLoopGroup.next()
         let future: EventLoopFuture<Void> = credentialProvider.getCredential(on: eventLoop).flatMapThrowing { credential in
-            let signer = AWSSigner(credentials: credential, name: self.serviceConfig.signingName, region: self.serviceConfig.region.rawValue)
+            let signer = AWSSigner(credentials: credential, name: serviceConfig.signingName, region: serviceConfig.region.rawValue)
             let awsRequest = try AWSRequest(
                 operation: operationName,
                 path: path,
                 httpMethod: httpMethod,
-                configuration: self.serviceConfig)
+                configuration: serviceConfig)
             return try awsRequest
-                .applyMiddlewares(self.serviceConfig.middlewares + self.middlewares)
+                .applyMiddlewares(serviceConfig.middlewares + self.middlewares)
                 .createHTTPRequest(signer: signer)
             
         }.flatMap { request in
@@ -254,19 +254,19 @@ extension AWSClient {
     public func execute<Output: AWSDecodableShape>(operation operationName: String, path: String, httpMethod: String, serviceConfig: AWSServiceConfig, on eventLoop: EventLoop? = nil) -> EventLoopFuture<Output> {
         let eventLoop = eventLoop ?? eventLoopGroup.next()
         let future: EventLoopFuture<Output> = credentialProvider.getCredential(on: eventLoop).flatMapThrowing { credential in
-            let signer = AWSSigner(credentials: credential, name: self.serviceConfig.signingName, region: self.serviceConfig.region.rawValue)
+            let signer = AWSSigner(credentials: credential, name: serviceConfig.signingName, region: serviceConfig.region.rawValue)
             let awsRequest = try AWSRequest(
                 operation: operationName,
                 path: path,
                 httpMethod: httpMethod,
-                configuration: self.serviceConfig)
+                configuration: serviceConfig)
             return try awsRequest
-                .applyMiddlewares(self.serviceConfig.middlewares + self.middlewares)
+                .applyMiddlewares(serviceConfig.middlewares + self.middlewares)
                 .createHTTPRequest(signer: signer)
         }.flatMap { request in
             return self.invoke(request, on: eventLoop)
         }.flatMapThrowing { response in
-            return try self.validate(operation: operationName, response: response, serviceConfig: self.serviceConfig)
+            return try self.validate(operation: operationName, response: response, serviceConfig: serviceConfig)
         }
         return recordMetrics(future, service: serviceConfig.service, operation: operationName)
     }
@@ -282,20 +282,20 @@ extension AWSClient {
     public func execute<Output: AWSDecodableShape, Input: AWSEncodableShape>(operation operationName: String, path: String, httpMethod: String, serviceConfig: AWSServiceConfig, input: Input, on eventLoop: EventLoop? = nil) -> EventLoopFuture<Output> {
         let eventLoop = eventLoop ?? eventLoopGroup.next()
         let future: EventLoopFuture<Output> = credentialProvider.getCredential(on: eventLoop).flatMapThrowing { credential in
-            let signer = AWSSigner(credentials: credential, name: self.serviceConfig.signingName, region: self.serviceConfig.region.rawValue)
+            let signer = AWSSigner(credentials: credential, name: serviceConfig.signingName, region: serviceConfig.region.rawValue)
             let awsRequest = try AWSRequest(
                         operation: operationName,
                         path: path,
                         httpMethod: httpMethod,
                         input: input,
-                        configuration: self.serviceConfig)
+                        configuration: serviceConfig)
             return try awsRequest
-                .applyMiddlewares(self.serviceConfig.middlewares + self.middlewares)
+                .applyMiddlewares(serviceConfig.middlewares + self.middlewares)
                 .createHTTPRequest(signer: signer)
         }.flatMap { request in
             return self.invoke(request, on: eventLoop)
         }.flatMapThrowing { response in
-            return try self.validate(operation: operationName, response: response, serviceConfig: self.serviceConfig)
+            return try self.validate(operation: operationName, response: response, serviceConfig: serviceConfig)
         }
         return recordMetrics(future, service: serviceConfig.service, operation: operationName)
     }
@@ -303,20 +303,20 @@ extension AWSClient {
     public func execute<Output: AWSDecodableShape, Input: AWSEncodableShape>(operation operationName: String, path: String, httpMethod: String, serviceConfig: AWSServiceConfig, input: Input, on eventLoop: EventLoop? = nil, stream: @escaping AWSHTTPClient.ResponseStream) -> EventLoopFuture<Output> {
         let eventLoop = eventLoop ?? eventLoopGroup.next()
         return credentialProvider.getCredential(on: eventLoop).flatMapThrowing { credential in
-            let signer = AWSSigner(credentials: credential, name: self.serviceConfig.signingName, region: self.serviceConfig.region.rawValue)
+            let signer = AWSSigner(credentials: credential, name: serviceConfig.signingName, region: serviceConfig.region.rawValue)
             let awsRequest = try AWSRequest(
                 operation: operationName,
                 path: path,
                 httpMethod: httpMethod,
                 input: input,
-                configuration: self.serviceConfig)
+                configuration: serviceConfig)
             return try awsRequest
-                .applyMiddlewares(self.serviceConfig.middlewares + self.middlewares)
+                .applyMiddlewares(serviceConfig.middlewares + self.middlewares)
                 .createHTTPRequest(signer: signer)
         }.flatMap { request in
             return self.invoke(request, on: eventLoop, stream: stream)
         }.flatMapThrowing { response in
-            return try self.validate(operation: operationName, response: response, serviceConfig: self.serviceConfig)
+            return try self.validate(operation: operationName, response: response, serviceConfig: serviceConfig)
         }
     }
 

--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -195,7 +195,7 @@ extension AWSClient {
     ///     - input: Input object
     /// - returns:
     ///     Empty Future that completes when response is received
-    public func send<Input: AWSEncodableShape>(operation operationName: String, path: String, httpMethod: String, serviceConfig: AWSServiceConfig, input: Input, on eventLoop: EventLoop? = nil) -> EventLoopFuture<Void> {
+    public func execute<Input: AWSEncodableShape>(operation operationName: String, path: String, httpMethod: String, serviceConfig: AWSServiceConfig, input: Input, on eventLoop: EventLoop? = nil) -> EventLoopFuture<Void> {
         let eventLoop = eventLoop ?? eventLoopGroup.next()
         let future: EventLoopFuture<Void> = credentialProvider.getCredential(on: eventLoop).flatMapThrowing { credential in
             let signer = AWSSigner(credentials: credential, name: serviceConfig.signingName, region: serviceConfig.region.rawValue)

--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -51,8 +51,6 @@ public final class AWSClient {
         case createNew
     }
 
-    /// AWS service configuration
-    public let serviceConfig: AWSServiceConfig
     /// AWS credentials provider
     let credentialProvider: CredentialProvider
     /// middleware code to be applied to requests and responses
@@ -71,19 +69,15 @@ public final class AWSClient {
     /// Initialize an AWSClient struct
     /// - parameters:
     ///     - credentialProvider: An object that returns valid signing credentials for request signing.
-    ///     - serviceConfig: AWS service configuration
     ///     - retryPolicy: Object returning whether retries should be attempted. Possible options are NoRetry(), ExponentialRetry() or JitterRetry()
     ///     - middlewares: Array of middlewares to apply to requests and responses
     ///     - httpClientProvider: HTTPClient to use. Use `.createNew` if you want the client to manage its own HTTPClient.
     public init(
         credentialProviderFactory: CredentialProviderFactory = .runtime,
-        serviceConfig: AWSServiceConfig,
         retryPolicy: RetryPolicy = JitterRetry(),
         middlewares: [AWSServiceMiddleware] = [],
         httpClientProvider: HTTPClientProvider
     ) {
-        self.serviceConfig = serviceConfig
-
         // setup httpClient
         self.httpClientProvider = httpClientProvider
         switch httpClientProvider {

--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -192,7 +192,7 @@ extension AWSClient {
 // public facing apis
 extension AWSClient {
 
-    /// send a request with an input object and return a future with an empty response
+    /// execute a request with an input object and return a future with an empty response
     /// - parameters:
     ///     - operationName: Name of the AWS operation
     ///     - path: path to append to endpoint URL
@@ -221,14 +221,14 @@ extension AWSClient {
         return recordMetrics(future, service: serviceConfig.service, operation: operationName)
     }
 
-    /// send an empty request and return a future with an empty response
+    /// execute an empty request and return a future with an empty response
     /// - parameters:
     ///     - operationName: Name of the AWS operation
     ///     - path: path to append to endpoint URL
     ///     - httpMethod: HTTP method to use ("GET", "PUT", "PUSH" etc)
     /// - returns:
     ///     Empty Future that completes when response is received
-    public func send(operation operationName: String, path: String, httpMethod: String, on eventLoop: EventLoop? = nil) -> EventLoopFuture<Void> {
+    public func execute(operation operationName: String, path: String, httpMethod: String, on eventLoop: EventLoop? = nil) -> EventLoopFuture<Void> {
         let eventLoop = eventLoop ?? eventLoopGroup.next()
         let future: EventLoopFuture<Void> = credentialProvider.getCredential(on: eventLoop).flatMapThrowing { credential in
             let signer = AWSSigner(credentials: credential, name: self.serviceConfig.signingName, region: self.serviceConfig.region.rawValue)
@@ -249,14 +249,14 @@ extension AWSClient {
         return recordMetrics(future, service: serviceConfig.service, operation: operationName)
     }
 
-    /// send an empty request and return a future with the output object generated from the response
+    /// execute an empty request and return a future with the output object generated from the response
     /// - parameters:
     ///     - operationName: Name of the AWS operation
     ///     - path: path to append to endpoint URL
     ///     - httpMethod: HTTP method to use ("GET", "PUT", "PUSH" etc)
     /// - returns:
     ///     Future containing output object that completes when response is received
-    public func send<Output: AWSDecodableShape>(operation operationName: String, path: String, httpMethod: String, on eventLoop: EventLoop? = nil) -> EventLoopFuture<Output> {
+    public func execute<Output: AWSDecodableShape>(operation operationName: String, path: String, httpMethod: String, on eventLoop: EventLoop? = nil) -> EventLoopFuture<Output> {
         let eventLoop = eventLoop ?? eventLoopGroup.next()
         let future: EventLoopFuture<Output> = credentialProvider.getCredential(on: eventLoop).flatMapThrowing { credential in
             let signer = AWSSigner(credentials: credential, name: self.serviceConfig.signingName, region: self.serviceConfig.region.rawValue)
@@ -276,7 +276,7 @@ extension AWSClient {
         return recordMetrics(future, service: serviceConfig.service, operation: operationName)
     }
 
-    /// send a request with an input object and return a future with the output object generated from the response
+    /// execute a request with an input object and return a future with the output object generated from the response
     /// - parameters:
     ///     - operationName: Name of the AWS operation
     ///     - path: path to append to endpoint URL
@@ -284,7 +284,7 @@ extension AWSClient {
     ///     - input: Input object
     /// - returns:
     ///     Future containing output object that completes when response is received
-    public func send<Output: AWSDecodableShape, Input: AWSEncodableShape>(operation operationName: String, path: String, httpMethod: String, input: Input, on eventLoop: EventLoop? = nil) -> EventLoopFuture<Output> {
+    public func execute<Output: AWSDecodableShape, Input: AWSEncodableShape>(operation operationName: String, path: String, httpMethod: String, input: Input, on eventLoop: EventLoop? = nil) -> EventLoopFuture<Output> {
         let eventLoop = eventLoop ?? eventLoopGroup.next()
         let future: EventLoopFuture<Output> = credentialProvider.getCredential(on: eventLoop).flatMapThrowing { credential in
             let signer = AWSSigner(credentials: credential, name: self.serviceConfig.signingName, region: self.serviceConfig.region.rawValue)
@@ -305,7 +305,7 @@ extension AWSClient {
         return recordMetrics(future, service: serviceConfig.service, operation: operationName)
     }
 
-    public func send<Output: AWSDecodableShape, Input: AWSEncodableShape>(
+    public func execute<Output: AWSDecodableShape, Input: AWSEncodableShape>(
         operation operationName: String,
         path: String,
         httpMethod: String,

--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -195,7 +195,7 @@ extension AWSClient {
     ///     - input: Input object
     /// - returns:
     ///     Empty Future that completes when response is received
-    public func send<Input: AWSEncodableShape>(operation operationName: String, path: String, httpMethod: String, input: Input, on eventLoop: EventLoop? = nil) -> EventLoopFuture<Void> {
+    public func send<Input: AWSEncodableShape>(operation operationName: String, path: String, httpMethod: String, serviceConfig: AWSServiceConfig, input: Input, on eventLoop: EventLoop? = nil) -> EventLoopFuture<Void> {
         let eventLoop = eventLoop ?? eventLoopGroup.next()
         let future: EventLoopFuture<Void> = credentialProvider.getCredential(on: eventLoop).flatMapThrowing { credential in
             let signer = AWSSigner(credentials: credential, name: self.serviceConfig.signingName, region: self.serviceConfig.region.rawValue)
@@ -223,7 +223,7 @@ extension AWSClient {
     ///     - httpMethod: HTTP method to use ("GET", "PUT", "PUSH" etc)
     /// - returns:
     ///     Empty Future that completes when response is received
-    public func execute(operation operationName: String, path: String, httpMethod: String, on eventLoop: EventLoop? = nil) -> EventLoopFuture<Void> {
+    public func execute(operation operationName: String, path: String, httpMethod: String, serviceConfig: AWSServiceConfig, on eventLoop: EventLoop? = nil) -> EventLoopFuture<Void> {
         let eventLoop = eventLoop ?? eventLoopGroup.next()
         let future: EventLoopFuture<Void> = credentialProvider.getCredential(on: eventLoop).flatMapThrowing { credential in
             let signer = AWSSigner(credentials: credential, name: self.serviceConfig.signingName, region: self.serviceConfig.region.rawValue)
@@ -251,7 +251,7 @@ extension AWSClient {
     ///     - httpMethod: HTTP method to use ("GET", "PUT", "PUSH" etc)
     /// - returns:
     ///     Future containing output object that completes when response is received
-    public func execute<Output: AWSDecodableShape>(operation operationName: String, path: String, httpMethod: String, on eventLoop: EventLoop? = nil) -> EventLoopFuture<Output> {
+    public func execute<Output: AWSDecodableShape>(operation operationName: String, path: String, httpMethod: String, serviceConfig: AWSServiceConfig, on eventLoop: EventLoop? = nil) -> EventLoopFuture<Output> {
         let eventLoop = eventLoop ?? eventLoopGroup.next()
         let future: EventLoopFuture<Output> = credentialProvider.getCredential(on: eventLoop).flatMapThrowing { credential in
             let signer = AWSSigner(credentials: credential, name: self.serviceConfig.signingName, region: self.serviceConfig.region.rawValue)
@@ -279,7 +279,7 @@ extension AWSClient {
     ///     - input: Input object
     /// - returns:
     ///     Future containing output object that completes when response is received
-    public func execute<Output: AWSDecodableShape, Input: AWSEncodableShape>(operation operationName: String, path: String, httpMethod: String, input: Input, on eventLoop: EventLoop? = nil) -> EventLoopFuture<Output> {
+    public func execute<Output: AWSDecodableShape, Input: AWSEncodableShape>(operation operationName: String, path: String, httpMethod: String, serviceConfig: AWSServiceConfig, input: Input, on eventLoop: EventLoop? = nil) -> EventLoopFuture<Output> {
         let eventLoop = eventLoop ?? eventLoopGroup.next()
         let future: EventLoopFuture<Output> = credentialProvider.getCredential(on: eventLoop).flatMapThrowing { credential in
             let signer = AWSSigner(credentials: credential, name: self.serviceConfig.signingName, region: self.serviceConfig.region.rawValue)
@@ -300,14 +300,7 @@ extension AWSClient {
         return recordMetrics(future, service: serviceConfig.service, operation: operationName)
     }
 
-    public func execute<Output: AWSDecodableShape, Input: AWSEncodableShape>(
-        operation operationName: String,
-        path: String,
-        httpMethod: String,
-        input: Input,
-        on eventLoop: EventLoop? = nil,
-        stream: @escaping AWSHTTPClient.ResponseStream
-    ) -> EventLoopFuture<Output> {
+    public func execute<Output: AWSDecodableShape, Input: AWSEncodableShape>(operation operationName: String, path: String, httpMethod: String, serviceConfig: AWSServiceConfig, input: Input, on eventLoop: EventLoop? = nil, stream: @escaping AWSHTTPClient.ResponseStream) -> EventLoopFuture<Output> {
         let eventLoop = eventLoop ?? eventLoopGroup.next()
         return credentialProvider.getCredential(on: eventLoop).flatMapThrowing { credential in
             let signer = AWSSigner(credentials: credential, name: self.serviceConfig.signingName, region: self.serviceConfig.region.rawValue)

--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -192,6 +192,7 @@ extension AWSClient {
     ///     - operationName: Name of the AWS operation
     ///     - path: path to append to endpoint URL
     ///     - httpMethod: HTTP method to use ("GET", "PUT", "PUSH" etc)
+    ///     - serviceConfig: configuration to be used to request creation and signing
     ///     - input: Input object
     /// - returns:
     ///     Empty Future that completes when response is received
@@ -221,6 +222,7 @@ extension AWSClient {
     ///     - operationName: Name of the AWS operation
     ///     - path: path to append to endpoint URL
     ///     - httpMethod: HTTP method to use ("GET", "PUT", "PUSH" etc)
+    ///     - serviceConfig: configuration to be used to request creation and signing
     /// - returns:
     ///     Empty Future that completes when response is received
     public func execute(operation operationName: String, path: String, httpMethod: String, serviceConfig: AWSServiceConfig, on eventLoop: EventLoop? = nil) -> EventLoopFuture<Void> {
@@ -249,6 +251,7 @@ extension AWSClient {
     ///     - operationName: Name of the AWS operation
     ///     - path: path to append to endpoint URL
     ///     - httpMethod: HTTP method to use ("GET", "PUT", "PUSH" etc)
+    ///     - serviceConfig: configuration to be used to request creation and signing
     /// - returns:
     ///     Future containing output object that completes when response is received
     public func execute<Output: AWSDecodableShape>(operation operationName: String, path: String, httpMethod: String, serviceConfig: AWSServiceConfig, on eventLoop: EventLoop? = nil) -> EventLoopFuture<Output> {
@@ -276,6 +279,7 @@ extension AWSClient {
     ///     - operationName: Name of the AWS operation
     ///     - path: path to append to endpoint URL
     ///     - httpMethod: HTTP method to use ("GET", "PUT", "PUSH" etc)
+    ///     - serviceConfig: configuration to be used to request creation and signing
     ///     - input: Input object
     /// - returns:
     ///     Future containing output object that completes when response is received
@@ -300,6 +304,15 @@ extension AWSClient {
         return recordMetrics(future, service: serviceConfig.service, operation: operationName)
     }
 
+    /// execute a request with an input object and return a future with the output object generated from the response
+    /// - parameters:
+    ///     - operationName: Name of the AWS operation
+    ///     - path: path to append to endpoint URL
+    ///     - httpMethod: HTTP method to use ("GET", "PUT", "PUSH" etc)
+    ///     - serviceConfig: configuration to be used to request creation and signing
+    ///     - input: Input object
+    /// - returns:
+    ///     Future containing output object that completes when response is received
     public func execute<Output: AWSDecodableShape, Input: AWSEncodableShape>(operation operationName: String, path: String, httpMethod: String, serviceConfig: AWSServiceConfig, input: Input, on eventLoop: EventLoop? = nil, stream: @escaping AWSHTTPClient.ResponseStream) -> EventLoopFuture<Output> {
         let eventLoop = eventLoop ?? eventLoopGroup.next()
         return credentialProvider.getCredential(on: eventLoop).flatMapThrowing { credential in
@@ -325,7 +338,7 @@ extension AWSClient {
     ///     - url : URL to sign
     ///     - httpMethod: HTTP method to use ("GET", "PUT", "PUSH" etc)
     ///     - expires: How long before the signed URL expires
-    ///        - 
+    ///     - serviceConfig: Additional configuration to sign the url
     /// - returns:
     ///     A signed URL
     public func signURL(url: URL, httpMethod: String, expires: Int = 86400, serviceConfig: AWSServiceConfig) -> EventLoopFuture<URL> {

--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -186,7 +186,7 @@ extension AWSClient {
     ///     - operationName: Name of the AWS operation
     ///     - path: path to append to endpoint URL
     ///     - httpMethod: HTTP method to use ("GET", "PUT", "PUSH" etc)
-    ///     - serviceConfig: configuration to be used to request creation and signing
+    ///     - serviceConfig: AWS service configuration used in request creation and signing
     ///     - input: Input object
     /// - returns:
     ///     Empty Future that completes when response is received
@@ -223,7 +223,7 @@ extension AWSClient {
     ///     - operationName: Name of the AWS operation
     ///     - path: path to append to endpoint URL
     ///     - httpMethod: HTTP method to use ("GET", "PUT", "PUSH" etc)
-    ///     - serviceConfig: configuration to be used to request creation and signing
+    ///     - serviceConfig: AWS service configuration used in request creation and signing
     /// - returns:
     ///     Empty Future that completes when response is received
     public func execute(
@@ -258,7 +258,7 @@ extension AWSClient {
     ///     - operationName: Name of the AWS operation
     ///     - path: path to append to endpoint URL
     ///     - httpMethod: HTTP method to use ("GET", "PUT", "PUSH" etc)
-    ///     - serviceConfig: configuration to be used to request creation and signing
+    ///     - serviceConfig: AWS service configuration used in request creation and signing
     /// - returns:
     ///     Future containing output object that completes when response is received
     public func execute<Output: AWSDecodableShape>(
@@ -292,7 +292,7 @@ extension AWSClient {
     ///     - operationName: Name of the AWS operation
     ///     - path: path to append to endpoint URL
     ///     - httpMethod: HTTP method to use ("GET", "PUT", "PUSH" etc)
-    ///     - serviceConfig: configuration to be used to request creation and signing
+    ///     - serviceConfig: AWS service configuration used in request creation and signing
     ///     - input: Input object
     /// - returns:
     ///     Future containing output object that completes when response is received
@@ -329,7 +329,7 @@ extension AWSClient {
     ///     - operationName: Name of the AWS operation
     ///     - path: path to append to endpoint URL
     ///     - httpMethod: HTTP method to use ("GET", "PUT", "PUSH" etc)
-    ///     - serviceConfig: configuration to be used to request creation and signing
+    ///     - serviceConfig: AWS service configuration used in request creation and signing
     ///     - input: Input object
     /// - returns:
     ///     Future containing output object that completes when response is received
@@ -366,7 +366,7 @@ extension AWSClient {
     ///     - url : URL to sign
     ///     - httpMethod: HTTP method to use ("GET", "PUT", "PUSH" etc)
     ///     - expires: How long before the signed URL expires
-    ///     - serviceConfig: Additional configuration to sign the url
+    ///     - serviceConfig: additional AWS service configuration used to sign the url
     /// - returns:
     ///     A signed URL
     public func signURL(url: URL, httpMethod: String, expires: Int = 86400, serviceConfig: AWSServiceConfig) -> EventLoopFuture<URL> {

--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -332,22 +332,20 @@ extension AWSClient {
     ///     - url : URL to sign
     ///     - httpMethod: HTTP method to use ("GET", "PUT", "PUSH" etc)
     ///     - expires: How long before the signed URL expires
+    ///        - 
     /// - returns:
     ///     A signed URL
-    public func signURL(url: URL, httpMethod: String, expires: Int = 86400) -> EventLoopFuture<URL> {
-        return signer.map { signer in signer.signURL(url: url, method: HTTPMethod(rawValue: httpMethod), expires: expires) }
-    }
-}
-
-// request creator
-extension AWSClient {
-
-    var signer: EventLoopFuture<AWSSigner> {
-        return credentialProvider.getCredential(on: eventLoopGroup.next()).map { credential in
-            return AWSSigner(credentials: credential, name: self.serviceConfig.signingName, region: self.serviceConfig.region.rawValue)
+    public func signURL(url: URL, httpMethod: String, expires: Int = 86400, serviceConfig: AWSServiceConfig) -> EventLoopFuture<URL> {
+        return createSigner(serviceConfig: serviceConfig).map { signer in
+            signer.signURL(url: url, method: HTTPMethod(rawValue: httpMethod), expires: expires)
         }
     }
     
+    public func createSigner(serviceConfig: AWSServiceConfig) -> EventLoopFuture<AWSSigner> {
+        return credentialProvider.getCredential(on: eventLoopGroup.next()).map { credential in
+            return AWSSigner(credentials: credential, name: serviceConfig.signingName, region: serviceConfig.region.rawValue)
+        }
+    }
 }
 
 // response validator

--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -190,7 +190,14 @@ extension AWSClient {
     ///     - input: Input object
     /// - returns:
     ///     Empty Future that completes when response is received
-    public func execute<Input: AWSEncodableShape>(operation operationName: String, path: String, httpMethod: String, serviceConfig: AWSServiceConfig, input: Input, on eventLoop: EventLoop? = nil) -> EventLoopFuture<Void> {
+    public func execute<Input: AWSEncodableShape>(
+        operation operationName: String,
+        path: String,
+        httpMethod: String,
+        serviceConfig: AWSServiceConfig,
+        input: Input,
+        on eventLoop: EventLoop? = nil
+    ) -> EventLoopFuture<Void> {
         let eventLoop = eventLoop ?? eventLoopGroup.next()
         let future: EventLoopFuture<Void> = credentialProvider.getCredential(on: eventLoop).flatMapThrowing { credential in
             let signer = AWSSigner(credentials: credential, name: serviceConfig.signingName, region: serviceConfig.region.rawValue)
@@ -219,7 +226,13 @@ extension AWSClient {
     ///     - serviceConfig: configuration to be used to request creation and signing
     /// - returns:
     ///     Empty Future that completes when response is received
-    public func execute(operation operationName: String, path: String, httpMethod: String, serviceConfig: AWSServiceConfig, on eventLoop: EventLoop? = nil) -> EventLoopFuture<Void> {
+    public func execute(
+        operation operationName: String,
+        path: String,
+        httpMethod: String,
+        serviceConfig: AWSServiceConfig,
+        on eventLoop: EventLoop? = nil
+    ) -> EventLoopFuture<Void> {
         let eventLoop = eventLoop ?? eventLoopGroup.next()
         let future: EventLoopFuture<Void> = credentialProvider.getCredential(on: eventLoop).flatMapThrowing { credential in
             let signer = AWSSigner(credentials: credential, name: serviceConfig.signingName, region: serviceConfig.region.rawValue)
@@ -248,7 +261,13 @@ extension AWSClient {
     ///     - serviceConfig: configuration to be used to request creation and signing
     /// - returns:
     ///     Future containing output object that completes when response is received
-    public func execute<Output: AWSDecodableShape>(operation operationName: String, path: String, httpMethod: String, serviceConfig: AWSServiceConfig, on eventLoop: EventLoop? = nil) -> EventLoopFuture<Output> {
+    public func execute<Output: AWSDecodableShape>(
+        operation operationName: String,
+        path: String,
+        httpMethod: String,
+        serviceConfig: AWSServiceConfig,
+        on eventLoop: EventLoop? = nil
+    ) -> EventLoopFuture<Output> {
         let eventLoop = eventLoop ?? eventLoopGroup.next()
         let future: EventLoopFuture<Output> = credentialProvider.getCredential(on: eventLoop).flatMapThrowing { credential in
             let signer = AWSSigner(credentials: credential, name: serviceConfig.signingName, region: serviceConfig.region.rawValue)
@@ -277,7 +296,14 @@ extension AWSClient {
     ///     - input: Input object
     /// - returns:
     ///     Future containing output object that completes when response is received
-    public func execute<Output: AWSDecodableShape, Input: AWSEncodableShape>(operation operationName: String, path: String, httpMethod: String, serviceConfig: AWSServiceConfig, input: Input, on eventLoop: EventLoop? = nil) -> EventLoopFuture<Output> {
+    public func execute<Output: AWSDecodableShape, Input: AWSEncodableShape>(
+        operation operationName: String,
+        path: String,
+        httpMethod: String,
+        serviceConfig: AWSServiceConfig,
+        input: Input,
+        on eventLoop: EventLoop? = nil
+    ) -> EventLoopFuture<Output> {
         let eventLoop = eventLoop ?? eventLoopGroup.next()
         let future: EventLoopFuture<Output> = credentialProvider.getCredential(on: eventLoop).flatMapThrowing { credential in
             let signer = AWSSigner(credentials: credential, name: serviceConfig.signingName, region: serviceConfig.region.rawValue)
@@ -307,7 +333,15 @@ extension AWSClient {
     ///     - input: Input object
     /// - returns:
     ///     Future containing output object that completes when response is received
-    public func execute<Output: AWSDecodableShape, Input: AWSEncodableShape>(operation operationName: String, path: String, httpMethod: String, serviceConfig: AWSServiceConfig, input: Input, on eventLoop: EventLoop? = nil, stream: @escaping AWSHTTPClient.ResponseStream) -> EventLoopFuture<Output> {
+    public func execute<Output: AWSDecodableShape, Input: AWSEncodableShape>(
+        operation operationName: String,
+        path: String,
+        httpMethod: String,
+        serviceConfig: AWSServiceConfig,
+        input: Input,
+        on eventLoop: EventLoop? = nil,
+        stream: @escaping AWSHTTPClient.ResponseStream
+    ) -> EventLoopFuture<Output> {
         let eventLoop = eventLoop ?? eventLoopGroup.next()
         return credentialProvider.getCredential(on: eventLoop).flatMapThrowing { credential in
             let signer = AWSSigner(credentials: credential, name: serviceConfig.signingName, region: serviceConfig.region.rawValue)

--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -68,11 +68,6 @@ public final class AWSClient {
 
     private let isShutdown = NIOAtomic<Bool>.makeAtomic(value: false)
 
-    // public accessors to ensure code outside of aws-sdk-swift-core still compiles
-    public var region: Region { return serviceConfig.region }
-    public var endpoint: String { return serviceConfig.endpoint }
-    public var serviceProtocol: ServiceProtocol { return serviceConfig.serviceProtocol }
-
     /// Initialize an AWSClient struct
     /// - parameters:
     ///     - credentialProvider: An object that returns valid signing credentials for request signing.

--- a/Sources/AWSSDKSwiftCore/AWSServiceConfig.swift
+++ b/Sources/AWSSDKSwiftCore/AWSServiceConfig.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 /// Configuration class defining an AWS service
-public class ServiceConfig {
+public class AWSServiceConfig {
 
     /// Region where service is running
     public let region: Region

--- a/Sources/AWSSDKSwiftCore/Message/AWSRequest.swift
+++ b/Sources/AWSSDKSwiftCore/Message/AWSRequest.swift
@@ -92,7 +92,7 @@ public struct AWSRequest {
 
 extension AWSRequest {
     
-    internal init(operation operationName: String, path: String, httpMethod: String, configuration: ServiceConfig) throws {
+    internal init(operation operationName: String, path: String, httpMethod: String, configuration: AWSServiceConfig) throws {
         var headers = HTTPHeaders()
 
         guard let url = URL(string: "\(configuration.endpoint)\(path)"), let _ = url.host else {
@@ -120,7 +120,7 @@ extension AWSRequest {
         path: String,
         httpMethod: String,
         input: Input,
-        configuration: ServiceConfig) throws
+        configuration: AWSServiceConfig) throws
     {
         var headers = HTTPHeaders()
         var path = path

--- a/Sources/AWSSDKSwiftCore/Message/AWSResponse.swift
+++ b/Sources/AWSSDKSwiftCore/Message/AWSResponse.swift
@@ -183,7 +183,7 @@ public struct AWSResponse {
     }
     
     /// extract error code and message from AWSResponse
-    func generateError(serviceConfig: ServiceConfig) -> Error? {
+    func generateError(serviceConfig: AWSServiceConfig) -> Error? {
         var apiError: APIError? = nil
         switch serviceConfig.serviceProtocol {
         case .query:

--- a/Sources/AWSTestUtils/TestUtils.swift
+++ b/Sources/AWSTestUtils/TestUtils.swift
@@ -83,9 +83,9 @@ public func createServiceConfig(
     serviceEndpoints: [String: String] = [:],
     partitionEndpoints: [Partition: (endpoint: String, region: Region)] = [:],
     possibleErrorTypes: [AWSErrorType.Type] = [],
-    middlewares: [AWSServiceMiddleware] = []) -> ServiceConfig
+    middlewares: [AWSServiceMiddleware] = []) -> AWSServiceConfig
 {
-    ServiceConfig(
+    AWSServiceConfig(
         region: region,
         partition: partition,
         amzTarget: amzTarget,

--- a/Sources/AWSTestUtils/TestUtils.swift
+++ b/Sources/AWSTestUtils/TestUtils.swift
@@ -37,7 +37,7 @@ public func createAWSClient(
     region: Region? = nil,
     partition: Partition = .aws,
     amzTarget: String? = nil,
-    service: String = "testService",
+    service: String = "test",
     signingName: String? = nil,
     serviceProtocol: ServiceProtocol = .restjson,
     apiVersion: String = "01-01-2001",
@@ -62,6 +62,22 @@ public func createAWSClient(
         partitionEndpoints: partitionEndpoints,
         possibleErrorTypes: possibleErrorTypes
     )
+    return AWSClient(
+        credentialProviderFactory: credentialProvider,
+        serviceConfig: serviceConfig,
+        retryPolicy: retryPolicy,
+        middlewares: middlewares,
+        httpClientProvider: httpClientProvider
+    )
+}
+
+public func createAWSClient(
+    serviceConfig: AWSServiceConfig = createServiceConfig(),
+    credentialProvider: CredentialProviderFactory = .runtime,
+    retryPolicy: RetryPolicy = NoRetry(),
+    middlewares: [AWSServiceMiddleware] = [],
+    httpClientProvider: AWSClient.HTTPClientProvider = .createNew
+) -> AWSClient {
     return AWSClient(
         credentialProviderFactory: credentialProvider,
         serviceConfig: serviceConfig,

--- a/Sources/AWSTestUtils/TestUtils.swift
+++ b/Sources/AWSTestUtils/TestUtils.swift
@@ -34,53 +34,12 @@ import Foundation
 
 public func createAWSClient(
     credentialProvider: CredentialProviderFactory = .runtime,
-    region: Region? = nil,
-    partition: Partition = .aws,
-    amzTarget: String? = nil,
-    service: String = "test",
-    signingName: String? = nil,
-    serviceProtocol: ServiceProtocol = .restjson,
-    apiVersion: String = "01-01-2001",
-    endpoint: String? = nil,
-    serviceEndpoints: [String: String] = [:],
-    partitionEndpoints: [Partition: (endpoint: String, region: Region)] = [:],
-    retryPolicy: RetryPolicy = NoRetry(),
-    middlewares: [AWSServiceMiddleware] = [],
-    possibleErrorTypes: [AWSErrorType.Type] = [],
-    httpClientProvider: AWSClient.HTTPClientProvider = .createNew
-) -> AWSClient {
-    let serviceConfig = createServiceConfig(
-        region: region,
-        partition: partition,
-        amzTarget: amzTarget,
-        service: service,
-        signingName: signingName,
-        serviceProtocol: serviceProtocol,
-        apiVersion: apiVersion,
-        endpoint: endpoint,
-        serviceEndpoints: serviceEndpoints,
-        partitionEndpoints: partitionEndpoints,
-        possibleErrorTypes: possibleErrorTypes
-    )
-    return AWSClient(
-        credentialProviderFactory: credentialProvider,
-        serviceConfig: serviceConfig,
-        retryPolicy: retryPolicy,
-        middlewares: middlewares,
-        httpClientProvider: httpClientProvider
-    )
-}
-
-public func createAWSClient(
-    serviceConfig: AWSServiceConfig = createServiceConfig(),
-    credentialProvider: CredentialProviderFactory = .runtime,
     retryPolicy: RetryPolicy = NoRetry(),
     middlewares: [AWSServiceMiddleware] = [],
     httpClientProvider: AWSClient.HTTPClientProvider = .createNew
 ) -> AWSClient {
     return AWSClient(
         credentialProviderFactory: credentialProvider,
-        serviceConfig: serviceConfig,
         retryPolicy: retryPolicy,
         middlewares: middlewares,
         httpClientProvider: httpClientProvider

--- a/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
@@ -77,7 +77,7 @@ class AWSClientTests: XCTestCase {
         defer {
             XCTAssertNoThrow(try client.syncShutdown())
         }
-        let response: EventLoopFuture<AWSTestServer.HTTPBinResponse> = client.execute(operation: "test", path: "/", httpMethod: "POST")
+        let response: EventLoopFuture<AWSTestServer.HTTPBinResponse> = client.execute(operation: "test", path: "/", httpMethod: "POST", serviceConfig: client.serviceConfig)
 
         XCTAssertNoThrow(try awsServer.httpBin())
         var httpBinResponse: AWSTestServer.HTTPBinResponse? = nil
@@ -100,7 +100,7 @@ class AWSClientTests: XCTestCase {
                 XCTAssertNoThrow(try client.syncShutdown())
                 XCTAssertNoThrow(try awsServer.stop())
             }
-            let response = client.execute(operation: "test", path: "/", httpMethod: "POST")
+            let response = client.execute(operation: "test", path: "/", httpMethod: "POST", serviceConfig: client.serviceConfig)
 
             try awsServer.processRaw { request in
                 let response = AWSTestServer.Response(httpStatus: .ok, headers: [:], body: nil)
@@ -131,7 +131,7 @@ class AWSClientTests: XCTestCase {
                 XCTAssertNoThrow(try awsServer.stop())
             }
             let input = Input(e:.second, i: [1,2,4,8])
-            let response = client.send(operation: "test", path: "/", httpMethod: "POST", input: input)
+            let response = client.send(operation: "test", path: "/", httpMethod: "POST", serviceConfig: client.serviceConfig, input: input)
 
             try awsServer.processRaw { request in
                 let receivedInput = try JSONDecoder().decode(Input.self, from: request.body)
@@ -159,7 +159,7 @@ class AWSClientTests: XCTestCase {
                 XCTAssertNoThrow(try client.syncShutdown())
                 XCTAssertNoThrow(try awsServer.stop())
             }
-            let response: EventLoopFuture<Output> = client.execute(operation: "test", path: "/", httpMethod: "POST")
+            let response: EventLoopFuture<Output> = client.execute(operation: "test", path: "/", httpMethod: "POST", serviceConfig: client.serviceConfig)
 
             try awsServer.processRaw { request in
                 let output = Output(s: "TestOutputString", i: 547)
@@ -196,7 +196,7 @@ class AWSClientTests: XCTestCase {
             return eventLoop.makeSucceededFuture(buffer)
         }
         let input = Input(payload: payload)
-        let response = client.send(operation: "test", path: "/", httpMethod: "POST", input: input)
+        let response = client.send(operation: "test", path: "/", httpMethod: "POST", serviceConfig: client.serviceConfig, input: input)
 
         try server.processRaw { request in
             let bytes = request.body.getBytes(at: 0, length: request.body.readableBytes)
@@ -267,7 +267,7 @@ class AWSClientTests: XCTestCase {
                 return eventLoop.makeSucceededFuture(buffer)
             }
             let input = Input(payload: payload)
-            let response = client.send(operation: "test", path: "/", httpMethod: "POST", input: input)
+            let response = client.send(operation: "test", path: "/", httpMethod: "POST", serviceConfig: client.serviceConfig, input: input)
             try response.wait()
         } catch AWSClient.ClientError.tooMuchData {
         } catch {
@@ -311,7 +311,7 @@ class AWSClientTests: XCTestCase {
             }
 
             let input = Input(payload: .fileHandle(fileHandle, size: bufferSize, fileIO: fileIO))
-            let response = client.send(operation: "test", path: "/", httpMethod: "POST", input: input)
+            let response = client.send(operation: "test", path: "/", httpMethod: "POST", serviceConfig: client.serviceConfig, input: input)
 
             try awsServer.processRaw { request in
                 XCTAssertNil(request.headers["transfer-encoding"])
@@ -363,7 +363,7 @@ class AWSClientTests: XCTestCase {
                 }
             }
             let input = Input(payload: payload)
-            let response = client.send(operation: "test", path: "/", httpMethod: "POST", input: input)
+            let response = client.send(operation: "test", path: "/", httpMethod: "POST", serviceConfig: client.serviceConfig, input: input)
 
             try awsServer.processRaw { request in
                 let bytes = request.body.getBytes(at: 0, length: request.body.readableBytes)
@@ -396,7 +396,7 @@ class AWSClientTests: XCTestCase {
                 XCTAssertNoThrow(try client.syncShutdown())
                 XCTAssertNoThrow(try httpClient.syncShutdown())
             }
-            let response = client.execute(operation: "test", path: "/", httpMethod: "POST")
+            let response = client.execute(operation: "test", path: "/", httpMethod: "POST", serviceConfig: client.serviceConfig)
 
             try awsServer.processRaw { request in
                 let response = AWSTestServer.Response(httpStatus: .temporaryRedirect, headers: ["Location":awsServer.address], body: nil)
@@ -437,7 +437,7 @@ class AWSClientTests: XCTestCase {
                 XCTAssertNoThrow(try client.syncShutdown())
                 XCTAssertNoThrow(try httpClient.syncShutdown())
             }
-            let response = client.execute(operation: "test", path: "/", httpMethod: "POST")
+            let response = client.execute(operation: "test", path: "/", httpMethod: "POST", serviceConfig: client.serviceConfig)
 
             var count = 0
             try awsServer.processRaw { request in
@@ -481,7 +481,7 @@ class AWSClientTests: XCTestCase {
                 XCTAssertNoThrow(try client.syncShutdown())
                 XCTAssertNoThrow(try httpClient.syncShutdown())
             }
-            let response: EventLoopFuture<Output> = client.execute(operation: "test", path: "/", httpMethod: "POST")
+            let response: EventLoopFuture<Output> = client.execute(operation: "test", path: "/", httpMethod: "POST", serviceConfig: client.serviceConfig)
 
             var count = 0
             try awsServer.processRaw { request in
@@ -523,7 +523,7 @@ class AWSClientTests: XCTestCase {
                 XCTAssertNoThrow(try client.syncShutdown())
                 XCTAssertNoThrow(try httpClient.syncShutdown())
             }
-            let response: EventLoopFuture<Output> = client.execute(operation: "test", path: "/", httpMethod: "POST")
+            let response: EventLoopFuture<Output> = client.execute(operation: "test", path: "/", httpMethod: "POST", serviceConfig: client.serviceConfig)
 
             try awsServer.processRaw { request in
                 return .error(.accessDenied, continueProcessing: false)
@@ -556,7 +556,7 @@ class AWSClientTests: XCTestCase {
                 XCTAssertNoThrow(try awsServer.stop())
             }
             let eventLoop = client.eventLoopGroup.next()
-            let response: EventLoopFuture<Void> = client.execute(operation: "test", path: "/", httpMethod: "POST", on: eventLoop)
+            let response: EventLoopFuture<Void> = client.execute(operation: "test", path: "/", httpMethod: "POST", serviceConfig: client.serviceConfig, on: eventLoop)
 
             try awsServer.processRaw { request in
                 return .result(.ok)
@@ -594,7 +594,7 @@ class AWSClientTests: XCTestCase {
                 XCTAssertNoThrow(try awsServer.stop())
             }
             var count = 0
-            let response: EventLoopFuture<Output> = client.execute(operation: "test", path: "/", httpMethod: "GET", input: Input()) { (payload: ByteBuffer, eventLoop: EventLoop) in
+            let response: EventLoopFuture<Output> = client.execute(operation: "test", path: "/", httpMethod: "GET", serviceConfig: client.serviceConfig, input: Input()) { (payload: ByteBuffer, eventLoop: EventLoop) in
                 let payloadSize = payload.readableBytes
                 let slice = Data(data[count..<(count+payloadSize)])
                 let payloadData = payload.getData(at: 0, length: payload.readableBytes)
@@ -635,7 +635,7 @@ class AWSClientTests: XCTestCase {
             XCTAssertNoThrow(try awsServer.stop())
         }
         
-        let response = client.execute(operation: "test", path: "/", httpMethod: "POST")
+        let response = client.execute(operation: "test", path: "/", httpMethod: "POST", serviceConfig: client.serviceConfig)
 
         XCTAssertNoThrow(try awsServer.processRaw { request in
             XCTAssertEqual(request.uri, "/test")

--- a/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
@@ -131,7 +131,7 @@ class AWSClientTests: XCTestCase {
                 XCTAssertNoThrow(try awsServer.stop())
             }
             let input = Input(e:.second, i: [1,2,4,8])
-            let response = client.send(operation: "test", path: "/", httpMethod: "POST", serviceConfig: client.serviceConfig, input: input)
+            let response = client.execute(operation: "test", path: "/", httpMethod: "POST", serviceConfig: client.serviceConfig, input: input)
 
             try awsServer.processRaw { request in
                 let receivedInput = try JSONDecoder().decode(Input.self, from: request.body)
@@ -196,7 +196,7 @@ class AWSClientTests: XCTestCase {
             return eventLoop.makeSucceededFuture(buffer)
         }
         let input = Input(payload: payload)
-        let response = client.send(operation: "test", path: "/", httpMethod: "POST", serviceConfig: client.serviceConfig, input: input)
+        let response = client.execute(operation: "test", path: "/", httpMethod: "POST", serviceConfig: client.serviceConfig, input: input)
 
         try server.processRaw { request in
             let bytes = request.body.getBytes(at: 0, length: request.body.readableBytes)
@@ -267,7 +267,7 @@ class AWSClientTests: XCTestCase {
                 return eventLoop.makeSucceededFuture(buffer)
             }
             let input = Input(payload: payload)
-            let response = client.send(operation: "test", path: "/", httpMethod: "POST", serviceConfig: client.serviceConfig, input: input)
+            let response = client.execute(operation: "test", path: "/", httpMethod: "POST", serviceConfig: client.serviceConfig, input: input)
             try response.wait()
         } catch AWSClient.ClientError.tooMuchData {
         } catch {
@@ -311,7 +311,7 @@ class AWSClientTests: XCTestCase {
             }
 
             let input = Input(payload: .fileHandle(fileHandle, size: bufferSize, fileIO: fileIO))
-            let response = client.send(operation: "test", path: "/", httpMethod: "POST", serviceConfig: client.serviceConfig, input: input)
+            let response = client.execute(operation: "test", path: "/", httpMethod: "POST", serviceConfig: client.serviceConfig, input: input)
 
             try awsServer.processRaw { request in
                 XCTAssertNil(request.headers["transfer-encoding"])
@@ -363,7 +363,7 @@ class AWSClientTests: XCTestCase {
                 }
             }
             let input = Input(payload: payload)
-            let response = client.send(operation: "test", path: "/", httpMethod: "POST", serviceConfig: client.serviceConfig, input: input)
+            let response = client.execute(operation: "test", path: "/", httpMethod: "POST", serviceConfig: client.serviceConfig, input: input)
 
             try awsServer.processRaw { request in
                 let bytes = request.body.getBytes(at: 0, length: request.body.readableBytes)

--- a/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
@@ -77,7 +77,7 @@ class AWSClientTests: XCTestCase {
         defer {
             XCTAssertNoThrow(try client.syncShutdown())
         }
-        let response: EventLoopFuture<AWSTestServer.HTTPBinResponse> = client.send(operation: "test", path: "/", httpMethod: "POST")
+        let response: EventLoopFuture<AWSTestServer.HTTPBinResponse> = client.execute(operation: "test", path: "/", httpMethod: "POST")
 
         XCTAssertNoThrow(try awsServer.httpBin())
         var httpBinResponse: AWSTestServer.HTTPBinResponse? = nil
@@ -100,7 +100,7 @@ class AWSClientTests: XCTestCase {
                 XCTAssertNoThrow(try client.syncShutdown())
                 XCTAssertNoThrow(try awsServer.stop())
             }
-            let response = client.send(operation: "test", path: "/", httpMethod: "POST")
+            let response = client.execute(operation: "test", path: "/", httpMethod: "POST")
 
             try awsServer.processRaw { request in
                 let response = AWSTestServer.Response(httpStatus: .ok, headers: [:], body: nil)
@@ -159,7 +159,7 @@ class AWSClientTests: XCTestCase {
                 XCTAssertNoThrow(try client.syncShutdown())
                 XCTAssertNoThrow(try awsServer.stop())
             }
-            let response: EventLoopFuture<Output> = client.send(operation: "test", path: "/", httpMethod: "POST")
+            let response: EventLoopFuture<Output> = client.execute(operation: "test", path: "/", httpMethod: "POST")
 
             try awsServer.processRaw { request in
                 let output = Output(s: "TestOutputString", i: 547)
@@ -396,7 +396,7 @@ class AWSClientTests: XCTestCase {
                 XCTAssertNoThrow(try client.syncShutdown())
                 XCTAssertNoThrow(try httpClient.syncShutdown())
             }
-            let response = client.send(operation: "test", path: "/", httpMethod: "POST")
+            let response = client.execute(operation: "test", path: "/", httpMethod: "POST")
 
             try awsServer.processRaw { request in
                 let response = AWSTestServer.Response(httpStatus: .temporaryRedirect, headers: ["Location":awsServer.address], body: nil)
@@ -437,7 +437,7 @@ class AWSClientTests: XCTestCase {
                 XCTAssertNoThrow(try client.syncShutdown())
                 XCTAssertNoThrow(try httpClient.syncShutdown())
             }
-            let response = client.send(operation: "test", path: "/", httpMethod: "POST")
+            let response = client.execute(operation: "test", path: "/", httpMethod: "POST")
 
             var count = 0
             try awsServer.processRaw { request in
@@ -481,7 +481,7 @@ class AWSClientTests: XCTestCase {
                 XCTAssertNoThrow(try client.syncShutdown())
                 XCTAssertNoThrow(try httpClient.syncShutdown())
             }
-            let response: EventLoopFuture<Output> = client.send(operation: "test", path: "/", httpMethod: "POST")
+            let response: EventLoopFuture<Output> = client.execute(operation: "test", path: "/", httpMethod: "POST")
 
             var count = 0
             try awsServer.processRaw { request in
@@ -523,7 +523,7 @@ class AWSClientTests: XCTestCase {
                 XCTAssertNoThrow(try client.syncShutdown())
                 XCTAssertNoThrow(try httpClient.syncShutdown())
             }
-            let response: EventLoopFuture<Output> = client.send(operation: "test", path: "/", httpMethod: "POST")
+            let response: EventLoopFuture<Output> = client.execute(operation: "test", path: "/", httpMethod: "POST")
 
             try awsServer.processRaw { request in
                 return .error(.accessDenied, continueProcessing: false)
@@ -556,7 +556,7 @@ class AWSClientTests: XCTestCase {
                 XCTAssertNoThrow(try awsServer.stop())
             }
             let eventLoop = client.eventLoopGroup.next()
-            let response: EventLoopFuture<Void> = client.send(operation: "test", path: "/", httpMethod: "POST", on: eventLoop)
+            let response: EventLoopFuture<Void> = client.execute(operation: "test", path: "/", httpMethod: "POST", on: eventLoop)
 
             try awsServer.processRaw { request in
                 return .result(.ok)
@@ -594,7 +594,7 @@ class AWSClientTests: XCTestCase {
                 XCTAssertNoThrow(try awsServer.stop())
             }
             var count = 0
-            let response: EventLoopFuture<Output> = client.send(operation: "test", path: "/", httpMethod: "GET", input: Input()) { (payload: ByteBuffer, eventLoop: EventLoop) in
+            let response: EventLoopFuture<Output> = client.execute(operation: "test", path: "/", httpMethod: "GET", input: Input()) { (payload: ByteBuffer, eventLoop: EventLoop) in
                 let payloadSize = payload.readableBytes
                 let slice = Data(data[count..<(count+payloadSize)])
                 let payloadData = payload.getData(at: 0, length: payload.readableBytes)
@@ -635,7 +635,7 @@ class AWSClientTests: XCTestCase {
             XCTAssertNoThrow(try awsServer.stop())
         }
         
-        let response = client.send(operation: "test", path: "/", httpMethod: "POST")
+        let response = client.execute(operation: "test", path: "/", httpMethod: "POST")
 
         XCTAssertNoThrow(try awsServer.processRaw { request in
             XCTAssertEqual(request.uri, "/test")

--- a/Tests/AWSSDKSwiftCoreTests/PaginateTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/PaginateTests.swift
@@ -63,7 +63,7 @@ class PaginateTests: XCTestCase {
     }
 
     func counter(_ input: CounterInput, on eventLoop: EventLoop?) -> EventLoopFuture<CounterOutput> {
-        return client.execute(operation: "TestOperation", path: "/", httpMethod: "POST", input: input, on: eventLoop)
+        return client.execute(operation: "TestOperation", path: "/", httpMethod: "POST", serviceConfig: client.serviceConfig, input: input, on: eventLoop)
     }
 
     func counterPaginator(_ input: CounterInput, onPage: @escaping (CounterOutput, EventLoop)->EventLoopFuture<Bool>) -> EventLoopFuture<Void> {
@@ -127,7 +127,7 @@ class PaginateTests: XCTestCase {
     }
 
     func stringList(_ input: StringListInput, on eventLoop: EventLoop? = nil) -> EventLoopFuture<StringListOutput> {
-        return client.execute(operation: "TestOperation", path: "/", httpMethod: "POST", input: input, on: eventLoop)
+        return client.execute(operation: "TestOperation", path: "/", httpMethod: "POST", serviceConfig: client.serviceConfig, input: input, on: eventLoop)
     }
 
     func stringListPaginator(_ input: StringListInput, on eventLoop: EventLoop? = nil, onPage: @escaping (StringListOutput, EventLoop)->EventLoopFuture<Bool>) -> EventLoopFuture<Void> {

--- a/Tests/AWSSDKSwiftCoreTests/PaginateTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/PaginateTests.swift
@@ -63,7 +63,7 @@ class PaginateTests: XCTestCase {
     }
 
     func counter(_ input: CounterInput, on eventLoop: EventLoop?) -> EventLoopFuture<CounterOutput> {
-        return client.send(operation: "TestOperation", path: "/", httpMethod: "POST", input: input, on: eventLoop)
+        return client.execute(operation: "TestOperation", path: "/", httpMethod: "POST", input: input, on: eventLoop)
     }
 
     func counterPaginator(_ input: CounterInput, onPage: @escaping (CounterOutput, EventLoop)->EventLoopFuture<Bool>) -> EventLoopFuture<Void> {
@@ -127,7 +127,7 @@ class PaginateTests: XCTestCase {
     }
 
     func stringList(_ input: StringListInput, on eventLoop: EventLoop? = nil) -> EventLoopFuture<StringListOutput> {
-        return client.send(operation: "TestOperation", path: "/", httpMethod: "POST", input: input, on: eventLoop)
+        return client.execute(operation: "TestOperation", path: "/", httpMethod: "POST", input: input, on: eventLoop)
     }
 
     func stringListPaginator(_ input: StringListInput, on eventLoop: EventLoop? = nil, onPage: @escaping (StringListOutput, EventLoop)->EventLoopFuture<Bool>) -> EventLoopFuture<Void> {

--- a/Tests/AWSSDKSwiftCoreTests/PaginateTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/PaginateTests.swift
@@ -26,13 +26,15 @@ class PaginateTests: XCTestCase {
     var eventLoopGroup: EventLoopGroup!
     var httpClient: AWSHTTPClient!
     var client: AWSClient!
+    var config: AWSServiceConfig!
 
     override func setUp() {
         // create server and client
         awsServer = AWSTestServer(serviceProtocol: .json)
         eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 3)
         httpClient = AsyncHTTPClient.HTTPClient(eventLoopGroupProvider: .shared(eventLoopGroup))
-        client = createAWSClient(credentialProvider: .empty, serviceProtocol: .json(version: "1.1"), endpoint: awsServer.address, retryPolicy: NoRetry(), httpClientProvider: .shared(httpClient))
+        config = createServiceConfig(serviceProtocol: .json(version: "1.1"), endpoint: awsServer.address)
+        client = createAWSClient(credentialProvider: .empty, retryPolicy: NoRetry(), httpClientProvider: .shared(httpClient))
     }
 
     override func tearDown() {
@@ -63,7 +65,7 @@ class PaginateTests: XCTestCase {
     }
 
     func counter(_ input: CounterInput, on eventLoop: EventLoop?) -> EventLoopFuture<CounterOutput> {
-        return client.execute(operation: "TestOperation", path: "/", httpMethod: "POST", serviceConfig: client.serviceConfig, input: input, on: eventLoop)
+        return client.execute(operation: "TestOperation", path: "/", httpMethod: "POST", serviceConfig: config, input: input, on: eventLoop)
     }
 
     func counterPaginator(_ input: CounterInput, onPage: @escaping (CounterOutput, EventLoop)->EventLoopFuture<Bool>) -> EventLoopFuture<Void> {
@@ -127,7 +129,7 @@ class PaginateTests: XCTestCase {
     }
 
     func stringList(_ input: StringListInput, on eventLoop: EventLoop? = nil) -> EventLoopFuture<StringListOutput> {
-        return client.execute(operation: "TestOperation", path: "/", httpMethod: "POST", serviceConfig: client.serviceConfig, input: input, on: eventLoop)
+        return client.execute(operation: "TestOperation", path: "/", httpMethod: "POST", serviceConfig: config, input: input, on: eventLoop)
     }
 
     func stringListPaginator(_ input: StringListInput, on eventLoop: EventLoop? = nil, onPage: @escaping (StringListOutput, EventLoop)->EventLoopFuture<Bool>) -> EventLoopFuture<Void> {

--- a/Tests/AWSSDKSwiftCoreTests/PayloadTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/PayloadTests.swift
@@ -74,7 +74,7 @@ class PayloadTests: XCTestCase {
             defer {
                 XCTAssertNoThrow(try client.syncShutdown())
             }
-            let response: EventLoopFuture<Output> = client.send(operation: "test", path: "/", httpMethod: "POST")
+            let response: EventLoopFuture<Output> = client.execute(operation: "test", path: "/", httpMethod: "POST")
 
             try awsServer.processRaw { request in
                 var byteBuffer = ByteBufferAllocator().buffer(capacity: 0)

--- a/Tests/AWSSDKSwiftCoreTests/PayloadTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/PayloadTests.swift
@@ -34,7 +34,7 @@ class PayloadTests: XCTestCase {
                 XCTAssertNoThrow(try client.syncShutdown())
             }
             let input = DataPayload(data: payload)
-            let response = client.send(operation: "test", path: "/", httpMethod: "POST", serviceConfig: client.serviceConfig, input: input)
+            let response = client.execute(operation: "test", path: "/", httpMethod: "POST", serviceConfig: client.serviceConfig, input: input)
 
             try awsServer.processRaw { request in
                 XCTAssertEqual(request.body.getString(at: 0, length: request.body.readableBytes), expectedResult)

--- a/Tests/AWSSDKSwiftCoreTests/PayloadTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/PayloadTests.swift
@@ -34,7 +34,7 @@ class PayloadTests: XCTestCase {
                 XCTAssertNoThrow(try client.syncShutdown())
             }
             let input = DataPayload(data: payload)
-            let response = client.send(operation: "test", path: "/", httpMethod: "POST", input: input)
+            let response = client.send(operation: "test", path: "/", httpMethod: "POST", serviceConfig: client.serviceConfig, input: input)
 
             try awsServer.processRaw { request in
                 XCTAssertEqual(request.body.getString(at: 0, length: request.body.readableBytes), expectedResult)
@@ -74,7 +74,7 @@ class PayloadTests: XCTestCase {
             defer {
                 XCTAssertNoThrow(try client.syncShutdown())
             }
-            let response: EventLoopFuture<Output> = client.execute(operation: "test", path: "/", httpMethod: "POST")
+            let response: EventLoopFuture<Output> = client.execute(operation: "test", path: "/", httpMethod: "POST", serviceConfig: client.serviceConfig)
 
             try awsServer.processRaw { request in
                 var byteBuffer = ByteBufferAllocator().buffer(capacity: 0)

--- a/Tests/AWSSDKSwiftCoreTests/PayloadTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/PayloadTests.swift
@@ -29,12 +29,13 @@ class PayloadTests: XCTestCase {
 
         do {
             let awsServer = AWSTestServer(serviceProtocol: .json)
-            let client = createAWSClient(credentialProvider: .empty, endpoint: awsServer.address)
+            let config = createServiceConfig(endpoint: awsServer.address)
+            let client = createAWSClient(credentialProvider: .empty)
             defer {
                 XCTAssertNoThrow(try client.syncShutdown())
             }
             let input = DataPayload(data: payload)
-            let response = client.execute(operation: "test", path: "/", httpMethod: "POST", serviceConfig: client.serviceConfig, input: input)
+            let response = client.execute(operation: "test", path: "/", httpMethod: "POST", serviceConfig: config, input: input)
 
             try awsServer.processRaw { request in
                 XCTAssertEqual(request.body.getString(at: 0, length: request.body.readableBytes), expectedResult)
@@ -70,11 +71,12 @@ class PayloadTests: XCTestCase {
         }
         do {
             let awsServer = AWSTestServer(serviceProtocol: .json)
-            let client = createAWSClient(credentialProvider: .empty, endpoint: awsServer.address)
+            let config = createServiceConfig(endpoint: awsServer.address)
+            let client = createAWSClient(credentialProvider: .empty)
             defer {
                 XCTAssertNoThrow(try client.syncShutdown())
             }
-            let response: EventLoopFuture<Output> = client.execute(operation: "test", path: "/", httpMethod: "POST", serviceConfig: client.serviceConfig)
+            let response: EventLoopFuture<Output> = client.execute(operation: "test", path: "/", httpMethod: "POST", serviceConfig: config)
 
             try awsServer.processRaw { request in
                 var byteBuffer = ByteBufferAllocator().buffer(capacity: 0)

--- a/Tests/AWSSDKSwiftCoreTests/PerformanceTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/PerformanceTests.swift
@@ -228,7 +228,7 @@ class PerformanceTests: XCTestCase {
             configuration: client.serviceConfig
         ).applyMiddlewares(client.serviceConfig.middlewares + client.middlewares)
         
-        let signer = try! client.signer.wait()
+        let signer = try! client.createSigner(serviceConfig: client.serviceConfig).wait()
         measure {
             for _ in 0..<1000 {
                 _ = awsRequest.createHTTPRequest(signer: signer)

--- a/Tests/AWSSDKSwiftCoreTests/PerformanceTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/PerformanceTests.swift
@@ -217,6 +217,7 @@ class PerformanceTests: XCTestCase {
 
     func testSignedURLRequest() {
         guard Self.enableTimingTests == true else { return }
+        let config = createServiceConfig()
         let client = createAWSClient(credentialProvider: .static(accessKeyId: "MyAccessKeyId", secretAccessKey: "MySecretAccessKey"))
         defer {
             XCTAssertNoThrow(try client.syncShutdown())
@@ -225,10 +226,10 @@ class PerformanceTests: XCTestCase {
             operation: "Test",
             path: "/",
             httpMethod: "GET",
-            configuration: client.serviceConfig
-        ).applyMiddlewares(client.serviceConfig.middlewares + client.middlewares)
+            configuration: config
+        ).applyMiddlewares(config.middlewares + client.middlewares)
         
-        let signer = try! client.createSigner(serviceConfig: client.serviceConfig).wait()
+        let signer = try! client.createSigner(serviceConfig: config).wait()
         measure {
             for _ in 0..<1000 {
                 _ = awsRequest.createHTTPRequest(signer: signer)


### PR DESCRIPTION
This reduces the impact of #276

## Changes
- rename `ServiceConfig` to `AWSServiceConfig` to prevent symbol clashes with other libraries
- remove `serviceConfig` property from `AWSClient` and the corresponding public accessor properties
- rename all `AWSClient.send` methods to `AWSClient.execute`
- `AWSServiceConfig` must now be provided individually to any of the `AWSClient.execute` methods
- the computed `signer` property on `AWSClient` is now a function (also needs the config)
- adjusted the tests

## Discussion
- the `aws-sdk-swift` package still needs to be adjusted to reflect these changes
- concerning the `AWSClient.createSigner` method: should we really require an `AWSServiceConfig` or is it ok to just provide `signingName` and `region` individually (possibly overloading with a method that still takes the `AWSServiceConfig`)?
- I also needed to add a `serviceConfig` parameter to the `AWSClient.invoke` methods. I opted into naming it `with`. Any better ideas?
- I added documentation for the `serviceConfig` parameter of the `AWSClient.execute` methods. Unsure about if this was necessary or if it is helpful.