### PR TITLE
AWSServiceContext version 2

### DIFF
--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -222,16 +222,16 @@ extension AWSClient {
     }
 
     /// invoke HTTP request
-    fileprivate func invoke(_ httpRequest: AWSHTTPRequest, with serviceConfig: AWSServiceConfig, on eventLoop: EventLoop, logger: Logger) -> EventLoopFuture<AWSHTTPResponse> {
+    fileprivate func invoke(_ httpRequest: AWSHTTPRequest, with serviceConfig: AWSServiceConfig, timeout: TimeAmount, on eventLoop: EventLoop, logger: Logger) -> EventLoopFuture<AWSHTTPResponse> {
         return invoke(with: serviceConfig, logger: logger) {
-            return self.httpClient.execute(request: httpRequest, timeout: serviceConfig.timeout, on: eventLoop, logger: logger)
+            return self.httpClient.execute(request: httpRequest, timeout: timeout, on: eventLoop, logger: logger)
         }
     }
 
     /// invoke HTTP request with response streaming
-    fileprivate func invoke(_ httpRequest: AWSHTTPRequest, with serviceConfig: AWSServiceConfig, on eventLoop: EventLoop, logger: Logger, stream: @escaping AWSHTTPClient.ResponseStream) -> EventLoopFuture<AWSHTTPResponse> {
+    fileprivate func invoke(_ httpRequest: AWSHTTPRequest, with serviceConfig: AWSServiceConfig, timeout: TimeAmount, on eventLoop: EventLoop, logger: Logger, stream: @escaping AWSHTTPClient.ResponseStream) -> EventLoopFuture<AWSHTTPResponse> {
         return invoke(with: serviceConfig, logger: logger) {
-            return self.httpClient.execute(request: httpRequest, timeout: serviceConfig.timeout, on: eventLoop, logger: logger, stream: stream)
+            return self.httpClient.execute(request: httpRequest, timeout: timeout, on: eventLoop, logger: logger, stream: stream)
         }
     }
 
@@ -276,7 +276,7 @@ extension AWSClient {
                 .applyMiddlewares(config.middlewares + self.middlewares)
                 .createHTTPRequest(signer: signer)
         }.flatMap { request in
-            return self.invoke(request, with: config, on: eventLoop, logger: logger)
+            return self.invoke(request, with: config, timeout: context.timeout, on: eventLoop, logger: logger)
         }.map { _ in
             return
         }
@@ -314,7 +314,7 @@ extension AWSClient {
                 .createHTTPRequest(signer: signer)
 
         }.flatMap { request -> EventLoopFuture<AWSHTTPResponse> in
-            return self.invoke(request, with: config, on: eventLoop, logger: logger)
+            return self.invoke(request, with: config, timeout: context.timeout, on: eventLoop, logger: logger)
         }.map { _ in
             return
         }
@@ -351,7 +351,7 @@ extension AWSClient {
                 .applyMiddlewares(config.middlewares + self.middlewares)
                 .createHTTPRequest(signer: signer)
         }.flatMap { request in
-            return self.invoke(request, with: config, on: eventLoop, logger: logger)
+            return self.invoke(request, with: config, timeout: context.timeout, on: eventLoop, logger: logger)
         }.flatMapThrowing { response in
             return try self.validate(operation: operationName, response: response, config: config)
         }
@@ -391,7 +391,7 @@ extension AWSClient {
                 .applyMiddlewares(config.middlewares + self.middlewares)
                 .createHTTPRequest(signer: signer)
         }.flatMap { request in
-            return self.invoke(request, with: config, on: eventLoop, logger: logger)
+            return self.invoke(request, with: config, timeout: context.timeout, on: eventLoop, logger: logger)
         }.flatMapThrowing { response in
             return try self.validate(operation: operationName, response: response, config: config)
         }
@@ -432,7 +432,7 @@ extension AWSClient {
                 .applyMiddlewares(config.middlewares + self.middlewares)
                 .createHTTPRequest(signer: signer)
         }.flatMap { request in
-            return self.invoke(request, with: config, on: eventLoop, logger: logger, stream: stream)
+            return self.invoke(request, with: config, timeout: context.timeout, on: eventLoop, logger: logger, stream: stream)
         }.flatMapThrowing { response in
             return try self.validate(operation: operationName, response: response, config: config)
         }

--- a/Sources/AWSSDKSwiftCore/AWSService.swift
+++ b/Sources/AWSSDKSwiftCore/AWSService.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Foundation
+
 public protocol AWSService {
     /// client used to communicate with AWS
     var client: AWSClient { get }
@@ -19,16 +21,34 @@ public protocol AWSService {
     var config: AWSServiceConfig { get }
     /// service context details
     var context: AWSServiceContext { get }
-    
+
     /// create copy of service with new context
     func withNewContext(_: (AWSServiceContext) -> AWSServiceContext) -> Self
+}
+
+extension AWSService {
+    /// Region where service is running
+    public var region: Region { return config.region }
+    /// The url to use in requests
+    public var endpoint: String { return config.endpoint }
+    
+    /// generate a signed URL
+    /// - parameters:
+    ///     - url : URL to sign
+    ///     - httpMethod: HTTP method to use ("GET", "PUT", "PUSH" etc)
+    ///     - expires: How long before the signed URL expires
+    /// - returns:
+    ///     A signed URL
+    public func signURL(url: URL, httpMethod: String, expires: Int = 86400) -> EventLoopFuture<URL> {
+        return self.client.signURL(url: url, httpMethod: httpMethod, expires: expires, config: self.config, context: self.context)
+    }
 }
 
 extension AWSService {
     public func delegating(to eventLoop: EventLoop) -> Self {
         return withNewContext { $0.delegating(to: eventLoop) }
     }
-    
+
     public func logging(to logger: Logger) -> Self {
         return withNewContext { $0.logging(to: logger) }
     }

--- a/Sources/AWSSDKSwiftCore/AWSService.swift
+++ b/Sources/AWSSDKSwiftCore/AWSService.swift
@@ -31,7 +31,9 @@ extension AWSService {
     public var region: Region { return config.region }
     /// The url to use in requests
     public var endpoint: String { return config.endpoint }
-    
+    /// The EventLoopGroup service is using
+    public var eventLoopGroup: EventLoopGroup { return client.eventLoopGroup }
+
     /// generate a signed URL
     /// - parameters:
     ///     - url : URL to sign

--- a/Sources/AWSSDKSwiftCore/AWSService.swift
+++ b/Sources/AWSSDKSwiftCore/AWSService.swift
@@ -1,0 +1,40 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the AWSSDKSwift open source project
+//
+// Copyright (c) 2020 the AWSSDKSwift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of AWSSDKSwift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+public protocol AWSService {
+    /// client used to communicate with AWS
+    var client: AWSClient { get }
+    /// service context details
+    var config: AWSServiceConfig { get }
+    /// service context details
+    var context: AWSServiceContext { get }
+    
+    /// create copy of service with new context
+    func withNewContext(_: (AWSServiceContext) -> AWSServiceContext) -> Self
+}
+
+extension AWSService {
+    public func delegating(to eventLoop: EventLoop) -> Self {
+        return withNewContext { $0.delegating(to: eventLoop) }
+    }
+    
+    public func logging(to logger: Logger) -> Self {
+        return withNewContext { $0.logging(to: logger) }
+    }
+
+    /// return new AWSServiceConfig with new timeout value
+    public func timingOut(after timeout: TimeAmount) -> Self {
+        return withNewContext { $0.timingOut(after: timeout) }
+    }
+}

--- a/Sources/AWSSDKSwiftCore/AWSServiceConfig.swift
+++ b/Sources/AWSSDKSwiftCore/AWSServiceConfig.swift
@@ -34,8 +34,6 @@ public class AWSServiceConfig {
     public let possibleErrorTypes: [AWSErrorType.Type]
     /// Middleware code specific to the service used to edit requests before they sent and responses before they are decoded
     public let middlewares: [AWSServiceMiddleware]
-    /// timeout value for HTTP requests
-    public let timeout: TimeAmount
 
     /// Create a ServiceConfig object
     ///
@@ -52,7 +50,6 @@ public class AWSServiceConfig {
     ///   - partitionEndpoints: Default endpoint to use, if no region endpoint is supplied
     ///   - possibleErrorTypes: Array of possible error types that the client can throw
     ///   - middlewares: Array of middlewares to apply to requests and responses
-    ///   - timeout: Time out value for HTTP requests
     public init(
         region: Region?,
         partition: AWSPartition,
@@ -65,8 +62,7 @@ public class AWSServiceConfig {
         serviceEndpoints: [String: String] = [:],
         partitionEndpoints: [AWSPartition: (endpoint: String, region: Region)] = [:],
         possibleErrorTypes: [AWSErrorType.Type] = [],
-        middlewares: [AWSServiceMiddleware] = [],
-        timeout: TimeAmount? = nil
+        middlewares: [AWSServiceMiddleware] = []
     ) {
         var partition = partition
         if let region = region {
@@ -87,7 +83,6 @@ public class AWSServiceConfig {
         self.serviceProtocol = serviceProtocol
         self.possibleErrorTypes = possibleErrorTypes
         self.middlewares = middlewares
-        self.timeout = timeout ?? .seconds(20)
 
         // work out endpoint, if provided use that otherwise
         if let endpoint = endpoint {

--- a/Sources/AWSSDKSwiftCore/AWSServiceContext.swift
+++ b/Sources/AWSSDKSwiftCore/AWSServiceContext.swift
@@ -16,29 +16,28 @@ public struct AWSServiceContext {
     public var eventLoop: EventLoop?
     public var logger: Logger
     public var timeout: TimeAmount
-    
+
     public init(eventLoop: EventLoop? = nil, logger: Logger = AWSClient.loggingDisabled, timeout: TimeAmount = .seconds(20)) {
         self.eventLoop = eventLoop
         self.logger = logger
         self.timeout = timeout
     }
-    
+
     public func delegating(to eventLoop: EventLoop) -> AWSServiceContext {
         var context = self
         context.eventLoop = eventLoop
         return context
     }
-    
+
     public func logging(to logger: Logger) -> AWSServiceContext {
         var context = self
         context.logger = logger
         return context
     }
-    
+
     public func timingOut(after timeout: TimeAmount) -> AWSServiceContext {
         var context = self
         context.timeout = timeout
         return context
     }
 }
-

--- a/Sources/AWSSDKSwiftCore/AWSServiceContext.swift
+++ b/Sources/AWSSDKSwiftCore/AWSServiceContext.swift
@@ -1,0 +1,38 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the AWSSDKSwift open source project
+//
+// Copyright (c) 2020 the AWSSDKSwift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of AWSSDKSwift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+public struct AWSServiceContext {
+    public var eventLoop: EventLoop? = nil
+    public var logger: Logger = AWSClient.loggingDisabled
+    public var timeout: TimeAmount = .seconds(20)
+    
+    public func delegating(to eventLoop: EventLoop) -> AWSServiceContext {
+        var context = self
+        context.eventLoop = eventLoop
+        return context
+    }
+    
+    public func logging(to logger: Logger) -> AWSServiceContext {
+        var context = self
+        context.logger = logger
+        return context
+    }
+    
+    public func timingOut(after timeout: TimeAmount) -> AWSServiceContext {
+        var context = self
+        context.timeout = timeout
+        return context
+    }
+}
+

--- a/Sources/AWSSDKSwiftCore/AWSServiceContext.swift
+++ b/Sources/AWSSDKSwiftCore/AWSServiceContext.swift
@@ -13,9 +13,15 @@
 //===----------------------------------------------------------------------===//
 
 public struct AWSServiceContext {
-    public var eventLoop: EventLoop? = nil
-    public var logger: Logger = AWSClient.loggingDisabled
-    public var timeout: TimeAmount = .seconds(20)
+    public var eventLoop: EventLoop?
+    public var logger: Logger
+    public var timeout: TimeAmount
+    
+    public init(eventLoop: EventLoop? = nil, logger: Logger = AWSClient.loggingDisabled, timeout: TimeAmount = .seconds(20)) {
+        self.eventLoop = eventLoop
+        self.logger = logger
+        self.timeout = timeout
+    }
     
     public func delegating(to eventLoop: EventLoop) -> AWSServiceContext {
         var context = self

--- a/Sources/AWSTestUtils/TestUtils.swift
+++ b/Sources/AWSTestUtils/TestUtils.swift
@@ -59,8 +59,7 @@ public func createServiceConfig(
     serviceEndpoints: [String: String] = [:],
     partitionEndpoints: [AWSPartition: (endpoint: String, region: Region)] = [:],
     possibleErrorTypes: [AWSErrorType.Type] = [],
-    middlewares: [AWSServiceMiddleware] = [],
-    timeout: TimeAmount? = nil
+    middlewares: [AWSServiceMiddleware] = []
 ) -> AWSServiceConfig {
     AWSServiceConfig(
         region: region,
@@ -74,8 +73,7 @@ public func createServiceConfig(
         serviceEndpoints: serviceEndpoints,
         partitionEndpoints: partitionEndpoints,
         possibleErrorTypes: possibleErrorTypes,
-        middlewares: middlewares,
-        timeout: timeout
+        middlewares: middlewares
     )
 }
 

--- a/Sources/AWSTestUtils/TestUtils.swift
+++ b/Sources/AWSTestUtils/TestUtils.swift
@@ -102,7 +102,7 @@ public struct TestEnvironment {
     }
 
     public static var context: AWSServiceContext { .init(logger: logger) }
-    
+
     public static var logger: Logger = {
         if let loggingLevel = Environment["AWS_LOG_LEVEL"] {
             if let logLevel = Logger.Level(rawValue: loggingLevel.lowercased()) {

--- a/Sources/AWSTestUtils/TestUtils.swift
+++ b/Sources/AWSTestUtils/TestUtils.swift
@@ -103,6 +103,8 @@ public struct TestEnvironment {
         return (Environment["AWS_ENABLE_LOGGING"] == "true") ? [AWSLoggingMiddleware()] : []
     }
 
+    public static var context: AWSServiceContext { .init(logger: logger) }
+    
     public static var logger: Logger = {
         if let loggingLevel = Environment["AWS_LOG_LEVEL"] {
             if let logLevel = Logger.Level(rawValue: loggingLevel.lowercased()) {

--- a/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/AWSClientTests.swift
@@ -95,7 +95,7 @@ class AWSClientTests: XCTestCase {
         defer {
             XCTAssertNoThrow(try client.syncShutdown())
         }
-        let response: EventLoopFuture<AWSTestServer.HTTPBinResponse> = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, logger: TestEnvironment.logger)
+        let response: EventLoopFuture<AWSTestServer.HTTPBinResponse> = client.execute(operation: "test", path: "/", httpMethod: .POST, config: config, context: TestEnvironment.context)
 
         XCTAssertNoThrow(try awsServer.httpBin())
         var httpBinResponse: AWSTestServer.HTTPBinResponse?
@@ -119,7 +119,7 @@ class AWSClientTests: XCTestCase {
                 XCTAssertNoThrow(try client.syncShutdown())
                 XCTAssertNoThrow(try awsServer.stop())
             }
-            let response = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, logger: TestEnvironment.logger)
+            let response = client.execute(operation: "test", path: "/", httpMethod: .POST, config: config, context: TestEnvironment.context)
 
             try awsServer.processRaw { _ in
                 let response = AWSTestServer.Response(httpStatus: .ok, headers: [:], body: nil)
@@ -151,7 +151,7 @@ class AWSClientTests: XCTestCase {
                 XCTAssertNoThrow(try awsServer.stop())
             }
             let input = Input(e: .second, i: [1, 2, 4, 8])
-            let response = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, input: input, logger: TestEnvironment.logger)
+            let response = client.execute(operation: "test", path: "/", httpMethod: .POST, input: input, config: config, context: TestEnvironment.context)
 
             try awsServer.processRaw { request in
                 let receivedInput = try JSONDecoder().decode(Input.self, from: request.body)
@@ -180,7 +180,7 @@ class AWSClientTests: XCTestCase {
                 XCTAssertNoThrow(try client.syncShutdown())
                 XCTAssertNoThrow(try awsServer.stop())
             }
-            let response: EventLoopFuture<Output> = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, logger: TestEnvironment.logger)
+            let response: EventLoopFuture<Output> = client.execute(operation: "test", path: "/", httpMethod: .POST, config: config, context: TestEnvironment.context)
 
             try awsServer.processRaw { _ in
                 let output = Output(s: "TestOutputString", i: 547)
@@ -217,7 +217,7 @@ class AWSClientTests: XCTestCase {
             return eventLoop.makeSucceededFuture(.byteBuffer(buffer))
         }
         let input = Input(payload: payload)
-        let response = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, input: input, logger: TestEnvironment.logger)
+        let response = client.execute(operation: "test", path: "/", httpMethod: .POST, input: input, config: config, context: TestEnvironment.context)
 
         try server.processRaw { request in
             let bytes = request.body.getBytes(at: 0, length: request.body.readableBytes)
@@ -290,7 +290,7 @@ class AWSClientTests: XCTestCase {
                 return eventLoop.makeSucceededFuture(.byteBuffer(buffer))
             }
             let input = Input(payload: payload)
-            let response = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, input: input, logger: TestEnvironment.logger)
+            let response = client.execute(operation: "test", path: "/", httpMethod: .POST, input: input, config: config, context: TestEnvironment.context)
             try response.wait()
         } catch let error as HTTPClientError where error == .bodyLengthMismatch {
         } catch {
@@ -335,7 +335,7 @@ class AWSClientTests: XCTestCase {
             }
 
             let input = Input(payload: .fileHandle(fileHandle, size: bufferSize, fileIO: fileIO) { size in print(size) })
-            let response = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, input: input, logger: TestEnvironment.logger)
+            let response = client.execute(operation: "test", path: "/", httpMethod: .POST, input: input, config: config, context: TestEnvironment.context)
 
             try awsServer.processRaw { request in
                 XCTAssertNil(request.headers["transfer-encoding"])
@@ -387,7 +387,7 @@ class AWSClientTests: XCTestCase {
                 }
             }
             let input = Input(payload: payload)
-            let response = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, input: input, logger: TestEnvironment.logger)
+            let response = client.execute(operation: "test", path: "/", httpMethod: .POST, input: input, config: config, context: TestEnvironment.context)
 
             try awsServer.processRaw { request in
                 let bytes = request.body.getBytes(at: 0, length: request.body.readableBytes)
@@ -416,7 +416,7 @@ class AWSClientTests: XCTestCase {
                 XCTAssertNoThrow(try client.syncShutdown())
                 XCTAssertNoThrow(try httpClient.syncShutdown())
             }
-            let response = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, logger: TestEnvironment.logger)
+            let response = client.execute(operation: "test", path: "/", httpMethod: .POST, config: config, context: TestEnvironment.context)
 
             try awsServer.processRaw { _ in
                 let response = AWSTestServer.Response(httpStatus: .temporaryRedirect, headers: ["Location": awsServer.address], body: nil)
@@ -452,7 +452,7 @@ class AWSClientTests: XCTestCase {
                 XCTAssertNoThrow(try client.syncShutdown())
                 XCTAssertNoThrow(try httpClient.syncShutdown())
             }
-            let response = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, logger: TestEnvironment.logger)
+            let response = client.execute(operation: "test", path: "/", httpMethod: .POST, config: config, context: TestEnvironment.context)
 
             var count = 0
             try awsServer.processRaw { _ in
@@ -495,8 +495,8 @@ class AWSClientTests: XCTestCase {
                 operation: "test",
                 path: "/",
                 httpMethod: .POST,
-                serviceConfig: config,
-                logger: TestEnvironment.logger
+                config: config,
+                context: TestEnvironment.context
             )
 
             var count = 0
@@ -538,8 +538,8 @@ class AWSClientTests: XCTestCase {
                 operation: "test",
                 path: "/",
                 httpMethod: .POST,
-                serviceConfig: config,
-                logger: TestEnvironment.logger
+                config: config,
+                context: TestEnvironment.context
             )
 
             try awsServer.processRaw { _ in
@@ -574,9 +574,8 @@ class AWSClientTests: XCTestCase {
                 operation: "test",
                 path: "/",
                 httpMethod: .POST,
-                serviceConfig: config,
-                on: eventLoop,
-                logger: TestEnvironment.logger
+                config: config,
+                context: TestEnvironment.context.delegating(to: eventLoop)
             )
 
             try awsServer.processRaw { _ in
@@ -615,9 +614,9 @@ class AWSClientTests: XCTestCase {
                 operation: "test",
                 path: "/",
                 httpMethod: .GET,
-                serviceConfig: config,
                 input: Input(),
-                logger: TestEnvironment.logger
+                config: config,
+                context: TestEnvironment.context
             ) { (payload: ByteBuffer, eventLoop: EventLoop) in
                 let payloadSize = payload.readableBytes
                 let slice = Data(data[count..<(count + payloadSize)])
@@ -668,9 +667,9 @@ class AWSClientTests: XCTestCase {
             operation: "test",
             path: "/",
             httpMethod: .GET,
-            serviceConfig: config,
             input: Input(),
-            logger: TestEnvironment.logger
+            config: config,
+            context: TestEnvironment.context
         ) { (_: ByteBuffer, eventLoop: EventLoop) in
             lock.withLock { count += 1 }
             return eventLoop.scheduleTask(in: .milliseconds(200)) {
@@ -706,7 +705,7 @@ class AWSClientTests: XCTestCase {
             XCTAssertNoThrow(try awsServer.stop())
         }
 
-        let response = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, logger: TestEnvironment.logger)
+        let response = client.execute(operation: "test", path: "/", httpMethod: .POST, config: config, context: TestEnvironment.context)
 
         XCTAssertNoThrow(try awsServer.processRaw { request in
             XCTAssertEqual(request.uri, "/test")

--- a/Tests/AWSSDKSwiftCoreTests/AWSServiceTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/AWSServiceTests.swift
@@ -1,0 +1,69 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the AWSSDKSwift open source project
+//
+// Copyright (c) 2017-2020 the AWSSDKSwift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of AWSSDKSwift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import AWSSDKSwiftCore
+import AWSTestUtils
+import XCTest
+
+class AWSServiceTests: XCTestCase {
+    var client: AWSClient!
+
+    override func setUp() {
+        self.client = createAWSClient()
+    }
+
+    override func tearDown() {
+        XCTAssertNoThrow(try self.client.syncShutdown())
+    }
+
+    func testRegion() {
+        let service = TestService(client: client, config: createServiceConfig(region: .eucentral1), context: .init())
+        XCTAssertEqual(service.region, .eucentral1)
+    }
+
+    func testEndpoint() {
+        let endpoint = "https://myendpoint:8000"
+        let service = TestService(client: client, config: createServiceConfig(endpoint: endpoint), context: .init())
+        XCTAssertEqual(service.endpoint, endpoint)
+    }
+
+    func testDelegatingToEventloop() {
+        let service = TestService(client: client, config: createServiceConfig(), context: .init())
+        let eventLoop = service.eventLoopGroup.next()
+        XCTAssertNil(service.context.eventLoop)
+        XCTAssertTrue(service.delegating(to: eventLoop).context.eventLoop === eventLoop)
+    }
+
+    func testTimeout() {
+        let service = TestService(client: client, config: createServiceConfig(), context: .init(timeout: .seconds(23)))
+        XCTAssertEqual(service.context.timeout, .seconds(23))
+        XCTAssertEqual(service.timingOut(after: .seconds(34)).context.timeout, .seconds(34))
+    }
+
+    func testLogger() {
+        let service = TestService(client: client, config: createServiceConfig(), context: .init())
+        XCTAssertEqual(service.context.logger.label, AWSClient.loggingDisabled.label)
+        XCTAssertEqual(service.logging(to: Logger(label: "TestLogger")).context.logger.label, "TestLogger")
+    }
+}
+
+struct TestService: AWSService {
+    var client: AWSClient
+    var config: AWSServiceConfig
+    var context: AWSServiceContext
+
+    func withNewContext(_ process: (AWSServiceContext) -> AWSServiceContext) -> Self {
+        return Self(client: self.client, config: self.config, context: process(self.context))
+    }
+}

--- a/Tests/AWSSDKSwiftCoreTests/LoggingTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/LoggingTests.swift
@@ -35,8 +35,8 @@ class LoggingTests: XCTestCase {
             endpoint: server.address
         )
 
-        let response = client.execute(operation: "test1", path: "/", httpMethod: .GET, serviceConfig: config, logger: logger)
-        let response2 = client.execute(operation: "test2", path: "/", httpMethod: .GET, serviceConfig: config, logger: logger)
+        let response = client.execute(operation: "test1", path: "/", httpMethod: .GET, config: config, context: .init(logger: logger))
+        let response2 = client.execute(operation: "test2", path: "/", httpMethod: .GET, config: config, context: .init(logger: logger))
 
         var count = 0
         XCTAssertNoThrow(try server.processRaw { _ in
@@ -76,7 +76,7 @@ class LoggingTests: XCTestCase {
             endpoint: server.address
         )
 
-        let response = client.execute(operation: "TestOperation", path: "/", httpMethod: .GET, serviceConfig: config, logger: logger)
+        let response = client.execute(operation: "TestOperation", path: "/", httpMethod: .GET, config: config, context: .init(logger: logger))
 
         XCTAssertNoThrow(try server.processRaw { _ in
             return .result(.ok, continueProcessing: false)
@@ -109,7 +109,7 @@ class LoggingTests: XCTestCase {
             endpoint: server.address
         )
 
-        let response = client.execute(operation: "test", path: "/", httpMethod: .GET, serviceConfig: config, logger: logger)
+        let response = client.execute(operation: "test", path: "/", httpMethod: .GET, config: config, context: .init(logger: logger))
 
         XCTAssertNoThrow(try server.processRaw { _ in
             return .error(.accessDenied, continueProcessing: false)
@@ -136,7 +136,7 @@ class LoggingTests: XCTestCase {
             endpoint: server.address
         )
 
-        let response = client.execute(operation: "test1", path: "/", httpMethod: .GET, serviceConfig: config, logger: logger)
+        let response = client.execute(operation: "test1", path: "/", httpMethod: .GET, config: config, context: .init(logger: logger))
 
         var count = 0
         XCTAssertNoThrow(try server.processRaw { _ in
@@ -164,8 +164,8 @@ class LoggingTests: XCTestCase {
             operation: "Test",
             path: "/",
             httpMethod: .GET,
-            serviceConfig: serviceConfig,
-            logger: logger
+            config: serviceConfig,
+            context: .init(logger: logger)
         ).wait())
         XCTAssertNotNil(logCollection.filter(metadata: "aws-error-message", with: "No credential provider found").first)
     }

--- a/Tests/AWSSDKSwiftCoreTests/PaginateTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/PaginateTests.swift
@@ -201,7 +201,7 @@ struct PaginateTestService: AWSService {
     func withNewContext(_ process: (AWSServiceContext) -> AWSServiceContext) -> PaginateTestService {
         return PaginateTestService(client: self.client, config: self.config, context: process(self.context))
     }
-    
+
     public let client: AWSClient
     public let config: AWSServiceConfig
     public let context: AWSServiceContext
@@ -211,7 +211,7 @@ struct PaginateTestService: AWSService {
         self.config = config
         self.context = context
     }
-    
+
     func counter(_ input: CounterInput) -> EventLoopFuture<CounterOutput> {
         return self.client.execute(
             operation: "TestOperation",
@@ -219,7 +219,7 @@ struct PaginateTestService: AWSService {
             httpMethod: .POST,
             input: input,
             config: self.config,
-            context: context
+            context: self.context
         )
     }
 
@@ -240,7 +240,7 @@ struct PaginateTestService: AWSService {
             httpMethod: .POST,
             input: input,
             config: self.config,
-            context: context
+            context: self.context
         )
     }
 
@@ -249,7 +249,7 @@ struct PaginateTestService: AWSService {
             input: input,
             command: self.stringList,
             tokenKey: \StringListOutput.outputToken,
-            context: context,
+            context: self.context,
             onPage: onPage
         )
     }

--- a/Tests/AWSSDKSwiftCoreTests/PayloadTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/PayloadTests.swift
@@ -38,9 +38,9 @@ class PayloadTests: XCTestCase {
                 operation: "test",
                 path: "/",
                 httpMethod: .POST,
-                serviceConfig: config,
                 input: input,
-                logger: TestEnvironment.logger
+                config: config,
+                context: TestEnvironment.context
             )
 
             try awsServer.processRaw { request in
@@ -86,8 +86,8 @@ class PayloadTests: XCTestCase {
                 operation: "test",
                 path: "/",
                 httpMethod: .POST,
-                serviceConfig: config,
-                logger: TestEnvironment.logger
+                config: config,
+                context: TestEnvironment.context
             )
 
             try awsServer.processRaw { _ in

--- a/Tests/AWSSDKSwiftCoreTests/PerformanceTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/PerformanceTests.swift
@@ -238,7 +238,7 @@ class PerformanceTests: XCTestCase {
             configuration: config
         ).applyMiddlewares(config.middlewares + client.middlewares)
 
-        let signer = try! client.createSigner(serviceConfig: config, logger: AWSClient.loggingDisabled).wait()
+        let signer = try! client.createSigner(config: config, logger: AWSClient.loggingDisabled).wait()
         measure {
             for _ in 0..<1000 {
                 _ = awsRequest.createHTTPRequest(signer: signer)


### PR DESCRIPTION
Create `AWSServiceContext` struct that holds context data for requests
AWSClient public functions take `AWSServiceContext` in addition to the `AWSServiceConfig`
Added `AWSService` protocol that supports editing of `AWSServiceContext`