### PR TITLE
Added RetryPolicyFactory struct with dot notation

### DIFF
--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -74,7 +74,7 @@ public final class AWSClient {
     ///     - httpClientProvider: HTTPClient to use. Use `.createNew` if you want the client to manage its own HTTPClient.
     public init(
         credentialProvider credentialProviderFactory: CredentialProviderFactory = .default,
-        retryPolicy: RetryPolicy = JitterRetry(),
+        retryPolicy retryPolicyFactory: RetryPolicyFactory = .default,
         middlewares: [AWSServiceMiddleware] = [],
         httpClientProvider: HTTPClientProvider
     ) {
@@ -92,7 +92,7 @@ public final class AWSClient {
             eventLoop: httpClient.eventLoopGroup.next()))
 
         self.middlewares = middlewares
-        self.retryPolicy = retryPolicy
+        self.retryPolicy = retryPolicyFactory.retryPolicy
     }
 
     deinit {

--- a/Sources/AWSTestUtils/TestUtils.swift
+++ b/Sources/AWSTestUtils/TestUtils.swift
@@ -34,7 +34,7 @@ import Foundation
 
 public func createAWSClient(
     credentialProvider: CredentialProviderFactory = .default,
-    retryPolicy: RetryPolicy = NoRetry(),
+    retryPolicy: RetryPolicyFactory = .noRetry,
     middlewares: [AWSServiceMiddleware] = [],
     httpClientProvider: AWSClient.HTTPClientProvider = .createNew
 ) -> AWSClient {

--- a/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
@@ -429,7 +429,7 @@ class AWSClientTests: XCTestCase {
             let httpClient = AsyncHTTPClient.HTTPClient(eventLoopGroupProvider: .createNew)
             let awsServer = AWSTestServer(serviceProtocol: .json)
             let config = createServiceConfig(serviceProtocol: .json(version: "1.1"), endpoint: awsServer.address)
-            let client = createAWSClient(credentialProvider: .empty, retryPolicy: ExponentialRetry(base: .milliseconds(200)), httpClientProvider: .shared(httpClient))
+            let client = createAWSClient(credentialProvider: .empty, retryPolicy: .exponential(base: .milliseconds(200)), httpClientProvider: .shared(httpClient))
             defer {
                 XCTAssertNoThrow(try awsServer.stop())
                 XCTAssertNoThrow(try client.syncShutdown())
@@ -468,7 +468,7 @@ class AWSClientTests: XCTestCase {
             let httpClient = AsyncHTTPClient.HTTPClient(eventLoopGroupProvider: .createNew)
             let awsServer = AWSTestServer(serviceProtocol: .json)
             let config = createServiceConfig(serviceProtocol: .json(version: "1.1"), endpoint: awsServer.address)
-            let client = createAWSClient(credentialProvider: .empty, retryPolicy: JitterRetry(), httpClientProvider: .shared(httpClient))
+            let client = createAWSClient(credentialProvider: .empty, retryPolicy: .jitter(), httpClientProvider: .shared(httpClient))
             defer {
                 XCTAssertNoThrow(try awsServer.stop())
                 XCTAssertNoThrow(try client.syncShutdown())
@@ -505,7 +505,7 @@ class AWSClientTests: XCTestCase {
             let httpClient = AsyncHTTPClient.HTTPClient(eventLoopGroupProvider: .createNew)
             let awsServer = AWSTestServer(serviceProtocol: .json)
             let config = createServiceConfig(serviceProtocol: .json(version: "1.1"), endpoint: awsServer.address)
-            let client = createAWSClient(credentialProvider: .empty, retryPolicy: JitterRetry(), httpClientProvider: .shared(httpClient))
+            let client = createAWSClient(credentialProvider: .empty, retryPolicy: .jitter(), httpClientProvider: .shared(httpClient))
             defer {
                 XCTAssertNoThrow(try awsServer.stop())
                 XCTAssertNoThrow(try client.syncShutdown())

--- a/Tests/AWSSDKSwiftCoreTests/PaginateTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/PaginateTests.swift
@@ -34,7 +34,7 @@ class PaginateTests: XCTestCase {
         eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 3)
         httpClient = AsyncHTTPClient.HTTPClient(eventLoopGroupProvider: .shared(eventLoopGroup))
         config = createServiceConfig(serviceProtocol: .json(version: "1.1"), endpoint: awsServer.address)
-        client = createAWSClient(credentialProvider: .empty, retryPolicy: NoRetry(), httpClientProvider: .shared(httpClient))
+        client = createAWSClient(credentialProvider: .empty, retryPolicy: .noRetry, httpClientProvider: .shared(httpClient))
     }
 
     override func tearDown() {


### PR DESCRIPTION
Setup like the credential provider factory, for consistency
Instead of calling 
```
let client = AWSClient(retryPolicy: JitterRetry())
```
now the user calls
```
let client = AWSClient(retryPolicy: .jitter())
```
Dot notation eases finding retry policies
removes a load of public symbols