### PR TITLE
Provider sync shutdown

### DIFF
--- a/Sources/AWSSDKSwiftCore/Credential/RotatingCredentialProvider.swift
+++ b/Sources/AWSSDKSwiftCore/Credential/RotatingCredentialProvider.swift
@@ -35,11 +35,11 @@ public final class RotatingCredentialProvider: CredentialProvider {
     }
 
     public func syncShutdown() throws {
-        self.lock.lock()
-        defer { self.lock.unlock() }
-        if let future = credentialFuture {
+        let future: EventLoopFuture<Credential>? = self.lock.withLock { credentialFuture }
+        if let future = future {
             _ = try future.wait()
         }
+        try provider.syncShutdown()
     }
 
     public func getCredential(on eventLoop: EventLoop) -> EventLoopFuture<Credential> {


### PR DESCRIPTION
- Added syncShutdown() call to managed CredentialProvider in both RotatingCredentialProvider and DeferredCredentialProvider. 
- Also fixed hang, where the RotatingCredentialProvider.syncShutdown wouldn't finish because it was waiting on a EventLoopFuture to complete but the EventLoopFuture couldn't finish because it couldn't get access to the lock that syncShutdown had locked