### PR TITLE
Add logging to AWSClient

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,6 +21,7 @@ let package = Package(
         .library(name: "AWSSDKSwiftCore", targets: ["AWSSDKSwiftCore"])
     ],
     dependencies: [
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.4.0"),
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0" ..< "3.0.0"),
         .package(url: "https://github.com/apple/swift-nio.git", .upToNextMajor(from:"2.16.1")),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", .upToNextMajor(from:"2.7.2")),
@@ -32,6 +33,7 @@ let package = Package(
             .byName(name: "AWSSignerV4"),
             .byName(name: "AWSXML"),
             .byName(name: "INIParser"),
+            .product(name: "Logging", package: "swift-log"),
             .product(name: "AsyncHTTPClient", package: "async-http-client"),
             .product(name: "Metrics", package: "swift-metrics"),
             .product(name: "NIO", package: "swift-nio"),

--- a/Sources/AWSSDKSwiftCore/Credential/CredentialProviderError.swift
+++ b/Sources/AWSSDKSwiftCore/Credential/CredentialProviderError.swift
@@ -20,3 +20,12 @@ public struct CredentialProviderError: Error, Equatable {
 
     public static var noProvider: CredentialProviderError { return .init(error: .noProvider) }
 }
+
+extension CredentialProviderError: CustomStringConvertible {
+    public var description: String {
+        switch error {
+        case .noProvider:
+            return "No credential provider found"
+        }
+    }
+}

--- a/Sources/AWSSDKSwiftCore/Credential/MetaDataCredentialProvider.swift
+++ b/Sources/AWSSDKSwiftCore/Credential/MetaDataCredentialProvider.swift
@@ -121,7 +121,7 @@ struct ECSMetaDataClient: MetaDataClient {
     
     private func request(url: String, timeout: TimeInterval, on eventLoop: EventLoop) -> EventLoopFuture<AWSHTTPResponse> {
         let request = AWSHTTPRequest(url: URL(string: url)!, method: .GET, headers: [:], body: .empty)
-        return httpClient.execute(request: request, timeout: TimeAmount.seconds(2), on: eventLoop)
+        return httpClient.execute(request: request, timeout: TimeAmount.seconds(2), on: eventLoop, logger: AWSClient.loggingDisabled)
     }
 }
 
@@ -247,7 +247,7 @@ struct InstanceMetaDataClient: MetaDataClient {
         on eventLoop: EventLoop) -> EventLoopFuture<AWSHTTPResponse>
     {
         let request = AWSHTTPRequest(url: url, method: method, headers: headers, body: .empty)
-        return httpClient.execute(request: request, timeout: timeout, on: eventLoop)
+        return httpClient.execute(request: request, timeout: timeout, on: eventLoop, logger: AWSClient.loggingDisabled)
     }
 }
 

--- a/Sources/AWSSDKSwiftCore/HTTP/AWSHTTPClient.swift
+++ b/Sources/AWSSDKSwiftCore/HTTP/AWSHTTPClient.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
+import Logging
 import NIO
 import NIOHTTP1
 
@@ -43,10 +44,10 @@ public protocol AWSHTTPClient {
     typealias ResponseStream = (ByteBuffer, EventLoop)->EventLoopFuture<Void>
 
     /// Execute HTTP request and return a future holding a HTTP Response
-    func execute(request: AWSHTTPRequest, timeout: TimeAmount, on eventLoop: EventLoop) -> EventLoopFuture<AWSHTTPResponse>
+    func execute(request: AWSHTTPRequest, timeout: TimeAmount, on eventLoop: EventLoop, logger: Logger) -> EventLoopFuture<AWSHTTPResponse>
 
     /// Execute an HTTP request with a streamed response
-    func execute(request: AWSHTTPRequest, timeout: TimeAmount, on eventLoop: EventLoop, stream: @escaping ResponseStream) -> EventLoopFuture<AWSHTTPResponse>
+    func execute(request: AWSHTTPRequest, timeout: TimeAmount, on eventLoop: EventLoop, logger: Logger, stream: @escaping ResponseStream) -> EventLoopFuture<AWSHTTPResponse>
 
     /// This should be called before an HTTP Client can be de-initialised
     func syncShutdown() throws
@@ -57,7 +58,7 @@ public protocol AWSHTTPClient {
 
 extension AWSHTTPClient {
     /// Execute an HTTP request with a streamed response
-    public func execute(request: AWSHTTPRequest, timeout: TimeAmount, on eventLoop: EventLoop, stream: @escaping ResponseStream) -> EventLoopFuture<AWSHTTPResponse> {
+    public func execute(request: AWSHTTPRequest, timeout: TimeAmount, on eventLoop: EventLoop, logger: Logger, stream: @escaping ResponseStream) -> EventLoopFuture<AWSHTTPResponse> {
         preconditionFailure("\(type(of: self)) does not support response streaming")
     }
 

--- a/Sources/AWSSDKSwiftCore/HTTP/AsyncHTTPClient.swift
+++ b/Sources/AWSSDKSwiftCore/HTTP/AsyncHTTPClient.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import AsyncHTTPClient
+import Logging
 import NIO
 import NIOHTTP1
 
@@ -25,7 +26,7 @@ extension AsyncHTTPClient.HTTPClient: AWSHTTPClient {
     ///   - timeout: If execution is idle for longer than timeout then throw error
     ///   - eventLoop: eventLoop to run request on
     /// - Returns: EventLoopFuture that will be fulfilled with request response
-    public func execute(request: AWSHTTPRequest, timeout: TimeAmount, on eventLoop: EventLoop) -> EventLoopFuture<AWSHTTPResponse> {
+    public func execute(request: AWSHTTPRequest, timeout: TimeAmount, on eventLoop: EventLoop, logger: Logger) -> EventLoopFuture<AWSHTTPResponse> {
         let requestBody: AsyncHTTPClient.HTTPClient.Body?
         var requestHeaders = request.headers
         
@@ -51,7 +52,7 @@ extension AsyncHTTPClient.HTTPClient: AWSHTTPClient {
 
 /// extend to include response streaming support
 extension AsyncHTTPClient.HTTPClient {
-    public func execute(request: AWSHTTPRequest, timeout: TimeAmount, on eventLoop: EventLoop, stream: @escaping ResponseStream) -> EventLoopFuture<AWSHTTPResponse> {
+    public func execute(request: AWSHTTPRequest, timeout: TimeAmount, on eventLoop: EventLoop, logger: Logger, stream: @escaping ResponseStream) -> EventLoopFuture<AWSHTTPResponse> {
         let requestBody: AsyncHTTPClient.HTTPClient.Body?
         if case .byteBuffer(let body) = request.body.payload {
             requestBody = .byteBuffer(body)

--- a/Sources/AWSSDKSwiftCore/HTTP/NIOTSHTTPClient.swift
+++ b/Sources/AWSSDKSwiftCore/HTTP/NIOTSHTTPClient.swift
@@ -20,6 +20,7 @@
 #if canImport(Network)
 
 import Foundation
+import Logging
 import Network
 import NIO
 import NIOConcurrencyHelpers
@@ -241,7 +242,7 @@ public final class NIOTSHTTPClient {
 @available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
 extension NIOTSHTTPClient: AWSHTTPClient {
 
-    public func execute(request: AWSHTTPRequest, timeout: TimeAmount, on eventLoop: EventLoop) -> EventLoopFuture<AWSHTTPResponse> {
+    public func execute(request: AWSHTTPRequest, timeout: TimeAmount, on eventLoop: EventLoop, logger: Logger) -> EventLoopFuture<AWSHTTPResponse> {
         var head = HTTPRequestHead(
           version: HTTPVersion(major: 1, minor: 1),
           method: request.method,

--- a/Sources/AWSSDKSwiftCore/Message/AWSResponse.swift
+++ b/Sources/AWSSDKSwiftCore/Message/AWSResponse.swift
@@ -14,6 +14,7 @@
 
 import class Foundation.JSONSerialization
 import class Foundation.JSONDecoder
+import Logging
 import NIO
 import NIOHTTP1
 import AWSXML
@@ -183,7 +184,7 @@ public struct AWSResponse {
     }
     
     /// extract error code and message from AWSResponse
-    func generateError(serviceConfig: AWSServiceConfig) -> Error? {
+    func generateError(serviceConfig: AWSServiceConfig, logger: Logger) -> Error? {
         var apiError: APIError? = nil
         switch serviceConfig.serviceProtocol {
         case .query:
@@ -226,6 +227,12 @@ public struct AWSResponse {
             if let index = code.firstIndex(of: "#") {
                 code = String(code[code.index(index, offsetBy: 1)...])
             }
+
+            logger.error("AWS error", metadata: [
+                "aws-error-code": .string(code),
+                "aws-error-message": .string(errorMessage.message)
+            ])
+
             for errorType in serviceConfig.possibleErrorTypes {
                 if let error = errorType.init(errorCode: code, message: errorMessage.message) {
                     return error

--- a/Sources/AWSTestUtils/TestUtils.swift
+++ b/Sources/AWSTestUtils/TestUtils.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
+import Logging
 @testable import AWSSDKSwiftCore
 
 @propertyWrapper public struct EnvironmentVariable<Value: LosslessStringConvertible> {
@@ -36,13 +37,15 @@ public func createAWSClient(
     credentialProvider: CredentialProviderFactory = .default,
     retryPolicy: RetryPolicyFactory = .noRetry,
     middlewares: [AWSServiceMiddleware] = [],
-    httpClientProvider: AWSClient.HTTPClientProvider = .createNew
+    httpClientProvider: AWSClient.HTTPClientProvider = .createNew,
+    logger: Logger = AWSClient.loggingDisabled
 ) -> AWSClient {
     return AWSClient(
         credentialProvider: credentialProvider,
         retryPolicy: retryPolicy,
         middlewares: middlewares,
-        httpClientProvider: httpClientProvider
+        httpClientProvider: httpClientProvider,
+        logger: logger
     )
 }
 

--- a/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
@@ -14,6 +14,7 @@
 
 import XCTest
 import AsyncHTTPClient
+import Logging
 import NIO
 import NIOConcurrencyHelpers
 import NIOFoundationCompat
@@ -23,6 +24,7 @@ import AWSXML
 @testable import AWSSDKSwiftCore
 
 class AWSClientTests: XCTestCase {
+    let logger = Logger(label: "AWSClientTests")
 
     func testGetCredential() {
         let client = createAWSClient(credentialProvider: .static(accessKeyId: "key", secretAccessKey: "secret"))
@@ -272,7 +274,7 @@ class AWSClientTests: XCTestCase {
                 return eventLoop.makeSucceededFuture(.byteBuffer(buffer))
             }
             let input = Input(payload: payload)
-            let response = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, input: input)
+            let response = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, input: input, logger: logger)
             try response.wait()
         } catch AWSClient.ClientError.tooMuchData {
         } catch {
@@ -474,7 +476,7 @@ class AWSClientTests: XCTestCase {
                 XCTAssertNoThrow(try client.syncShutdown())
                 XCTAssertNoThrow(try httpClient.syncShutdown())
             }
-            let response: EventLoopFuture<Output> = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config)
+            let response: EventLoopFuture<Output> = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, logger: logger)
 
             var count = 0
             try awsServer.processRaw { request in
@@ -511,7 +513,7 @@ class AWSClientTests: XCTestCase {
                 XCTAssertNoThrow(try client.syncShutdown())
                 XCTAssertNoThrow(try httpClient.syncShutdown())
             }
-            let response: EventLoopFuture<Output> = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config)
+            let response: EventLoopFuture<Output> = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, logger: logger)
 
             try awsServer.processRaw { request in
                 return .error(.accessDenied, continueProcessing: false)
@@ -658,7 +660,7 @@ class AWSClientTests: XCTestCase {
             XCTAssertNoThrow(try client.syncShutdown())
             XCTAssertNoThrow(try awsServer.stop())
         }
-        
+
         let response = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config)
 
         XCTAssertNoThrow(try awsServer.processRaw { request in

--- a/Tests/AWSSDKSwiftCoreTests/AWSResponseTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/AWSResponseTests.swift
@@ -215,7 +215,7 @@ class AWSResponseTests: XCTestCase {
         
         var awsResponse: AWSResponse? = nil
         XCTAssertNoThrow(awsResponse = try AWSResponse(from: response, serviceProtocol: .json(version: "1.1"), raw: false))
-        let error = awsResponse?.generateError(serviceConfig: service)
+        let error = awsResponse?.generateError(serviceConfig: service, logger: AWSClient.loggingDisabled)
         XCTAssertEqual(error as? ServiceErrorType, .resourceNotFoundException(message: "Donald Where's Your Troosers?"))
     }
 
@@ -229,7 +229,7 @@ class AWSResponseTests: XCTestCase {
         
         var awsResponse: AWSResponse? = nil
         XCTAssertNoThrow(awsResponse = try AWSResponse(from: response, serviceProtocol: .restxml, raw: false))
-        let error = awsResponse?.generateError(serviceConfig: service)
+        let error = awsResponse?.generateError(serviceConfig: service, logger: AWSClient.loggingDisabled)
         XCTAssertEqual(error as? ServiceErrorType, .noSuchKey(message: "It doesn't exist"))
     }
 
@@ -243,7 +243,7 @@ class AWSResponseTests: XCTestCase {
         
         var awsResponse: AWSResponse? = nil
         XCTAssertNoThrow(awsResponse = try AWSResponse(from: response, serviceProtocol: .query, raw: false))
-        let error = awsResponse?.generateError(serviceConfig: queryService)
+        let error = awsResponse?.generateError(serviceConfig: queryService, logger: AWSClient.loggingDisabled)
         XCTAssertEqual(error as? ServiceErrorType, .messageRejected(message: "Don't like it"))
     }
 
@@ -257,7 +257,7 @@ class AWSResponseTests: XCTestCase {
         
         var awsResponse: AWSResponse? = nil
         XCTAssertNoThrow(awsResponse = try AWSResponse(from: response, serviceProtocol: .ec2, raw: false))
-        let error = awsResponse?.generateError(serviceConfig: service) as? AWSResponseError
+        let error = awsResponse?.generateError(serviceConfig: service, logger: AWSClient.loggingDisabled) as? AWSResponseError
         XCTAssertEqual(error?.errorCode, "NoSuchKey")
         XCTAssertEqual(error?.message, "It doesn't exist")
     }

--- a/Tests/AWSSDKSwiftCoreTests/LoggingTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/LoggingTests.swift
@@ -1,0 +1,232 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the AWSSDKSwift open source project
+//
+// Copyright (c) 2017-2020 the AWSSDKSwift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of AWSSDKSwift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+import Logging
+import NIOConcurrencyHelpers
+import AWSTestUtils
+@testable import AWSSDKSwiftCore
+
+class LoggingTests: XCTestCase {
+
+    func testRequestIdIncrements() {
+        let logCollection = LoggingCollector.Logs()
+        let logger = Logger(label: "LoggingTests", factory: { _ in LoggingCollector(logCollection, logLevel: .trace)})
+        let server = AWSTestServer(serviceProtocol: .json)
+        defer { XCTAssertNoThrow(try server.stop()) }
+        let client = AWSClient(
+            credentialProvider: .static(accessKeyId: "foo", secretAccessKey: "bar"),
+            httpClientProvider: .createNew,
+            logger: logger)
+        defer { XCTAssertNoThrow(try client.syncShutdown()) }
+        let config = createServiceConfig(
+            serviceProtocol: .json(version: "1.1"),
+            endpoint: server.address
+        )
+
+        let response = client.execute(operation: "test1", path: "/", httpMethod: .GET, serviceConfig: config, logger: logger)
+        let response2 = client.execute(operation: "test2", path: "/", httpMethod: .GET, serviceConfig: config, logger: logger)
+
+        var count = 0
+        XCTAssertNoThrow(try server.processRaw { request in
+            let results: [AWSTestServer.Result<AWSTestServer.Response>] = [
+                .result(.ok, continueProcessing: true),
+                .result(.ok, continueProcessing: false)
+            ]
+            let result = results[count]
+            count += 1
+            return result
+        })
+
+        XCTAssertNoThrow(_ = try response.wait())
+        XCTAssertNoThrow(_ = try response2.wait())
+        let requestId1 = logCollection.filter(metadata: "aws-operation", with: "test1").first?.metadata["aws-request-id"]
+        let requestId2 = logCollection.filter(metadata: "aws-operation", with: "test2").first?.metadata["aws-request-id"]
+        XCTAssertNotNil(requestId1)
+        XCTAssertNotNil(requestId2)
+        XCTAssertNotEqual(requestId1, requestId2)
+    }
+
+    func testAWSRequestResponse() throws {
+        let logCollection = LoggingCollector.Logs()
+        let logger = Logger(label: "LoggingTests", factory: { _ in LoggingCollector(logCollection)})
+        let server = AWSTestServer(serviceProtocol: .json)
+        defer { XCTAssertNoThrow(try server.stop()) }
+        let client = AWSClient(
+            credentialProvider: .static(accessKeyId: "foo", secretAccessKey: "bar"),
+            httpClientProvider: .createNew,
+            logger: logger)
+        defer { XCTAssertNoThrow(try client.syncShutdown()) }
+        let config = createServiceConfig(
+            service: "test-service",
+            serviceProtocol: .json(version: "1.1"),
+            endpoint: server.address
+        )
+
+        let response = client.execute(operation: "TestOperation", path: "/", httpMethod: .GET, serviceConfig: config, logger: logger)
+
+        XCTAssertNoThrow(try server.processRaw { request in
+            return .result(.ok, continueProcessing: false)
+        })
+
+        XCTAssertNoThrow(_ = try response.wait())
+        let requestEntry = try XCTUnwrap(logCollection.filter(message: "AWS Request").first)
+        XCTAssertEqual(requestEntry.level, .info)
+        XCTAssertEqual(requestEntry.metadata["aws-operation"], "TestOperation")
+        XCTAssertEqual(requestEntry.metadata["aws-service"], "test-service")
+        let responseEntry = try XCTUnwrap(logCollection.filter(message: "AWS Response").first)
+        XCTAssertEqual(responseEntry.level, .info)
+        XCTAssertEqual(responseEntry.metadata["aws-operation"], "TestOperation")
+        XCTAssertEqual(responseEntry.metadata["aws-service"], "test-service")
+    }
+
+    func testAWSError() {
+        let logCollection = LoggingCollector.Logs()
+        let logger = Logger(label: "LoggingTests", factory: { _ in LoggingCollector(logCollection)})
+        let server = AWSTestServer(serviceProtocol: .json)
+        defer { XCTAssertNoThrow(try server.stop()) }
+        let client = AWSClient(
+            credentialProvider: .static(accessKeyId: "foo", secretAccessKey: "bar"),
+            httpClientProvider: .createNew,
+            logger: logger)
+        defer { XCTAssertNoThrow(try client.syncShutdown()) }
+        let config = createServiceConfig(
+            serviceProtocol: .json(version: "1.1"),
+            endpoint: server.address
+        )
+
+        let response = client.execute(operation: "test", path: "/", httpMethod: .GET, serviceConfig: config, logger: logger)
+
+        XCTAssertNoThrow(try server.processRaw { request in
+            return .error(.accessDenied, continueProcessing: false)
+        })
+
+        XCTAssertThrowsError(_ = try response.wait())
+        XCTAssertEqual(logCollection.filter(metadata: "aws-error-code", with: "AccessDenied").first?.message, "AWS error")
+        XCTAssertEqual(logCollection.filter(metadata: "aws-error-code", with: "AccessDenied").first?.level, .error)
+    }
+
+    func testRetryRequest() {
+        let logCollection = LoggingCollector.Logs()
+        let logger = Logger(label: "LoggingTests", factory: { _ in LoggingCollector(logCollection, logLevel: .trace)})
+        let server = AWSTestServer(serviceProtocol: .json)
+        defer { XCTAssertNoThrow(try server.stop()) }
+        let client = AWSClient(
+            credentialProvider: .static(accessKeyId: "foo", secretAccessKey: "bar"),
+            httpClientProvider: .createNew,
+            logger: logger)
+        defer { XCTAssertNoThrow(try client.syncShutdown()) }
+        let config = createServiceConfig(
+            serviceProtocol: .json(version: "1.1"),
+            endpoint: server.address
+        )
+
+        let response = client.execute(operation: "test1", path: "/", httpMethod: .GET, serviceConfig: config, logger: logger)
+
+        var count = 0
+        XCTAssertNoThrow(try server.processRaw { request in
+            let results: [AWSTestServer.Result<AWSTestServer.Response>] = [
+                .error(.internal, continueProcessing: true),
+                .result(.ok, continueProcessing: false)
+            ]
+            let result = results[count]
+            count += 1
+            return result
+        })
+
+        XCTAssertNoThrow(_ = try response.wait())
+        XCTAssertEqual(logCollection.filter(metadata: "aws-retry-time").first?.message, "Retrying request")
+        XCTAssertEqual(logCollection.filter(metadata: "aws-retry-time").first?.level, .info)
+    }
+    
+    func testNoCredentialProvider() {
+        let logCollection = LoggingCollector.Logs()
+        let logger = Logger(label: "LoggingTests", factory: { _ in LoggingCollector(logCollection, logLevel: .trace)})
+        let client = createAWSClient(credentialProvider: .selector(.custom {_ in return NullCredentialProvider()} ))
+        defer { XCTAssertNoThrow(try client.syncShutdown()) }
+        let serviceConfig = createServiceConfig()
+        XCTAssertThrowsError(try client.execute(
+            operation: "Test",
+            path: "/",
+            httpMethod: .GET,
+            serviceConfig: serviceConfig,
+            logger: logger
+        ).wait())
+        XCTAssertNotNil(logCollection.filter(metadata: "aws-error-message", with: "No credential provider found").first)
+
+    }
+}
+
+struct LoggingCollector: LogHandler {
+    var metadata: Logger.Metadata = [:]
+    var logLevel: Logger.Level
+    var logs: Logs
+    var internalHandler: LogHandler
+
+    class Logs {
+        struct Entry {
+            var level: Logger.Level
+            var message: String
+            var metadata: [String: String]
+        }
+
+        private var lock = Lock()
+        private var logs: [Entry] = []
+
+        var allEntries: [Entry] { return self.lock.withLock { logs } }
+
+        func append(level: Logger.Level, message: Logger.Message, metadata: Logger.Metadata?) {
+            self.lock.withLock {
+                self.logs.append(Entry(level: level,
+                                       message: message.description,
+                                       metadata: metadata?.mapValues { $0.description } ?? [:]))
+            }
+        }
+
+        func filter(message: String) -> [Entry] {
+            return allEntries.filter { $0.message != message }
+        }
+        
+        func filter(metadata: String) -> [Entry] {
+            return allEntries.filter { $0.metadata[metadata] != nil }
+        }
+
+        func filter(metadata: String, with value: String) -> [Entry] {
+            return allEntries.filter { $0.metadata[metadata] == value }
+        }
+    }
+
+    init(_ logCollection: LoggingCollector.Logs, logLevel: Logger.Level = .info) {
+        self.logLevel = logLevel
+        self.logs = logCollection
+        self.internalHandler = StreamLogHandler.standardOutput(label: "_internal_" )
+        self.internalHandler.logLevel = logLevel
+    }
+
+    func log(level: Logger.Level, message: Logger.Message, metadata: Logger.Metadata?, source: String, file: String, function: String, line: UInt) {
+        let metadata = self.metadata.merging(metadata ?? [:]) { $1 }
+        internalHandler.log(level: level, message: message, metadata: metadata, source: source, file:file, function: function, line: line)
+        self.logs.append(level: level, message: message, metadata: metadata)
+    }
+
+    subscript(metadataKey key: String) -> Logger.Metadata.Value? {
+        get {
+            return self.metadata[key]
+        }
+        set {
+            self.metadata[key] = newValue
+        }
+    }
+}
+

--- a/Tests/AWSSDKSwiftCoreTests/PerformanceTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/PerformanceTests.swift
@@ -230,7 +230,7 @@ class PerformanceTests: XCTestCase {
             configuration: config
         ).applyMiddlewares(config.middlewares + client.middlewares)
         
-        let signer = try! client.createSigner(serviceConfig: config).wait()
+        let signer = try! client.createSigner(serviceConfig: config, logger: AWSClient.loggingDisabled).wait()
         measure {
             for _ in 0..<1000 {
                 _ = awsRequest.createHTTPRequest(signer: signer)


### PR DESCRIPTION
Using swift-log
Logs: requests, responses, errors, retries
passes Logger to AWSHTTPClient to be passed to AsyncHTTPClient when 1.2.0 released.

Will look to merge in credential provider logging support later on, wanted to simplify the initial PR.