### PR TITLE
Add callback to AWSPayload.fileHandle

### DIFF
--- a/Sources/AWSSDKSwiftCore/HTTP/StreamReader.swift
+++ b/Sources/AWSSDKSwiftCore/HTTP/StreamReader.swift
@@ -29,7 +29,7 @@ protocol StreamReader {
     /// total size of data to be streamed plus any chunk headers
     var contentSize: Int? { get }
     /// function providing data to be streamed
-    var read: (EventLoop)->EventLoopFuture<StreamReaderResult> { get }
+    var read: (EventLoop) -> EventLoopFuture<StreamReaderResult> { get }
     /// bytebuffer allocator
     var byteBufferAllocator: ByteBufferAllocator { get }
     
@@ -76,7 +76,7 @@ struct ChunkedStreamReader: StreamReader {
     /// size of data to be streamed
     let size: Int?
     /// function providing data to be streamed
-    let read: (EventLoop)->EventLoopFuture<StreamReaderResult>
+    let read: (EventLoop) -> EventLoopFuture<StreamReaderResult>
     /// bytebuffer allocator
     var byteBufferAllocator: ByteBufferAllocator
 }

--- a/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
@@ -74,7 +74,7 @@ class AWSClientTests: XCTestCase {
         }
         XCTAssertNoThrow(try promise.futureResult.wait())
     }
-    
+
     func testHeadersAreWritten() {
         let awsServer = AWSTestServer(serviceProtocol: .json)
         let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
@@ -335,7 +335,7 @@ class AWSClientTests: XCTestCase {
                 XCTAssertNoThrow(try threadPool.syncShutdownGracefully())
             }
 
-            let input = Input(payload: .fileHandle(fileHandle, size: bufferSize, fileIO: fileIO))
+            let input = Input(payload: .fileHandle(fileHandle, size: bufferSize, fileIO: fileIO) { size in print(size) })
             let response = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, input: input, logger: TestEnvironment.logger)
 
             try awsServer.processRaw { request in


### PR DESCRIPTION
Returns with how much data has been uploaded so far
User can throw an error from callback to cancel upload