### PR TITLE
Fake ec2/ecs metadata servers in AWSTestUtils

### DIFF
--- a/Sources/AWSSDKSwiftCore/Credential/MetaDataCredentialProvider.swift
+++ b/Sources/AWSSDKSwiftCore/Credential/MetaDataCredentialProvider.swift
@@ -69,7 +69,7 @@ extension MetaDataClient {
 struct ECSMetaDataClient: MetaDataClient {
     public typealias MetaData = ECSMetaData
     
-    static let Host = "169.254.170.2"
+    static let Host = "http://169.254.170.2"
     static let RelativeURIEnvironmentName = "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"
     
     struct ECSMetaData: ExpiringCredential, Decodable {
@@ -106,7 +106,7 @@ struct ECSMetaDataClient: MetaDataClient {
         }
         
         self.httpClient     = httpClient
-        self.endpointURL    = "http://\(host)\(relativeURL)"
+        self.endpointURL    = "\(host)\(relativeURL)"
     }
     
     func getMetaData(on eventLoop: EventLoop) -> EventLoopFuture<ECSMetaData> {
@@ -130,7 +130,7 @@ struct ECSMetaDataClient: MetaDataClient {
 struct InstanceMetaDataClient: MetaDataClient {
     typealias MetaData = InstanceMetaData
     
-    static let Host = "169.254.169.254"
+    static let Host = "http://169.254.169.254"
     static let CredentialUri = "/latest/meta-data/iam/security-credentials/"
     static let TokenUri = "/latest/api/token"
     static let TokenTimeToLiveHeader = (name: "X-aws-ec2-metadata-token-ttl-seconds", value: "21600")
@@ -165,10 +165,10 @@ struct InstanceMetaDataClient: MetaDataClient {
     }
   
     private var tokenURL: URL {
-        return URL(string: "http://\(self.host)\(Self.TokenUri)")!
+        return URL(string: "\(self.host)\(Self.TokenUri)")!
     }
     private var credentialURL: URL {
-        return URL(string: "http://\(self.host)\(Self.CredentialUri)")!
+        return URL(string: "\(self.host)\(Self.CredentialUri)")!
     }
     
     let httpClient: AWSHTTPClient

--- a/Tests/AWSSDKSwiftCoreTests/Credential/MetaDataCredentialProviderTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/Credential/MetaDataCredentialProviderTests.swift
@@ -36,7 +36,7 @@ class MetaDataCredentialProviderTests: XCTestCase {
         Environment.set(path, for: ECSMetaDataClient.RelativeURIEnvironmentName)
         defer { Environment.unset(name: ECSMetaDataClient.RelativeURIEnvironmentName) }
         
-        let client = ECSMetaDataClient(httpClient: httpClient, host: "\(testServer.host):\(testServer.serverPort)")
+        let client = ECSMetaDataClient(httpClient: httpClient, host: testServer.address)
         let future = client!.getMetaData(on: loop)
         
         XCTAssertNoThrow(try testServer.ecsMetadataServer(path: path))
@@ -52,7 +52,7 @@ class MetaDataCredentialProviderTests: XCTestCase {
     }
     
     func testECSMetaDataClientDefaultHost() {
-        XCTAssertEqual(ECSMetaDataClient.Host, "169.254.170.2")
+        XCTAssertEqual(ECSMetaDataClient.Host, "http://169.254.170.2")
         XCTAssertEqual(ECSMetaDataClient.RelativeURIEnvironmentName, "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI")
     }
     
@@ -66,7 +66,7 @@ class MetaDataCredentialProviderTests: XCTestCase {
 
         Environment.unset(name: ECSMetaDataClient.RelativeURIEnvironmentName)
         
-        XCTAssertNil(ECSMetaDataClient(httpClient: httpClient, host: "localhost"))
+        XCTAssertNil(ECSMetaDataClient(httpClient: httpClient, host: "http://localhost"))
     }
     
     // MARK: - InstanceMetaDataClient -
@@ -85,7 +85,7 @@ class MetaDataCredentialProviderTests: XCTestCase {
         Environment.set(path, for: ECSMetaDataClient.RelativeURIEnvironmentName)
         defer { Environment.unset(name: ECSMetaDataClient.RelativeURIEnvironmentName) }
         
-        let client = InstanceMetaDataClient(httpClient: httpClient, host: "\(testServer.host):\(testServer.serverPort)")
+        let client = InstanceMetaDataClient(httpClient: httpClient, host: testServer.address)
         let future = client.getMetaData(on: loop)
         
         XCTAssertNoThrow(try testServer.ec2MetadataServer(version: .v2))
@@ -112,7 +112,7 @@ class MetaDataCredentialProviderTests: XCTestCase {
         let testServer = AWSTestServer(serviceProtocol: .json)
         defer { XCTAssertNoThrow(try testServer.stop()) }
         
-        let client = InstanceMetaDataClient(httpClient: httpClient, host: "\(testServer.host):\(testServer.serverPort)")
+        let client = InstanceMetaDataClient(httpClient: httpClient, host: testServer.address)
         let future = client.getMetaData(on: loop)
         
         XCTAssertNoThrow(try testServer.ec2MetadataServer(version: .v1))
@@ -130,6 +130,6 @@ class MetaDataCredentialProviderTests: XCTestCase {
     }
     
     func testEC2UInstanceMetaDataClientDefaultHost() {
-        XCTAssertEqual(InstanceMetaDataClient.Host, "169.254.169.254")
+        XCTAssertEqual(InstanceMetaDataClient.Host, "http://169.254.169.254")
     }
 }

--- a/Tests/AWSSDKSwiftCoreTests/Credential/MetaDataCredentialProviderTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/Credential/MetaDataCredentialProviderTests.swift
@@ -39,49 +39,16 @@ class MetaDataCredentialProviderTests: XCTestCase {
         let client = ECSMetaDataClient(httpClient: httpClient, host: "\(testServer.host):\(testServer.serverPort)")
         let future = client!.getMetaData(on: loop)
         
-        let accessKeyId = "abc123"
-        let secretAccessKey = "123abc"
-        let sessionToken = "xyz987"
-        let expiration = Date(timeIntervalSince1970: Date().timeIntervalSince1970.rounded() + 60 * 2)
-        
-        let dateFormatter = DateFormatter()
-        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
-        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss'Z'"
-        dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
-        let roleArn = "asd:aws:asd"
-        
-        XCTAssertNoThrow(try testServer.processRaw {
-            (request: AWSTestServer.Request) -> AWSTestServer.Result<AWSTestServer.Response> in
-            
-            XCTAssertEqual(request.uri, path)
-            XCTAssertEqual(request.method, .GET)
-            
-            let json = """
-                {
-                    "AccessKeyId": "\(accessKeyId)",
-                    "SecretAccessKey": "\(secretAccessKey)",
-                    "Token": "\(sessionToken)",
-                    "Expiration": "\(dateFormatter.string(from: expiration))",
-                    "RoleArn": "\(roleArn)"
-                }
-                """
-            var byteButter = ByteBufferAllocator().buffer(capacity: json.utf8.count)
-            byteButter.writeString(json)
-            return .result(.init(httpStatus: .ok, body: byteButter), continueProcessing: false)
-        })
-        
+        XCTAssertNoThrow(try testServer.ecsMetadataServer(path: path))
+
         var metaData: ECSMetaDataClient.MetaData?
         XCTAssertNoThrow(metaData = try future.wait())
         
-        XCTAssertEqual(metaData?.accessKeyId, accessKeyId)
-        XCTAssertEqual(metaData?.secretAccessKey, secretAccessKey)
-        XCTAssertEqual(metaData?.token, sessionToken)
-        XCTAssertEqual(metaData?.expiration, expiration)
-        XCTAssertEqual(metaData?.roleArn, roleArn)
-        
-        XCTAssertEqual(metaData?.accessKeyId, accessKeyId)
-        XCTAssertEqual(metaData?.secretAccessKey, secretAccessKey)
-        XCTAssertEqual(metaData?.sessionToken, sessionToken)
+        XCTAssertEqual(metaData?.accessKeyId, AWSTestServer.ECSMetaData.default.accessKeyId)
+        XCTAssertEqual(metaData?.secretAccessKey, AWSTestServer.ECSMetaData.default.secretAccessKey)
+        XCTAssertEqual(metaData?.token, AWSTestServer.ECSMetaData.default.token)
+        XCTAssertEqual(metaData?.expiration.description, AWSTestServer.ECSMetaData.default.expiration.description)
+        XCTAssertEqual(metaData?.roleArn, AWSTestServer.ECSMetaData.default.roleArn)
     }
     
     func testECSMetaDataClientDefaultHost() {
@@ -121,76 +88,18 @@ class MetaDataCredentialProviderTests: XCTestCase {
         let client = InstanceMetaDataClient(httpClient: httpClient, host: "\(testServer.host):\(testServer.serverPort)")
         let future = client.getMetaData(on: loop)
         
-        let token = UUID().uuidString
-        XCTAssertNoThrow(try testServer.processRaw { (request) -> AWSTestServer.Result<AWSTestServer.Response> in
-            XCTAssertEqual(request.uri, InstanceMetaDataClient.TokenUri)
-            XCTAssertEqual(request.method, .PUT)
-            XCTAssertEqual(request.headers[InstanceMetaDataClient.TokenTimeToLiveHeader.name], InstanceMetaDataClient.TokenTimeToLiveHeader.value)
-            
-            var byteBuffer = ByteBufferAllocator().buffer(capacity: token.utf8.count)
-            byteBuffer.writeString(token)
-            return .result(.init(httpStatus: .ok, body: byteBuffer), continueProcessing: false)
-        })
-        
-        let roleName = "MySuperDuperAwesomeRoleName"
-        XCTAssertNoThrow(try testServer.processRaw { (request) -> AWSTestServer.Result<AWSTestServer.Response> in
-            XCTAssertEqual(request.uri, InstanceMetaDataClient.CredentialUri)
-            XCTAssertEqual(request.method, .GET)
-            XCTAssertEqual(request.headers[InstanceMetaDataClient.TokenHeaderName], token)
-            
-            var byteBuffer = ByteBufferAllocator().buffer(capacity: roleName.utf8.count)
-            byteBuffer.writeString(roleName)
-            return .result(.init(httpStatus: .ok, body: byteBuffer), continueProcessing: false)
-        })
-        
-        let accessKeyId = "abc123"
-        let secretAccessKey = "123abc"
-        let sessionToken = "xyz987"
-        let code = "Success"
-        let type = "AWS-HMAC"
-        let expiration = Date(timeIntervalSince1970: Date().timeIntervalSince1970.rounded() + 60 * 2)
-        let lastUpdated = Date(timeIntervalSince1970: Date().timeIntervalSince1970.rounded() - 60 * 2)
-        let dateFormatter = DateFormatter()
-        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
-        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss'Z'"
-        dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
-        
-        XCTAssertNoThrow(try testServer.processRaw { (request) -> AWSTestServer.Result<AWSTestServer.Response> in
-            XCTAssertEqual(request.uri, InstanceMetaDataClient.CredentialUri.appending(roleName))
-            XCTAssertEqual(request.method, .GET)
-            XCTAssertEqual(request.headers[InstanceMetaDataClient.TokenHeaderName], token)
-            
-            let json = """
-                {
-                    "AccessKeyId": "\(accessKeyId)",
-                    "SecretAccessKey": "\(secretAccessKey)",
-                    "Token": "\(sessionToken)",
-                    "Expiration": "\(dateFormatter.string(from: expiration))",
-                    "Code": "\(code)",
-                    "LastUpdated": "\(dateFormatter.string(from: lastUpdated))",
-                    "Type": "\(type)"
-                }
-                """
-
-            var byteBuffer = ByteBufferAllocator().buffer(capacity: json.utf8.count)
-            byteBuffer.writeString(json)
-            return .result(.init(httpStatus: .ok, body: byteBuffer), continueProcessing: false)
-        })
+        XCTAssertNoThrow(try testServer.ec2MetadataServer(version: .v2))
         
         var metaData: InstanceMetaDataClient.MetaData?
         XCTAssertNoThrow(metaData = try future.wait())
         
-        XCTAssertEqual(metaData?.accessKeyId, accessKeyId)
-        XCTAssertEqual(metaData?.secretAccessKey, secretAccessKey)
-        XCTAssertEqual(metaData?.token, sessionToken)
-        XCTAssertEqual(metaData?.expiration, expiration)
-        XCTAssertEqual(metaData?.code, code)
-        XCTAssertEqual(metaData?.lastUpdated, lastUpdated)
-        XCTAssertEqual(metaData?.type, type)
-        
-        XCTAssertEqual(metaData?.accessKeyId, accessKeyId)
-        XCTAssertEqual(metaData?.secretAccessKey, secretAccessKey)
-        XCTAssertEqual(metaData?.sessionToken, sessionToken)
+        XCTAssertEqual(metaData?.accessKeyId, AWSTestServer.EC2InstanceMetaData.default.accessKeyId)
+        XCTAssertEqual(metaData?.secretAccessKey, AWSTestServer.EC2InstanceMetaData.default.secretAccessKey)
+        XCTAssertEqual(metaData?.token, AWSTestServer.EC2InstanceMetaData.default.token)
+        XCTAssertEqual(metaData?.expiration.description, AWSTestServer.EC2InstanceMetaData.default.expiration.description)
+        XCTAssertEqual(metaData?.code, AWSTestServer.EC2InstanceMetaData.default.code)
+        XCTAssertEqual(metaData?.lastUpdated, AWSTestServer.EC2InstanceMetaData.default.lastUpdated)
+        XCTAssertEqual(metaData?.type, AWSTestServer.EC2InstanceMetaData.default.type)
     }
     
     func testEC2InstanceMetaDataClientUsingVersion1() {
@@ -203,81 +112,21 @@ class MetaDataCredentialProviderTests: XCTestCase {
         let testServer = AWSTestServer(serviceProtocol: .json)
         defer { XCTAssertNoThrow(try testServer.stop()) }
         
-        let path = "/" + UUID().uuidString
-        Environment.set(path, for: ECSMetaDataClient.RelativeURIEnvironmentName)
-        defer { Environment.unset(name: ECSMetaDataClient.RelativeURIEnvironmentName) }
-        
         let client = InstanceMetaDataClient(httpClient: httpClient, host: "\(testServer.host):\(testServer.serverPort)")
         let future = client.getMetaData(on: loop)
         
-        XCTAssertNoThrow(try testServer.processRaw { (request) -> AWSTestServer.Result<AWSTestServer.Response> in
-            // we try to use version 2, but this endpoint is not available, so we respond with 404
-            XCTAssertEqual(request.uri, InstanceMetaDataClient.TokenUri)
-            XCTAssertEqual(request.method, .PUT)
-            XCTAssertEqual(request.headers[InstanceMetaDataClient.TokenTimeToLiveHeader.name], InstanceMetaDataClient.TokenTimeToLiveHeader.value)
-            
-            return .result(.init(httpStatus: .notFound), continueProcessing: false)
-        })
-        
-        let roleName = "MySuperDuperAwesomeRoleName"
-        XCTAssertNoThrow(try testServer.processRaw { (request) -> AWSTestServer.Result<AWSTestServer.Response> in
-            XCTAssertEqual(request.uri, InstanceMetaDataClient.CredentialUri)
-            XCTAssertEqual(request.method, .GET)
-            XCTAssertNil(request.headers[InstanceMetaDataClient.TokenHeaderName])
-            
-            var byteBuffer = ByteBufferAllocator().buffer(capacity: roleName.utf8.count)
-            byteBuffer.writeString(roleName)
-            return .result(.init(httpStatus: .ok, body: byteBuffer), continueProcessing: false)
-        })
-        
-        let accessKeyId = "abc123"
-        let secretAccessKey = "123abc"
-        let sessionToken = "xyz987"
-        let code = "Success"
-        let type = "AWS-HMAC"
-        let expiration = Date(timeIntervalSince1970: Date().timeIntervalSince1970.rounded() + 60 * 2)
-        let lastUpdated = Date(timeIntervalSince1970: Date().timeIntervalSince1970.rounded() - 60 * 2)
-        let dateFormatter = DateFormatter()
-        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
-        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss'Z'"
-        dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
-        
-        XCTAssertNoThrow(try testServer.processRaw { (request) -> AWSTestServer.Result<AWSTestServer.Response> in
-            XCTAssertEqual(request.uri, InstanceMetaDataClient.CredentialUri.appending(roleName))
-            XCTAssertEqual(request.method, .GET)
-            XCTAssertNil(request.headers[InstanceMetaDataClient.TokenHeaderName])
-            
-            let json = """
-                {
-                    "AccessKeyId": "\(accessKeyId)",
-                    "SecretAccessKey": "\(secretAccessKey)",
-                    "Token": "\(sessionToken)",
-                    "Expiration": "\(dateFormatter.string(from: expiration))",
-                    "Code": "\(code)",
-                    "LastUpdated": "\(dateFormatter.string(from: lastUpdated))",
-                    "Type": "\(type)"
-                }
-                """
-
-            var byteBuffer = ByteBufferAllocator().buffer(capacity: json.utf8.count)
-            byteBuffer.writeString(json)
-            return .result(.init(httpStatus: .ok, body: byteBuffer), continueProcessing: false)
-        })
+        XCTAssertNoThrow(try testServer.ec2MetadataServer(version: .v1))
         
         var metaData: InstanceMetaDataClient.MetaData?
         XCTAssertNoThrow(metaData = try future.wait())
         
-        XCTAssertEqual(metaData?.accessKeyId, accessKeyId)
-        XCTAssertEqual(metaData?.secretAccessKey, secretAccessKey)
-        XCTAssertEqual(metaData?.token, sessionToken)
-        XCTAssertEqual(metaData?.expiration, expiration)
-        XCTAssertEqual(metaData?.code, code)
-        XCTAssertEqual(metaData?.lastUpdated, lastUpdated)
-        XCTAssertEqual(metaData?.type, type)
-        
-        XCTAssertEqual(metaData?.accessKeyId, accessKeyId)
-        XCTAssertEqual(metaData?.secretAccessKey, secretAccessKey)
-        XCTAssertEqual(metaData?.sessionToken, sessionToken)
+        XCTAssertEqual(metaData?.accessKeyId, AWSTestServer.EC2InstanceMetaData.default.accessKeyId)
+        XCTAssertEqual(metaData?.secretAccessKey, AWSTestServer.EC2InstanceMetaData.default.secretAccessKey)
+        XCTAssertEqual(metaData?.token, AWSTestServer.EC2InstanceMetaData.default.token)
+        XCTAssertEqual(metaData?.expiration.description, AWSTestServer.EC2InstanceMetaData.default.expiration.description)
+        XCTAssertEqual(metaData?.code, AWSTestServer.EC2InstanceMetaData.default.code)
+        XCTAssertEqual(metaData?.lastUpdated, AWSTestServer.EC2InstanceMetaData.default.lastUpdated)
+        XCTAssertEqual(metaData?.type, AWSTestServer.EC2InstanceMetaData.default.type)
     }
     
     func testEC2UInstanceMetaDataClientDefaultHost() {

--- a/Tests/AWSSDKSwiftCoreTests/Credential/RotatingCredentialProviderTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/Credential/RotatingCredentialProviderTests.swift
@@ -148,7 +148,8 @@ class RotatingCredentialProviderTests: XCTestCase {
             return eventLoop.makeSucceededFuture(cred)
         }
         let provider = RotatingCredentialProvider(eventLoop: loop, provider: client)
-        
+        XCTAssertNoThrow(_ = try provider.getCredential(on: loop).wait())
+        hitCount = 0
         let iterations = 100
         for _ in 0..<100 {
             XCTAssertNoThrow(_ = try provider.getCredential(on: loop).wait())

--- a/Tests/AWSSDKSwiftCoreTests/Credential/RuntimeSelectorCredentialProviderTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/Credential/RuntimeSelectorCredentialProviderTests.swift
@@ -111,7 +111,7 @@ class RuntimeSelectorCredentialProviderTests: XCTestCase {
         defer { Environment.unset(name: ECSMetaDataClient.RelativeURIEnvironmentName) }
 
         let customECS: CredentialProviderFactory = .custom { context in 
-            if let client = ECSMetaDataClient(httpClient: context.httpClient, host: "\(testServer.host):\(testServer.serverPort)") {
+            if let client = ECSMetaDataClient(httpClient: context.httpClient, host: testServer.address) {
                 return RotatingCredentialProvider(eventLoop: context.eventLoop, provider: client)
             }
             // fallback
@@ -155,7 +155,7 @@ class RuntimeSelectorCredentialProviderTests: XCTestCase {
         let testServer = AWSTestServer(serviceProtocol: .json)
         defer { XCTAssertNoThrow(try testServer.stop()) }
         let customEC2: CredentialProviderFactory = .custom { context in
-            let client = InstanceMetaDataClient(httpClient: context.httpClient, host: "\(testServer.host):\(testServer.serverPort)")
+            let client = InstanceMetaDataClient(httpClient: context.httpClient, host: testServer.address)
             return RotatingCredentialProvider(eventLoop: context.eventLoop, provider: client)
         }
         

--- a/Tests/AWSSDKSwiftCoreTests/Credential/RuntimeSelectorCredentialProviderTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/Credential/RuntimeSelectorCredentialProviderTests.swift
@@ -120,9 +120,6 @@ class RuntimeSelectorCredentialProviderTests: XCTestCase {
         let provider: CredentialProviderFactory = .selector(.environment, customECS, .empty)
         let client = createAWSClient(credentialProvider: provider)
         defer { XCTAssertNoThrow(try client.syncShutdown()) }
-
-        XCTAssertNoThrow(try testServer.ecsMetadataServer(path: path))
-
         let futureResult = client.credentialProvider.getCredential(on: client.eventLoopGroup.next()).flatMapThrowing { credential in
             XCTAssertEqual(credential.accessKeyId, AWSTestServer.ECSMetaData.default.accessKeyId)
             XCTAssertEqual(credential.secretAccessKey, AWSTestServer.ECSMetaData.default.secretAccessKey)
@@ -130,6 +127,9 @@ class RuntimeSelectorCredentialProviderTests: XCTestCase {
             let internalProvider = try XCTUnwrap((client.credentialProvider as? RuntimeSelectorCredentialProvider)?.internalProvider)
             XCTAssert(internalProvider is RotatingCredentialProvider)
         }
+
+        XCTAssertNoThrow(try testServer.ecsMetadataServer(path: path))
+
         XCTAssertNoThrow(try futureResult.wait())
     }
     
@@ -161,9 +161,6 @@ class RuntimeSelectorCredentialProviderTests: XCTestCase {
         
         let client = createAWSClient(credentialProvider: .selector(customEC2, .empty))
         defer { XCTAssertNoThrow(try client.syncShutdown()) }
-
-        XCTAssertNoThrow(try testServer.ec2MetadataServer(version: .v2))
-
         let futureResult = client.credentialProvider.getCredential(on: client.eventLoopGroup.next()).flatMapThrowing { credential in
             XCTAssertEqual(credential.accessKeyId, AWSTestServer.EC2InstanceMetaData.default.accessKeyId)
             XCTAssertEqual(credential.secretAccessKey, AWSTestServer.EC2InstanceMetaData.default.secretAccessKey)
@@ -171,6 +168,9 @@ class RuntimeSelectorCredentialProviderTests: XCTestCase {
             let internalProvider = try XCTUnwrap((client.credentialProvider as? RuntimeSelectorCredentialProvider)?.internalProvider)
             XCTAssert(internalProvider is RotatingCredentialProvider)
         }
+
+        XCTAssertNoThrow(try testServer.ec2MetadataServer(version: .v2))
+
         XCTAssertNoThrow(try futureResult.wait())
     }
     

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,7 +10,7 @@ services:
 
   test:
     <<: *common
-    command: /bin/bash -xcl "swift test --enable-test-discovery"
+    command: /bin/bash -xcl "swift test --enable-test-discovery -Xswiftc -g"
 
   test-amazon:
     build:
@@ -19,11 +19,11 @@ services:
     volumes:
       - ..:/working
     working_dir: /working
-    command: /bin/bash -xcl "swift test --enable-test-discovery"
+    command: /bin/bash -xcl "swift test --enable-test-discovery -Xswiftc -g"
 
   test-thread:
     <<: *common
-    command: /bin/bash -xcl "swift test --enable-test-discovery --sanitize=thread"
+    command: /bin/bash -xcl "swift test --enable-test-discovery --sanitize=thread -Xswiftc -g"
 
   test-address:
     <<: *common


### PR DESCRIPTION
Added fake ec2/ecs metadata servers in AWSTestUtils to test acquiring of EC2/ECS credentials