### PR TITLE
Fix compiler warning on AWSClient.swift

### DIFF
--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -163,7 +163,7 @@ public final class AWSClient {
         }
         let eventLoop = eventLoopGroup.next()
         // ignore errors from credential provider. Don't need shutdown erroring because no providers were available
-        _ = credentialProvider.shutdown(on: eventLoop).whenComplete { _ in
+        credentialProvider.shutdown(on: eventLoop).whenComplete { _ in
             // if httpClient was created by AWSClient then it is required to shutdown the httpClient.
             switch self.httpClientProvider {
             case .createNew:


### PR DESCRIPTION
Fix Swift compiler warning on line 166:

> /workspace/.build/checkouts/aws-sdk-swift-core/Sources/AWSSDKSwiftCore/AWSClient.swift:166:9: warning: using '_' to ignore the result of a Void-returning function is redundant
>        _ = credentialProvider.shutdown(on: eventLoop).whenComplete { _ in
>        ^~~~