### PR TITLE
AWSServiceContext

### DIFF
--- a/Sources/AWSSDKSwiftCore/AWSClient+Paginate.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient+Paginate.swift
@@ -34,17 +34,16 @@ extension AWSClient {
     ///   - onPage: closure called with each block of entries
     public func paginate<Input: AWSPaginateToken, Output: AWSShape>(
         input: Input,
-        command: @escaping (Input, EventLoop?, Logger) -> EventLoopFuture<Output>,
+        command: @escaping (Input, EventLoop?) -> EventLoopFuture<Output>,
         tokenKey: KeyPath<Output, Input.Token?>,
         on eventLoop: EventLoop? = nil,
-        logger: Logger = AWSClient.loggingDisabled,
         onPage: @escaping (Output, EventLoop) -> EventLoopFuture<Bool>
     ) -> EventLoopFuture<Void> {
         let eventLoop = eventLoop ?? eventLoopGroup.next()
         let promise = eventLoop.makePromise(of: Void.self)
 
         func paginatePart(input: Input) {
-            let responseFuture = command(input, eventLoop, logger)
+            let responseFuture = command(input, eventLoop)
                 .flatMap { response in
                     return onPage(response, eventLoop)
                         .map { (rt) -> Void in

--- a/Sources/AWSSDKSwiftCore/AWSService.swift
+++ b/Sources/AWSSDKSwiftCore/AWSService.swift
@@ -15,7 +15,7 @@
 public protocol AWSService {
     var client: AWSClient { get }
     var context: AWSServiceContext { get }
-    func transform(_ :(AWSServiceContext) -> AWSServiceContext) -> Self
+    func transform(_: (AWSServiceContext) -> AWSServiceContext) -> Self
 }
 
 public extension AWSService {

--- a/Sources/AWSSDKSwiftCore/AWSService.swift
+++ b/Sources/AWSSDKSwiftCore/AWSService.swift
@@ -12,20 +12,15 @@
 //
 //===----------------------------------------------------------------------===//
 
+/// Protocol for AWS Services
 public protocol AWSService {
+    /// client used to communicate with AWS
     var client: AWSClient { get }
+    /// service details plus contextual info
     var context: AWSServiceContext { get }
-    func transform(_: (AWSServiceContext) -> AWSServiceContext) -> Self
 }
 
 public extension AWSService {
-    /// return new AWSServiceConfig with new timeout value
-    func with(timeout: TimeAmount) -> Self {
-        return transform { $0.with(timeout: timeout) }
-    }
-
-    /// return new AWSServiceConfig logging to specified Logger
-    func logging(to logger: Logger) -> Self {
-        return transform { $0.logging(to: logger) }
-    }
+    /// Region where service is running
+    var region: Region { context.region }
 }

--- a/Sources/AWSSDKSwiftCore/AWSService.swift
+++ b/Sources/AWSSDKSwiftCore/AWSService.swift
@@ -1,0 +1,31 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the AWSSDKSwift open source project
+//
+// Copyright (c) 2020 the AWSSDKSwift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of AWSSDKSwift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+public protocol AWSService {
+    var client: AWSClient { get }
+    var context: AWSServiceContext { get }
+    func transform(_ :(AWSServiceContext) -> AWSServiceContext) -> Self
+}
+
+public extension AWSService {
+    /// return new AWSServiceConfig with new timeout value
+    func with(timeout: TimeAmount) -> Self {
+        return transform { $0.with(timeout: timeout) }
+    }
+
+    /// return new AWSServiceConfig logging to specified Logger
+    func logging(to logger: Logger) -> Self {
+        return transform { $0.logging(to: logger) }
+    }
+}

--- a/Sources/AWSSDKSwiftCore/AWSServiceConfig.swift
+++ b/Sources/AWSSDKSwiftCore/AWSServiceConfig.swift
@@ -186,13 +186,13 @@ public struct AWSServiceContext {
 
 extension AWSServiceContext {
     /// return new AWSServiceConfig with new timeout value
-    func with(timeout: TimeAmount) -> AWSServiceContext {
+    public func with(timeout: TimeAmount) -> AWSServiceContext {
         var config = self
         config.timeout = timeout
         return config
     }
 
-    func logging(to logger: Logger) -> AWSServiceContext {
+    public func logging(to logger: Logger) -> AWSServiceContext {
         var config = self
         config.logger = logger
         config.logger[metadataKey: "aws-service"] = .string(self.service)

--- a/Sources/AWSSDKSwiftCore/AWSServiceConfig.swift
+++ b/Sources/AWSSDKSwiftCore/AWSServiceConfig.swift
@@ -107,25 +107,25 @@ public struct AWSServiceContext {
     }
 
     private let serviceConfig: AWSServiceConfig
-    
+
     /// Region where service is running
-    var region: Region { return serviceConfig.region }
+    var region: Region { return self.serviceConfig.region }
     /// The destination service of the request. Added as a header value, along with the operation name
-    var amzTarget: String? { return serviceConfig.amzTarget }
+    var amzTarget: String? { return self.serviceConfig.amzTarget }
     /// Name of service
-    var service: String { return serviceConfig.service }
+    var service: String { return self.serviceConfig.service }
     /// Name used to sign requests
-    var signingName: String { return serviceConfig.signingName }
+    var signingName: String { return self.serviceConfig.signingName }
     /// Protocol used by service json/xml/query
-    var serviceProtocol: ServiceProtocol { return serviceConfig.serviceProtocol }
+    var serviceProtocol: ServiceProtocol { return self.serviceConfig.serviceProtocol }
     /// Version of the Service API, added as a header in query protocol based services
-    var apiVersion: String { return serviceConfig.apiVersion }
+    var apiVersion: String { return self.serviceConfig.apiVersion }
     /// The url to use in requests
-    var endpoint: String { return serviceConfig.endpoint }
+    var endpoint: String { return self.serviceConfig.endpoint }
     /// Error type returned by the service
-    var errorType: AWSErrorType.Type? { return serviceConfig.errorType }
+    var errorType: AWSErrorType.Type? { return self.serviceConfig.errorType }
     /// Middleware code specific to the service used to edit requests before they sent and responses before they are decoded
-    var middlewares: [AWSServiceMiddleware] { return serviceConfig.middlewares }
+    var middlewares: [AWSServiceMiddleware] { return self.serviceConfig.middlewares }
 
     /// logger used by service
     public var logger: Logger
@@ -191,11 +191,11 @@ extension AWSServiceContext {
         config.timeout = timeout
         return config
     }
-    
+
     func logging(to logger: Logger) -> AWSServiceContext {
         var config = self
         config.logger = logger
-        config.logger[metadataKey: "aws-service"] = .string(service)
+        config.logger[metadataKey: "aws-service"] = .string(self.service)
         return config
     }
 }

--- a/Sources/AWSSDKSwiftCore/AWSServiceContext.swift
+++ b/Sources/AWSSDKSwiftCore/AWSServiceContext.swift
@@ -18,7 +18,7 @@ import NIO
 /// Configuration class defining an AWS service
 public struct AWSServiceContext {
     /// Sections of service config that are not editable
-    private final class AWSServiceConfig {
+    private final class Configuration {
         /// Region where service is running
         public let region: Region
         /// The destination service of the request. Added as a header value, along with the operation name
@@ -106,7 +106,7 @@ public struct AWSServiceContext {
         }
     }
 
-    private let serviceConfig: AWSServiceConfig
+    private let serviceConfig: Configuration
 
     /// Region where service is running
     var region: Region { return self.serviceConfig.region }
@@ -164,7 +164,7 @@ public struct AWSServiceContext {
         timeout: TimeAmount? = nil,
         logger: Logger = AWSClient.loggingDisabled
     ) {
-        self.serviceConfig = AWSServiceConfig(
+        self.serviceConfig = Configuration(
             region: region,
             partition: partition,
             amzTarget: amzTarget,
@@ -186,7 +186,7 @@ public struct AWSServiceContext {
 
 extension AWSServiceContext {
     /// return new AWSServiceConfig with new timeout value
-    public func with(timeout: TimeAmount) -> AWSServiceContext {
+    public func timingOut(after timeout: TimeAmount) -> AWSServiceContext {
         var config = self
         config.timeout = timeout
         return config

--- a/Sources/AWSSDKSwiftCore/Message/AWSRequest.swift
+++ b/Sources/AWSSDKSwiftCore/Message/AWSRequest.swift
@@ -92,7 +92,7 @@ public struct AWSRequest {
 }
 
 extension AWSRequest {
-    internal init(operation operationName: String, path: String, httpMethod: HTTPMethod, configuration: AWSServiceConfig) throws {
+    internal init(operation operationName: String, path: String, httpMethod: HTTPMethod, configuration: AWSServiceContext) throws {
         var headers = HTTPHeaders()
 
         guard let url = URL(string: "\(configuration.endpoint)\(path)"), let _ = url.host else {
@@ -120,7 +120,7 @@ extension AWSRequest {
         path: String,
         httpMethod: HTTPMethod,
         input: Input,
-        configuration: AWSServiceConfig
+        configuration: AWSServiceContext
     ) throws {
         var headers = HTTPHeaders()
         var path = path

--- a/Sources/AWSSDKSwiftCore/Message/AWSResponse.swift
+++ b/Sources/AWSSDKSwiftCore/Message/AWSResponse.swift
@@ -184,9 +184,9 @@ public struct AWSResponse {
     }
 
     /// extract error code and message from AWSResponse
-    func generateError(serviceConfig: AWSServiceConfig, logger: Logger) -> Error? {
+    func generateError(serviceContext: AWSServiceContext) -> Error? {
         var apiError: APIError?
-        switch serviceConfig.serviceProtocol {
+        switch serviceContext.serviceProtocol {
         case .query:
             guard case .xml(var element) = self.body else { break }
             if let errors = element.elements(forName: "Errors").first {
@@ -228,12 +228,12 @@ public struct AWSResponse {
                 code = String(code[code.index(index, offsetBy: 1)...])
             }
 
-            logger.error("AWS Error", metadata: [
+            serviceContext.logger.error("AWS Error", metadata: [
                 "aws-error-code": .string(code),
                 "aws-error-message": .string(errorMessage.message),
             ])
 
-            for errorType in serviceConfig.possibleErrorTypes {
+            if let errorType = serviceContext.errorType {
                 if let error = errorType.init(errorCode: code, message: errorMessage.message) {
                     return error
                 }

--- a/Sources/AWSTestUtils/TestUtils.swift
+++ b/Sources/AWSTestUtils/TestUtils.swift
@@ -47,7 +47,7 @@ public func createAWSClient(
     )
 }
 
-public func createServiceConfig(
+public func createServiceContext(
     region: Region? = nil,
     partition: AWSPartition = .aws,
     amzTarget: String? = nil,
@@ -62,8 +62,8 @@ public func createServiceConfig(
     middlewares: [AWSServiceMiddleware] = [],
     timeout: TimeAmount? = nil,
     logger: Logger = TestEnvironment.logger
-) -> AWSServiceConfig {
-    AWSServiceConfig(
+) -> AWSServiceContext {
+    AWSServiceContext(
         region: region,
         partition: partition,
         amzTarget: amzTarget,

--- a/Sources/AWSTestUtils/TestUtils.swift
+++ b/Sources/AWSTestUtils/TestUtils.swift
@@ -58,9 +58,10 @@ public func createServiceConfig(
     endpoint: String? = nil,
     serviceEndpoints: [String: String] = [:],
     partitionEndpoints: [AWSPartition: (endpoint: String, region: Region)] = [:],
-    possibleErrorTypes: [AWSErrorType.Type] = [],
+    errorType: AWSErrorType.Type? = nil,
     middlewares: [AWSServiceMiddleware] = [],
-    timeout: TimeAmount? = nil
+    timeout: TimeAmount? = nil,
+    logger: Logger = TestEnvironment.logger
 ) -> AWSServiceConfig {
     AWSServiceConfig(
         region: region,
@@ -73,9 +74,10 @@ public func createServiceConfig(
         endpoint: endpoint,
         serviceEndpoints: serviceEndpoints,
         partitionEndpoints: partitionEndpoints,
-        possibleErrorTypes: possibleErrorTypes,
+        errorType: errorType,
         middlewares: middlewares,
-        timeout: timeout
+        timeout: timeout,
+        logger: logger
     )
 }
 

--- a/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
@@ -95,7 +95,7 @@ class AWSClientTests: XCTestCase {
         defer {
             XCTAssertNoThrow(try client.syncShutdown())
         }
-        let response: EventLoopFuture<AWSTestServer.HTTPBinResponse> = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, logger: TestEnvironment.logger)
+        let response: EventLoopFuture<AWSTestServer.HTTPBinResponse> = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config)
 
         XCTAssertNoThrow(try awsServer.httpBin())
         var httpBinResponse: AWSTestServer.HTTPBinResponse?
@@ -119,7 +119,7 @@ class AWSClientTests: XCTestCase {
                 XCTAssertNoThrow(try client.syncShutdown())
                 XCTAssertNoThrow(try awsServer.stop())
             }
-            let response = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, logger: TestEnvironment.logger)
+            let response = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config)
 
             try awsServer.processRaw { _ in
                 let response = AWSTestServer.Response(httpStatus: .ok, headers: [:], body: nil)
@@ -151,7 +151,7 @@ class AWSClientTests: XCTestCase {
                 XCTAssertNoThrow(try awsServer.stop())
             }
             let input = Input(e: .second, i: [1, 2, 4, 8])
-            let response = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, input: input, logger: TestEnvironment.logger)
+            let response = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, input: input)
 
             try awsServer.processRaw { request in
                 let receivedInput = try JSONDecoder().decode(Input.self, from: request.body)
@@ -180,7 +180,7 @@ class AWSClientTests: XCTestCase {
                 XCTAssertNoThrow(try client.syncShutdown())
                 XCTAssertNoThrow(try awsServer.stop())
             }
-            let response: EventLoopFuture<Output> = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, logger: TestEnvironment.logger)
+            let response: EventLoopFuture<Output> = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config)
 
             try awsServer.processRaw { _ in
                 let output = Output(s: "TestOutputString", i: 547)
@@ -217,7 +217,7 @@ class AWSClientTests: XCTestCase {
             return eventLoop.makeSucceededFuture(.byteBuffer(buffer))
         }
         let input = Input(payload: payload)
-        let response = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, input: input, logger: TestEnvironment.logger)
+        let response = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, input: input)
 
         try server.processRaw { request in
             let bytes = request.body.getBytes(at: 0, length: request.body.readableBytes)
@@ -290,7 +290,7 @@ class AWSClientTests: XCTestCase {
                 return eventLoop.makeSucceededFuture(.byteBuffer(buffer))
             }
             let input = Input(payload: payload)
-            let response = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, input: input, logger: TestEnvironment.logger)
+            let response = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, input: input)
             try response.wait()
         } catch let error as HTTPClientError where error == .bodyLengthMismatch {
         } catch {
@@ -335,7 +335,7 @@ class AWSClientTests: XCTestCase {
             }
 
             let input = Input(payload: .fileHandle(fileHandle, size: bufferSize, fileIO: fileIO) { size in print(size) })
-            let response = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, input: input, logger: TestEnvironment.logger)
+            let response = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, input: input)
 
             try awsServer.processRaw { request in
                 XCTAssertNil(request.headers["transfer-encoding"])
@@ -387,7 +387,7 @@ class AWSClientTests: XCTestCase {
                 }
             }
             let input = Input(payload: payload)
-            let response = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, input: input, logger: TestEnvironment.logger)
+            let response = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, input: input)
 
             try awsServer.processRaw { request in
                 let bytes = request.body.getBytes(at: 0, length: request.body.readableBytes)
@@ -416,7 +416,7 @@ class AWSClientTests: XCTestCase {
                 XCTAssertNoThrow(try client.syncShutdown())
                 XCTAssertNoThrow(try httpClient.syncShutdown())
             }
-            let response = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, logger: TestEnvironment.logger)
+            let response = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config)
 
             try awsServer.processRaw { _ in
                 let response = AWSTestServer.Response(httpStatus: .temporaryRedirect, headers: ["Location": awsServer.address], body: nil)
@@ -452,7 +452,7 @@ class AWSClientTests: XCTestCase {
                 XCTAssertNoThrow(try client.syncShutdown())
                 XCTAssertNoThrow(try httpClient.syncShutdown())
             }
-            let response = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, logger: TestEnvironment.logger)
+            let response = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config)
 
             var count = 0
             try awsServer.processRaw { _ in
@@ -495,8 +495,7 @@ class AWSClientTests: XCTestCase {
                 operation: "test",
                 path: "/",
                 httpMethod: .POST,
-                serviceConfig: config,
-                logger: TestEnvironment.logger
+                serviceConfig: config
             )
 
             var count = 0
@@ -538,8 +537,7 @@ class AWSClientTests: XCTestCase {
                 operation: "test",
                 path: "/",
                 httpMethod: .POST,
-                serviceConfig: config,
-                logger: TestEnvironment.logger
+                serviceConfig: config
             )
 
             try awsServer.processRaw { _ in
@@ -575,8 +573,7 @@ class AWSClientTests: XCTestCase {
                 path: "/",
                 httpMethod: .POST,
                 serviceConfig: config,
-                on: eventLoop,
-                logger: TestEnvironment.logger
+                on: eventLoop
             )
 
             try awsServer.processRaw { _ in
@@ -616,8 +613,7 @@ class AWSClientTests: XCTestCase {
                 path: "/",
                 httpMethod: .GET,
                 serviceConfig: config,
-                input: Input(),
-                logger: TestEnvironment.logger
+                input: Input()
             ) { (payload: ByteBuffer, eventLoop: EventLoop) in
                 let payloadSize = payload.readableBytes
                 let slice = Data(data[count..<(count + payloadSize)])
@@ -669,8 +665,7 @@ class AWSClientTests: XCTestCase {
             path: "/",
             httpMethod: .GET,
             serviceConfig: config,
-            input: Input(),
-            logger: TestEnvironment.logger
+            input: Input()
         ) { (_: ByteBuffer, eventLoop: EventLoop) in
             lock.withLock { count += 1 }
             return eventLoop.scheduleTask(in: .milliseconds(200)) {
@@ -706,7 +701,7 @@ class AWSClientTests: XCTestCase {
             XCTAssertNoThrow(try awsServer.stop())
         }
 
-        let response = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, logger: TestEnvironment.logger)
+        let response = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config)
 
         XCTAssertNoThrow(try awsServer.processRaw { request in
             XCTAssertEqual(request.uri, "/test")

--- a/Tests/AWSSDKSwiftCoreTests/AWSResponseTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/AWSResponseTests.swift
@@ -210,11 +210,11 @@ class AWSResponseTests: XCTestCase {
             headers: HTTPHeaders(),
             bodyData: "{\"__type\":\"ResourceNotFoundException\", \"message\": \"Donald Where's Your Troosers?\"}".data(using: .utf8)!
         )
-        let service = createServiceConfig(serviceProtocol: .json(version: "1.1"), possibleErrorTypes: [ServiceErrorType.self])
+        let service = createServiceConfig(serviceProtocol: .json(version: "1.1"), errorType: ServiceErrorType.self)
 
         var awsResponse: AWSResponse?
         XCTAssertNoThrow(awsResponse = try AWSResponse(from: response, serviceProtocol: .json(version: "1.1"), raw: false))
-        let error = awsResponse?.generateError(serviceConfig: service, logger: TestEnvironment.logger)
+        let error = awsResponse?.generateError(serviceConfig: service)
         XCTAssertEqual(error as? ServiceErrorType, .resourceNotFoundException(message: "Donald Where's Your Troosers?"))
     }
 
@@ -224,11 +224,11 @@ class AWSResponseTests: XCTestCase {
             headers: HTTPHeaders(),
             bodyData: "<Error><Code>NoSuchKey</Code><Message>It doesn't exist</Message></Error>".data(using: .utf8)!
         )
-        let service = createServiceConfig(serviceProtocol: .restxml, possibleErrorTypes: [ServiceErrorType.self])
+        let service = createServiceConfig(serviceProtocol: .restxml, errorType: ServiceErrorType.self, logger: TestEnvironment.logger)
 
         var awsResponse: AWSResponse?
         XCTAssertNoThrow(awsResponse = try AWSResponse(from: response, serviceProtocol: .restxml, raw: false))
-        let error = awsResponse?.generateError(serviceConfig: service, logger: TestEnvironment.logger)
+        let error = awsResponse?.generateError(serviceConfig: service)
         XCTAssertEqual(error as? ServiceErrorType, .noSuchKey(message: "It doesn't exist"))
     }
 
@@ -238,11 +238,11 @@ class AWSResponseTests: XCTestCase {
             headers: HTTPHeaders(),
             bodyData: "<ErrorResponse><Error><Code>MessageRejected</Code><Message>Don't like it</Message></Error></ErrorResponse>".data(using: .utf8)!
         )
-        let queryService = createServiceConfig(serviceProtocol: .query, possibleErrorTypes: [ServiceErrorType.self])
+        let queryService = createServiceConfig(serviceProtocol: .query, errorType: ServiceErrorType.self, logger: TestEnvironment.logger)
 
         var awsResponse: AWSResponse?
         XCTAssertNoThrow(awsResponse = try AWSResponse(from: response, serviceProtocol: .query, raw: false))
-        let error = awsResponse?.generateError(serviceConfig: queryService, logger: TestEnvironment.logger)
+        let error = awsResponse?.generateError(serviceConfig: queryService)
         XCTAssertEqual(error as? ServiceErrorType, .messageRejected(message: "Don't like it"))
     }
 
@@ -256,7 +256,7 @@ class AWSResponseTests: XCTestCase {
 
         var awsResponse: AWSResponse?
         XCTAssertNoThrow(awsResponse = try AWSResponse(from: response, serviceProtocol: .ec2, raw: false))
-        let error = awsResponse?.generateError(serviceConfig: service, logger: TestEnvironment.logger) as? AWSResponseError
+        let error = awsResponse?.generateError(serviceConfig: service) as? AWSResponseError
         XCTAssertEqual(error?.errorCode, "NoSuchKey")
         XCTAssertEqual(error?.message, "It doesn't exist")
     }

--- a/Tests/AWSSDKSwiftCoreTests/AWSResponseTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/AWSResponseTests.swift
@@ -210,11 +210,11 @@ class AWSResponseTests: XCTestCase {
             headers: HTTPHeaders(),
             bodyData: "{\"__type\":\"ResourceNotFoundException\", \"message\": \"Donald Where's Your Troosers?\"}".data(using: .utf8)!
         )
-        let service = createServiceConfig(serviceProtocol: .json(version: "1.1"), errorType: ServiceErrorType.self)
+        let context = createServiceContext(serviceProtocol: .json(version: "1.1"), errorType: ServiceErrorType.self)
 
         var awsResponse: AWSResponse?
         XCTAssertNoThrow(awsResponse = try AWSResponse(from: response, serviceProtocol: .json(version: "1.1"), raw: false))
-        let error = awsResponse?.generateError(serviceConfig: service)
+        let error = awsResponse?.generateError(serviceContext: context)
         XCTAssertEqual(error as? ServiceErrorType, .resourceNotFoundException(message: "Donald Where's Your Troosers?"))
     }
 
@@ -224,11 +224,11 @@ class AWSResponseTests: XCTestCase {
             headers: HTTPHeaders(),
             bodyData: "<Error><Code>NoSuchKey</Code><Message>It doesn't exist</Message></Error>".data(using: .utf8)!
         )
-        let service = createServiceConfig(serviceProtocol: .restxml, errorType: ServiceErrorType.self, logger: TestEnvironment.logger)
+        let context = createServiceContext(serviceProtocol: .restxml, errorType: ServiceErrorType.self, logger: TestEnvironment.logger)
 
         var awsResponse: AWSResponse?
         XCTAssertNoThrow(awsResponse = try AWSResponse(from: response, serviceProtocol: .restxml, raw: false))
-        let error = awsResponse?.generateError(serviceConfig: service)
+        let error = awsResponse?.generateError(serviceContext: context)
         XCTAssertEqual(error as? ServiceErrorType, .noSuchKey(message: "It doesn't exist"))
     }
 
@@ -238,11 +238,11 @@ class AWSResponseTests: XCTestCase {
             headers: HTTPHeaders(),
             bodyData: "<ErrorResponse><Error><Code>MessageRejected</Code><Message>Don't like it</Message></Error></ErrorResponse>".data(using: .utf8)!
         )
-        let queryService = createServiceConfig(serviceProtocol: .query, errorType: ServiceErrorType.self, logger: TestEnvironment.logger)
+        let context = createServiceContext(serviceProtocol: .query, errorType: ServiceErrorType.self, logger: TestEnvironment.logger)
 
         var awsResponse: AWSResponse?
         XCTAssertNoThrow(awsResponse = try AWSResponse(from: response, serviceProtocol: .query, raw: false))
-        let error = awsResponse?.generateError(serviceConfig: queryService)
+        let error = awsResponse?.generateError(serviceContext: context)
         XCTAssertEqual(error as? ServiceErrorType, .messageRejected(message: "Don't like it"))
     }
 
@@ -252,11 +252,11 @@ class AWSResponseTests: XCTestCase {
             headers: HTTPHeaders(),
             bodyData: "<Errors><Error><Code>NoSuchKey</Code><Message>It doesn't exist</Message></Error></Errors>".data(using: .utf8)!
         )
-        let service = createServiceConfig(serviceProtocol: .ec2)
+        let context = createServiceContext(serviceProtocol: .ec2)
 
         var awsResponse: AWSResponse?
         XCTAssertNoThrow(awsResponse = try AWSResponse(from: response, serviceProtocol: .ec2, raw: false))
-        let error = awsResponse?.generateError(serviceConfig: service) as? AWSResponseError
+        let error = awsResponse?.generateError(serviceContext: context) as? AWSResponseError
         XCTAssertEqual(error?.errorCode, "NoSuchKey")
         XCTAssertEqual(error?.message, "It doesn't exist")
     }

--- a/Tests/AWSSDKSwiftCoreTests/LoggingTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/LoggingTests.swift
@@ -32,11 +32,12 @@ class LoggingTests: XCTestCase {
         defer { XCTAssertNoThrow(try client.syncShutdown()) }
         let config = createServiceConfig(
             serviceProtocol: .json(version: "1.1"),
-            endpoint: server.address
+            endpoint: server.address,
+            logger: logger
         )
 
-        let response = client.execute(operation: "test1", path: "/", httpMethod: .GET, serviceConfig: config, logger: logger)
-        let response2 = client.execute(operation: "test2", path: "/", httpMethod: .GET, serviceConfig: config, logger: logger)
+        let response = client.execute(operation: "test1", path: "/", httpMethod: .GET, serviceConfig: config)
+        let response2 = client.execute(operation: "test2", path: "/", httpMethod: .GET, serviceConfig: config)
 
         var count = 0
         XCTAssertNoThrow(try server.processRaw { _ in
@@ -73,10 +74,11 @@ class LoggingTests: XCTestCase {
         let config = createServiceConfig(
             service: "test-service",
             serviceProtocol: .json(version: "1.1"),
-            endpoint: server.address
+            endpoint: server.address,
+            logger: logger
         )
 
-        let response = client.execute(operation: "TestOperation", path: "/", httpMethod: .GET, serviceConfig: config, logger: logger)
+        let response = client.execute(operation: "TestOperation", path: "/", httpMethod: .GET, serviceConfig: config)
 
         XCTAssertNoThrow(try server.processRaw { _ in
             return .result(.ok, continueProcessing: false)
@@ -106,10 +108,11 @@ class LoggingTests: XCTestCase {
         defer { XCTAssertNoThrow(try client.syncShutdown()) }
         let config = createServiceConfig(
             serviceProtocol: .json(version: "1.1"),
-            endpoint: server.address
+            endpoint: server.address,
+            logger: logger
         )
 
-        let response = client.execute(operation: "test", path: "/", httpMethod: .GET, serviceConfig: config, logger: logger)
+        let response = client.execute(operation: "test", path: "/", httpMethod: .GET, serviceConfig: config)
 
         XCTAssertNoThrow(try server.processRaw { _ in
             return .error(.accessDenied, continueProcessing: false)
@@ -133,10 +136,11 @@ class LoggingTests: XCTestCase {
         defer { XCTAssertNoThrow(try client.syncShutdown()) }
         let config = createServiceConfig(
             serviceProtocol: .json(version: "1.1"),
-            endpoint: server.address
+            endpoint: server.address,
+            logger: logger
         )
 
-        let response = client.execute(operation: "test1", path: "/", httpMethod: .GET, serviceConfig: config, logger: logger)
+        let response = client.execute(operation: "test1", path: "/", httpMethod: .GET, serviceConfig: config)
 
         var count = 0
         XCTAssertNoThrow(try server.processRaw { _ in
@@ -159,13 +163,12 @@ class LoggingTests: XCTestCase {
         let logger = Logger(label: "LoggingTests", factory: { _ in LoggingCollector(logCollection, logLevel: .trace) })
         let client = createAWSClient(credentialProvider: .selector(.custom { _ in return NullCredentialProvider() }))
         defer { XCTAssertNoThrow(try client.syncShutdown()) }
-        let serviceConfig = createServiceConfig()
+        let serviceConfig = createServiceConfig(logger: logger)
         XCTAssertThrowsError(try client.execute(
             operation: "Test",
             path: "/",
             httpMethod: .GET,
-            serviceConfig: serviceConfig,
-            logger: logger
+            serviceConfig: serviceConfig
         ).wait())
         XCTAssertNotNil(logCollection.filter(metadata: "aws-error-message", with: "No credential provider found").first)
     }

--- a/Tests/AWSSDKSwiftCoreTests/LoggingTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/LoggingTests.swift
@@ -30,14 +30,14 @@ class LoggingTests: XCTestCase {
             logger: logger
         )
         defer { XCTAssertNoThrow(try client.syncShutdown()) }
-        let config = createServiceConfig(
+        let context = createServiceContext(
             serviceProtocol: .json(version: "1.1"),
             endpoint: server.address,
             logger: logger
         )
 
-        let response = client.execute(operation: "test1", path: "/", httpMethod: .GET, serviceConfig: config)
-        let response2 = client.execute(operation: "test2", path: "/", httpMethod: .GET, serviceConfig: config)
+        let response = client.execute(operation: "test1", path: "/", httpMethod: .GET, serviceContext: context)
+        let response2 = client.execute(operation: "test2", path: "/", httpMethod: .GET, serviceContext: context)
 
         var count = 0
         XCTAssertNoThrow(try server.processRaw { _ in
@@ -71,14 +71,14 @@ class LoggingTests: XCTestCase {
             logger: logger
         )
         defer { XCTAssertNoThrow(try client.syncShutdown()) }
-        let config = createServiceConfig(
+        let context = createServiceContext(
             service: "test-service",
             serviceProtocol: .json(version: "1.1"),
             endpoint: server.address,
             logger: logger
         )
 
-        let response = client.execute(operation: "TestOperation", path: "/", httpMethod: .GET, serviceConfig: config)
+        let response = client.execute(operation: "TestOperation", path: "/", httpMethod: .GET, serviceContext: context)
 
         XCTAssertNoThrow(try server.processRaw { _ in
             return .result(.ok, continueProcessing: false)
@@ -106,13 +106,13 @@ class LoggingTests: XCTestCase {
             logger: logger
         )
         defer { XCTAssertNoThrow(try client.syncShutdown()) }
-        let config = createServiceConfig(
+        let context = createServiceContext(
             serviceProtocol: .json(version: "1.1"),
             endpoint: server.address,
             logger: logger
         )
 
-        let response = client.execute(operation: "test", path: "/", httpMethod: .GET, serviceConfig: config)
+        let response = client.execute(operation: "test", path: "/", httpMethod: .GET, serviceContext: context)
 
         XCTAssertNoThrow(try server.processRaw { _ in
             return .error(.accessDenied, continueProcessing: false)
@@ -134,13 +134,13 @@ class LoggingTests: XCTestCase {
             logger: logger
         )
         defer { XCTAssertNoThrow(try client.syncShutdown()) }
-        let config = createServiceConfig(
+        let context = createServiceContext(
             serviceProtocol: .json(version: "1.1"),
             endpoint: server.address,
             logger: logger
         )
 
-        let response = client.execute(operation: "test1", path: "/", httpMethod: .GET, serviceConfig: config)
+        let response = client.execute(operation: "test1", path: "/", httpMethod: .GET, serviceContext: context)
 
         var count = 0
         XCTAssertNoThrow(try server.processRaw { _ in
@@ -163,12 +163,12 @@ class LoggingTests: XCTestCase {
         let logger = Logger(label: "LoggingTests", factory: { _ in LoggingCollector(logCollection, logLevel: .trace) })
         let client = createAWSClient(credentialProvider: .selector(.custom { _ in return NullCredentialProvider() }))
         defer { XCTAssertNoThrow(try client.syncShutdown()) }
-        let serviceConfig = createServiceConfig(logger: logger)
+        let serviceConfig = createServiceContext(logger: logger)
         XCTAssertThrowsError(try client.execute(
             operation: "Test",
             path: "/",
             httpMethod: .GET,
-            serviceConfig: serviceConfig
+            serviceContext: serviceConfig
         ).wait())
         XCTAssertNotNil(logCollection.filter(metadata: "aws-error-message", with: "No credential provider found").first)
     }

--- a/Tests/AWSSDKSwiftCoreTests/PaginateTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/PaginateTests.swift
@@ -66,15 +66,14 @@ class PaginateTests: XCTestCase {
         let outputToken: Int?
     }
 
-    func counter(_ input: CounterInput, on eventLoop: EventLoop?, logger: Logger) -> EventLoopFuture<CounterOutput> {
+    func counter(_ input: CounterInput, on eventLoop: EventLoop?) -> EventLoopFuture<CounterOutput> {
         return self.client.execute(
             operation: "TestOperation",
             path: "/",
             httpMethod: .POST,
             serviceConfig: self.config,
             input: input,
-            on: eventLoop,
-            logger: logger
+            on: eventLoop
         )
     }
 
@@ -83,7 +82,6 @@ class PaginateTests: XCTestCase {
             input: input,
             command: self.counter,
             tokenKey: \CounterOutput.outputToken,
-            logger: TestEnvironment.logger,
             onPage: onPage
         )
     }
@@ -144,15 +142,14 @@ class PaginateTests: XCTestCase {
         let outputToken: String?
     }
 
-    func stringList(_ input: StringListInput, on eventLoop: EventLoop? = nil, logger: Logger) -> EventLoopFuture<StringListOutput> {
+    func stringList(_ input: StringListInput, on eventLoop: EventLoop? = nil) -> EventLoopFuture<StringListOutput> {
         return self.client.execute(
             operation: "TestOperation",
             path: "/",
             httpMethod: .POST,
             serviceConfig: self.config,
             input: input,
-            on: eventLoop,
-            logger: logger
+            on: eventLoop
         )
     }
 
@@ -162,7 +159,6 @@ class PaginateTests: XCTestCase {
             command: self.stringList,
             tokenKey: \StringListOutput.outputToken,
             on: eventLoop,
-            logger: TestEnvironment.logger,
             onPage: onPage
         )
     }

--- a/Tests/AWSSDKSwiftCoreTests/PaginateTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/PaginateTests.swift
@@ -27,14 +27,14 @@ class PaginateTests: XCTestCase {
     var eventLoopGroup: EventLoopGroup!
     var httpClient: HTTPClient!
     var client: AWSClient!
-    var config: AWSServiceConfig!
+    var context: AWSServiceContext!
 
     override func setUp() {
         // create server and client
         self.awsServer = AWSTestServer(serviceProtocol: .json)
         self.eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 3)
         self.httpClient = AsyncHTTPClient.HTTPClient(eventLoopGroupProvider: .shared(self.eventLoopGroup))
-        self.config = createServiceConfig(serviceProtocol: .json(version: "1.1"), endpoint: self.awsServer.address)
+        self.context = createServiceContext(serviceProtocol: .json(version: "1.1"), endpoint: self.awsServer.address)
         self.client = createAWSClient(credentialProvider: .empty, retryPolicy: .noRetry, httpClientProvider: .shared(self.httpClient))
     }
 
@@ -71,7 +71,7 @@ class PaginateTests: XCTestCase {
             operation: "TestOperation",
             path: "/",
             httpMethod: .POST,
-            serviceConfig: self.config,
+            serviceContext: self.context,
             input: input,
             on: eventLoop
         )
@@ -147,7 +147,7 @@ class PaginateTests: XCTestCase {
             operation: "TestOperation",
             path: "/",
             httpMethod: .POST,
-            serviceConfig: self.config,
+            serviceContext: self.context,
             input: input,
             on: eventLoop
         )

--- a/Tests/AWSSDKSwiftCoreTests/PayloadTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/PayloadTests.swift
@@ -28,7 +28,7 @@ class PayloadTests: XCTestCase {
 
         do {
             let awsServer = AWSTestServer(serviceProtocol: .json)
-            let config = createServiceConfig(endpoint: awsServer.address, logger: TestEnvironment.logger)
+            let config = createServiceContext(endpoint: awsServer.address, logger: TestEnvironment.logger)
             let client = createAWSClient(credentialProvider: .empty)
             defer {
                 XCTAssertNoThrow(try client.syncShutdown())
@@ -38,7 +38,7 @@ class PayloadTests: XCTestCase {
                 operation: "test",
                 path: "/",
                 httpMethod: .POST,
-                serviceConfig: config,
+                serviceContext: config,
                 input: input
             )
 
@@ -76,7 +76,7 @@ class PayloadTests: XCTestCase {
         }
         do {
             let awsServer = AWSTestServer(serviceProtocol: .json)
-            let config = createServiceConfig(endpoint: awsServer.address, logger: TestEnvironment.logger)
+            let config = createServiceContext(endpoint: awsServer.address, logger: TestEnvironment.logger)
             let client = createAWSClient(credentialProvider: .empty)
             defer {
                 XCTAssertNoThrow(try client.syncShutdown())
@@ -85,7 +85,7 @@ class PayloadTests: XCTestCase {
                 operation: "test",
                 path: "/",
                 httpMethod: .POST,
-                serviceConfig: config
+                serviceContext: config
             )
 
             try awsServer.processRaw { _ in

--- a/Tests/AWSSDKSwiftCoreTests/PayloadTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/PayloadTests.swift
@@ -28,7 +28,7 @@ class PayloadTests: XCTestCase {
 
         do {
             let awsServer = AWSTestServer(serviceProtocol: .json)
-            let config = createServiceConfig(endpoint: awsServer.address)
+            let config = createServiceConfig(endpoint: awsServer.address, logger: TestEnvironment.logger)
             let client = createAWSClient(credentialProvider: .empty)
             defer {
                 XCTAssertNoThrow(try client.syncShutdown())
@@ -39,8 +39,7 @@ class PayloadTests: XCTestCase {
                 path: "/",
                 httpMethod: .POST,
                 serviceConfig: config,
-                input: input,
-                logger: TestEnvironment.logger
+                input: input
             )
 
             try awsServer.processRaw { request in
@@ -77,7 +76,7 @@ class PayloadTests: XCTestCase {
         }
         do {
             let awsServer = AWSTestServer(serviceProtocol: .json)
-            let config = createServiceConfig(endpoint: awsServer.address)
+            let config = createServiceConfig(endpoint: awsServer.address, logger: TestEnvironment.logger)
             let client = createAWSClient(credentialProvider: .empty)
             defer {
                 XCTAssertNoThrow(try client.syncShutdown())
@@ -86,8 +85,7 @@ class PayloadTests: XCTestCase {
                 operation: "test",
                 path: "/",
                 httpMethod: .POST,
-                serviceConfig: config,
-                logger: TestEnvironment.logger
+                serviceConfig: config
             )
 
             try awsServer.processRaw { _ in

--- a/Tests/AWSSDKSwiftCoreTests/PerformanceTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/PerformanceTests.swift
@@ -72,7 +72,7 @@ class PerformanceTests: XCTestCase {
 
     func testHeaderRequest() {
         guard Self.enableTimingTests == true else { return }
-        let config = createServiceConfig(
+        let context = createServiceContext(
             region: .useast1,
             service: "Test",
             serviceProtocol: .restxml,
@@ -83,7 +83,7 @@ class PerformanceTests: XCTestCase {
         measure {
             do {
                 for _ in 0..<1000 {
-                    _ = try AWSRequest(operation: "Test", path: "/", httpMethod: .POST, input: request, configuration: config)
+                    _ = try AWSRequest(operation: "Test", path: "/", httpMethod: .POST, input: request, configuration: context)
                 }
             } catch {
                 XCTFail("Unexpected Error: \(error.localizedDescription)")
@@ -93,7 +93,7 @@ class PerformanceTests: XCTestCase {
 
     func testXMLRequest() {
         guard Self.enableTimingTests == true else { return }
-        let config = createServiceConfig(
+        let context = createServiceContext(
             region: .useast1,
             service: "Test",
             serviceProtocol: .restxml,
@@ -104,7 +104,7 @@ class PerformanceTests: XCTestCase {
         measure {
             do {
                 for _ in 0..<1000 {
-                    _ = try AWSRequest(operation: "Test", path: "/", httpMethod: .POST, input: request, configuration: config)
+                    _ = try AWSRequest(operation: "Test", path: "/", httpMethod: .POST, input: request, configuration: context)
                 }
             } catch {
                 XCTFail("Unexpected Error: \(error.localizedDescription)")
@@ -114,7 +114,7 @@ class PerformanceTests: XCTestCase {
 
     func testXMLPayloadRequest() {
         guard Self.enableTimingTests == true else { return }
-        let config = createServiceConfig(
+        let context = createServiceContext(
             region: .useast1,
             service: "Test",
             serviceProtocol: .restxml,
@@ -125,7 +125,7 @@ class PerformanceTests: XCTestCase {
         measure {
             do {
                 for _ in 0..<1000 {
-                    _ = try AWSRequest(operation: "Test", path: "/", httpMethod: .POST, input: request, configuration: config)
+                    _ = try AWSRequest(operation: "Test", path: "/", httpMethod: .POST, input: request, configuration: context)
                 }
             } catch {
                 XCTFail("\(error)")
@@ -135,7 +135,7 @@ class PerformanceTests: XCTestCase {
 
     func testJSONRequest() {
         guard Self.enableTimingTests == true else { return }
-        let config = createServiceConfig(
+        let context = createServiceContext(
             region: .useast1,
             service: "Test",
             serviceProtocol: .restjson,
@@ -146,7 +146,7 @@ class PerformanceTests: XCTestCase {
         measure {
             do {
                 for _ in 0..<1000 {
-                    _ = try AWSRequest(operation: "Test", path: "/", httpMethod: .POST, input: request, configuration: config)
+                    _ = try AWSRequest(operation: "Test", path: "/", httpMethod: .POST, input: request, configuration: context)
                 }
             } catch {
                 XCTFail("\(error)")
@@ -156,7 +156,7 @@ class PerformanceTests: XCTestCase {
 
     func testJSONPayloadRequest() {
         guard Self.enableTimingTests == true else { return }
-        let config = createServiceConfig(
+        let context = createServiceContext(
             region: .useast1,
             service: "Test",
             serviceProtocol: .restjson,
@@ -167,7 +167,7 @@ class PerformanceTests: XCTestCase {
         measure {
             do {
                 for _ in 0..<1000 {
-                    _ = try AWSRequest(operation: "Test", path: "/", httpMethod: .POST, input: request, configuration: config)
+                    _ = try AWSRequest(operation: "Test", path: "/", httpMethod: .POST, input: request, configuration: context)
                 }
             } catch {
                 XCTFail("\(error)")
@@ -177,7 +177,7 @@ class PerformanceTests: XCTestCase {
 
     func testQueryRequest() {
         guard Self.enableTimingTests == true else { return }
-        let config = createServiceConfig(
+        let context = createServiceContext(
             region: .useast1,
             service: "Test",
             serviceProtocol: .query,
@@ -188,7 +188,7 @@ class PerformanceTests: XCTestCase {
         measure {
             do {
                 for _ in 0..<1000 {
-                    _ = try AWSRequest(operation: "Test", path: "/", httpMethod: .POST, input: request, configuration: config)
+                    _ = try AWSRequest(operation: "Test", path: "/", httpMethod: .POST, input: request, configuration: context)
                 }
             } catch {
                 XCTFail("\(error)")
@@ -198,7 +198,7 @@ class PerformanceTests: XCTestCase {
 
     func testUnsignedRequest() {
         guard Self.enableTimingTests == true else { return }
-        let config = createServiceConfig(
+        let context = createServiceContext(
             region: .useast1,
             service: "Test",
             serviceProtocol: .json(version: "1.1"),
@@ -209,13 +209,13 @@ class PerformanceTests: XCTestCase {
             operation: "Test",
             path: "/",
             httpMethod: .GET,
-            configuration: config
+            configuration: context
         )
 
         let signer = AWSSigner(
             credentials: StaticCredential(accessKeyId: "", secretAccessKey: ""),
-            name: config.service,
-            region: config.region.rawValue
+            name: context.service,
+            region: context.region.rawValue
         )
         measure {
             for _ in 0..<1000 {
@@ -226,7 +226,7 @@ class PerformanceTests: XCTestCase {
 
     func testSignedURLRequest() {
         guard Self.enableTimingTests == true else { return }
-        let config = createServiceConfig()
+        let context = createServiceContext()
         let client = createAWSClient(credentialProvider: .static(accessKeyId: "MyAccessKeyId", secretAccessKey: "MySecretAccessKey"))
         defer {
             XCTAssertNoThrow(try client.syncShutdown())
@@ -235,10 +235,10 @@ class PerformanceTests: XCTestCase {
             operation: "Test",
             path: "/",
             httpMethod: .GET,
-            configuration: config
-        ).applyMiddlewares(config.middlewares + client.middlewares)
+            configuration: context
+        ).applyMiddlewares(context.middlewares + client.middlewares)
 
-        let signer = try! client.createSigner(serviceConfig: config).wait()
+        let signer = try! client.createSigner(serviceContext: context).wait()
         measure {
             for _ in 0..<1000 {
                 _ = awsRequest.createHTTPRequest(signer: signer)
@@ -248,7 +248,7 @@ class PerformanceTests: XCTestCase {
 
     func testSignedHeadersRequest() {
         guard Self.enableTimingTests == true else { return }
-        let config = createServiceConfig(
+        let context = createServiceContext(
             region: .useast1,
             service: "Test",
             serviceProtocol: .json(version: "1.1"),
@@ -256,11 +256,11 @@ class PerformanceTests: XCTestCase {
         )
         let date = Date()
         let request = StandardRequest(item1: "item1", item2: 45, item3: 3.14, item4: TimeStamp(date), item5: [1, 2, 3, 4, 5])
-        let awsRequest = try! AWSRequest(operation: "Test", path: "/", httpMethod: .POST, input: request, configuration: config)
+        let awsRequest = try! AWSRequest(operation: "Test", path: "/", httpMethod: .POST, input: request, configuration: context)
         let signer = AWSSigner(
             credentials: StaticCredential(accessKeyId: "", secretAccessKey: ""),
-            name: config.service,
-            region: config.region.rawValue
+            name: context.service,
+            region: context.region.rawValue
         )
         measure {
             for _ in 0..<1000 {

--- a/Tests/AWSSDKSwiftCoreTests/PerformanceTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/PerformanceTests.swift
@@ -238,7 +238,7 @@ class PerformanceTests: XCTestCase {
             configuration: config
         ).applyMiddlewares(config.middlewares + client.middlewares)
 
-        let signer = try! client.createSigner(serviceConfig: config, logger: AWSClient.loggingDisabled).wait()
+        let signer = try! client.createSigner(serviceConfig: config).wait()
         measure {
             for _ in 0..<1000 {
                 _ = awsRequest.createHTTPRequest(signer: signer)

--- a/Tests/AWSSDKSwiftCoreTests/TimeStampTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/TimeStampTests.swift
@@ -99,10 +99,10 @@ class TimeStampTests: XCTestCase {
             @Coding<HTTPHeaderTimeStampCoder> var date: TimeStamp
         }
         let a = A(date: TimeStamp("2019-05-01T00:00:00.001Z")!)
-        let config = createServiceConfig()
+        let context = createServiceContext()
 
         var request: AWSRequest?
-        XCTAssertNoThrow(request = try AWSRequest(operation: "test", path: "/", httpMethod: .GET, input: a, configuration: config))
+        XCTAssertNoThrow(request = try AWSRequest(operation: "test", path: "/", httpMethod: .GET, input: a, configuration: context))
         XCTAssertEqual(request?.body.asString(), "{\"date\":\"Wed, 1 May 2019 00:00:00 GMT\"}")
     }
 


### PR DESCRIPTION
Create AWSServiceContext that holds context information like Logger, BaggageContext and also the AWSServiceConfig, now renamed as `AWSServiceContext.Configuration`.

Add functions that generate new `AWSServiceContext` with altered Logger, Timeout value.

Added AWSService protocol as a common interface to all the AWS structs.

Dealt with all the renaming of structs 