### PR TITLE
feat. Add a SSOCredentialProvider

### DIFF
--- a/Sources/SotoCore/Credential/CredentialProvider.swift
+++ b/Sources/SotoCore/Credential/CredentialProvider.swift
@@ -70,12 +70,12 @@ extension CredentialProviderFactory {
     /// files. On macOS is looks in the environment and then the config file.
     public static var `default`: CredentialProviderFactory {
         #if os(Linux)
-        return .selector(.environment, .ecs, .ec2, .configFile(), .login())
+        return .selector(.environment, .ecs, .ec2, .configFile(), .sso(), .login())
         #else
         if #available(macOS 13.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *) {
-            return .selector(.environment, .configFile(), .login())
+            return .selector(.environment, .configFile(), .sso(), .login())
         } else {
-            return .selector(.environment, .configFile())
+            return .selector(.environment, .configFile(), .sso())
         }
         #endif
     }

--- a/Sources/SotoCore/Credential/SSO/SSOCredentialProvider.swift
+++ b/Sources/SotoCore/Credential/SSO/SSOCredentialProvider.swift
@@ -21,13 +21,11 @@ import NIOFoundationCompat
 import NIOPosix
 import SotoSignerV4
 
-import struct Foundation.Data
-import struct Foundation.Date
-import class Foundation.ISO8601DateFormatter
-import class Foundation.JSONDecoder
-import class Foundation.ProcessInfo
-import struct Foundation.TimeInterval
-import struct Foundation.URL
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 // MARK: - SSO Credential Provider
 

--- a/Sources/SotoCore/Credential/SSO/SSOCredentialProvider.swift
+++ b/Sources/SotoCore/Credential/SSO/SSOCredentialProvider.swift
@@ -272,7 +272,7 @@ public struct SSOCredentialProvider: CredentialProvider {
 
         let body = try await response.body.collect(upTo: 1024 * 1024)
         let decoder = JSONDecoder()
-        let apiResponse = try decoder.decode(SSOGetRoleCredentialsResponse.self, from: Data(buffer: body))
+        let apiResponse = try decoder.decode(SSOGetRoleCredentialsResponse.self, from: body)
 
         return apiResponse.roleCredentials
     }

--- a/Sources/SotoCore/Credential/SSO/SSOCredentialProvider.swift
+++ b/Sources/SotoCore/Credential/SSO/SSOCredentialProvider.swift
@@ -1,0 +1,299 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Soto for AWS open source project
+//
+// Copyright (c) 2017-2026 the Soto project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Soto project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+// SSO Credential Provider - Main Provider
+
+import INIParser
+import Logging
+import NIOCore
+import NIOFoundationCompat
+import NIOPosix
+import SotoSignerV4
+
+import struct Foundation.Data
+import struct Foundation.Date
+import class Foundation.ISO8601DateFormatter
+import class Foundation.JSONDecoder
+import class Foundation.ProcessInfo
+import struct Foundation.TimeInterval
+import struct Foundation.URL
+
+// MARK: - SSO Credential Provider
+
+public struct SSOCredentialProvider: CredentialProvider {
+    private let configuration: SSOConfiguration?
+    private let profileName: String?
+    private let httpClient: AWSHTTPClient
+    private let threadPool: NIOThreadPool
+
+    /// Create an SSOCredentialProvider with explicit configuration (for testing)
+    init(configuration: SSOConfiguration, httpClient: AWSHTTPClient, threadPool: NIOThreadPool = .singleton) {
+        self.configuration = configuration
+        self.profileName = nil
+        self.httpClient = httpClient
+        self.threadPool = threadPool
+    }
+
+    /// Create an SSOCredentialProvider from profile configuration
+    /// - Parameters:
+    ///   - profileName: Name of the profile in ~/.aws/config (defaults to "default")
+    ///   - httpClient: HTTP client for making requests
+    public init(
+        profileName: String? = nil,
+        httpClient: AWSHTTPClient
+    ) {
+        self.configuration = nil
+        self.profileName = profileName
+        self.httpClient = httpClient
+        self.threadPool = .singleton
+    }
+
+    public func getCredential(logger: Logger) async throws -> Credential {
+        let profile = profileName ?? "default"
+        let config = try await getConfiguration()
+        let tokenManager = SSOTokenManager(httpClient: httpClient)
+        let fileIO = NonBlockingFileIO(threadPool: threadPool)
+
+        // Construct token cache path
+        let tokenPath = try tokenManager.constructTokenPath(config: config)
+
+        // Load token from cache (with automatic refresh if modern format)
+        let token: SSOToken
+        do {
+            token = try await tokenManager.getToken(
+                from: tokenPath,
+                config: config,
+                profileName: profile,
+                fileIO: fileIO,
+                threadPool: threadPool,
+                logger: logger
+            )
+        } catch let error as AWSSSOCredentialError where error.code == "invalidTokenFormat" {
+            throw AWSSSOCredentialError.tokenCacheNotFound(profile)
+        }
+
+        // Call SSO GetRoleCredentials API
+        let credentials = try await getRoleCredentials(
+            accessToken: token.accessToken,
+            accountId: config.ssoAccountId,
+            roleName: config.ssoRoleName,
+            region: config.ssoRegion,
+            logger: logger
+        )
+
+        // Return expiring credential
+        let expirationDate = Date(timeIntervalSince1970: TimeInterval(credentials.expiration / 1000))
+        return RotatingCredential(
+            accessKeyId: credentials.accessKeyId,
+            secretAccessKey: credentials.secretAccessKey,
+            sessionToken: credentials.sessionToken,
+            expiration: expirationDate
+        )
+    }
+
+    // MARK: - Configuration Loading
+
+    private func getConfiguration() async throws -> SSOConfiguration {
+        if let configuration = configuration {
+            return configuration
+        }
+        return try await loadConfiguration(profileName: profileName)
+    }
+
+    private func loadConfiguration(
+        profileName: String? = nil,
+        configPath: String? = nil
+    ) async throws -> SSOConfiguration {
+        let profile = profileName ?? "default"
+        let path = configPath ?? ConfigFileLoader.defaultProfileConfigPath
+
+        // Load INI file using ConfigFileLoader
+        let fileIO = NonBlockingFileIO(threadPool: .singleton)
+        let parser: INIParser
+        do {
+            parser = try await ConfigFileLoader.loadINIFile(path: path, fileIO: fileIO)
+        } catch {
+            throw AWSSSOCredentialError.configFileNotFound(path)
+        }
+
+        // Look for profile section
+        let profileKey = profile == "default" ? profile : "profile \(profile)"
+        guard let profileSection = parser.sections[profileKey] else {
+            throw AWSSSOCredentialError.profileNotFound(profile)
+        }
+
+        // Check for sso_session (modern format) or direct SSO fields (legacy format)
+        if let ssoSessionName = profileSection["sso_session"] {
+            // Modern format: Load from sso-session section
+            return try loadModernSSOConfig(
+                profileSection: profileSection,
+                ssoSessionName: ssoSessionName,
+                parser: parser,
+                profile: profile
+            )
+        } else {
+            // Legacy format: Load directly from profile
+            return try loadLegacySSOConfig(
+                profileSection: profileSection,
+                profile: profile
+            )
+        }
+    }
+
+    private func loadModernSSOConfig(
+        profileSection: [String: String],
+        ssoSessionName: String,
+        parser: INIParser,
+        profile: String
+    ) throws -> SSOConfiguration {
+        // Load sso-session section
+        let sessionKey = "sso-session \(ssoSessionName)"
+        guard let sessionSection = parser.sections[sessionKey] else {
+            throw AWSSSOCredentialError.ssoSessionNotFound(ssoSessionName)
+        }
+
+        // Required fields from sso-session
+        guard let ssoStartUrl = sessionSection["sso_start_url"] else {
+            throw AWSSSOCredentialError.ssoConfigMissing(profile)
+        }
+        guard let ssoRegionString = sessionSection["sso_region"] else {
+            throw AWSSSOCredentialError.ssoConfigMissing(profile)
+        }
+
+        // Required fields from profile
+        guard let ssoAccountId = profileSection["sso_account_id"] else {
+            throw AWSSSOCredentialError.ssoConfigMissing(profile)
+        }
+        guard let ssoRoleName = profileSection["sso_role_name"] else {
+            throw AWSSSOCredentialError.ssoConfigMissing(profile)
+        }
+
+        let region = profileSection["region"].map { Region(rawValue: $0) }
+
+        return SSOConfiguration(
+            ssoStartUrl: ssoStartUrl,
+            ssoRegion: Region(rawValue: ssoRegionString),
+            ssoAccountId: ssoAccountId,
+            ssoRoleName: ssoRoleName,
+            region: region,
+            sessionName: ssoSessionName
+        )
+    }
+
+    private func loadLegacySSOConfig(
+        profileSection: [String: String],
+        profile: String
+    ) throws -> SSOConfiguration {
+        guard let ssoStartUrl = profileSection["sso_start_url"] else {
+            throw AWSSSOCredentialError.ssoConfigMissing(profile)
+        }
+        guard let ssoRegionString = profileSection["sso_region"] else {
+            throw AWSSSOCredentialError.ssoConfigMissing(profile)
+        }
+        guard let ssoAccountId = profileSection["sso_account_id"] else {
+            throw AWSSSOCredentialError.ssoConfigMissing(profile)
+        }
+        guard let ssoRoleName = profileSection["sso_role_name"] else {
+            throw AWSSSOCredentialError.ssoConfigMissing(profile)
+        }
+
+        let region = profileSection["region"].map { Region(rawValue: $0) }
+
+        return SSOConfiguration(
+            ssoStartUrl: ssoStartUrl,
+            ssoRegion: Region(rawValue: ssoRegionString),
+            ssoAccountId: ssoAccountId,
+            ssoRoleName: ssoRoleName,
+            region: region,
+            sessionName: nil
+        )
+    }
+
+    // MARK: - SSO GetRoleCredentials API
+
+    private func getRoleCredentials(
+        accessToken: String,
+        accountId: String,
+        roleName: String,
+        region: Region,
+        logger: Logger
+    ) async throws -> SSORoleCredentials {
+        let endpoint = "portal.sso.\(region.rawValue).amazonaws.com"
+
+        // Build query string manually (cross-platform safe)
+        let query =
+            "role_name=\(RequestEncodingContainer.urlEncodeQueryParam(roleName))&account_id=\(RequestEncodingContainer.urlEncodeQueryParam(accountId))"
+        let urlString = "https://\(endpoint)/federation/credentials?\(query)"
+
+        guard let url = URL(string: urlString) else {
+            throw AWSSSOCredentialError.getRoleCredentialsFailed("Failed to construct SSO GetRoleCredentials URL")
+        }
+
+        var headers = HTTPHeaders()
+        headers.add(name: "x-amz-sso_bearer_token", value: accessToken)
+        headers.add(name: "Accept", value: "application/json")
+        headers.add(name: "Host", value: endpoint)
+
+        let request = AWSHTTPRequest(
+            url: url,
+            method: .GET,
+            headers: headers,
+            body: .init()
+        )
+
+        let response = try await httpClient.execute(request: request, timeout: .seconds(30), logger: logger)
+
+        guard (200...299).contains(response.status.code) else {
+            throw AWSSSOCredentialError.getRoleCredentialsFailed(
+                "HTTP \(response.status.code): Failed to get SSO credentials"
+            )
+        }
+
+        let body = try await response.body.collect(upTo: 1024 * 1024)
+        let decoder = JSONDecoder()
+        let apiResponse = try decoder.decode(SSOGetRoleCredentialsResponse.self, from: Data(buffer: body))
+
+        return apiResponse.roleCredentials
+    }
+
+}
+
+// MARK: - CredentialProviderFactory Extension
+
+extension CredentialProviderFactory {
+    /// Use AWS IAM Identity Center (SSO) credential provider
+    ///
+    /// This provider uses cached SSO session tokens to obtain temporary AWS credentials.
+    /// Users must authenticate with `aws sso login` before using this provider.
+    ///
+    /// Automatic token refresh:
+    /// - Modern sso-session format: Automatically refreshes expired tokens using OAuth refresh tokens
+    /// - Legacy format: Requires manual re-authentication with `aws sso login`
+    ///
+    /// - Parameters:
+    ///   - profileName: Name of the profile in ~/.aws/config (defaults to "default")
+    /// - Returns: A credential provider factory
+    public static func sso(
+        profileName: String? = nil
+    ) -> CredentialProviderFactory {
+        .custom { context in
+            let provider = SSOCredentialProvider(
+                profileName: profileName,
+                httpClient: context.httpClient
+            )
+            // Wrap in RotatingCredentialProvider for automatic credential rotation
+            return RotatingCredentialProvider(context: context, provider: provider)
+        }
+    }
+}

--- a/Sources/SotoCore/Credential/SSO/SSOCredentialProvider.swift
+++ b/Sources/SotoCore/Credential/SSO/SSOCredentialProvider.swift
@@ -34,6 +34,7 @@ import struct Foundation.URL
 public struct SSOCredentialProvider: CredentialProvider {
     private let configuration: SSOConfiguration?
     private let profileName: String?
+    private let configPath: String?
     private let httpClient: AWSHTTPClient
     private let threadPool: NIOThreadPool
 
@@ -41,6 +42,21 @@ public struct SSOCredentialProvider: CredentialProvider {
     init(configuration: SSOConfiguration, httpClient: AWSHTTPClient, threadPool: NIOThreadPool = .singleton) {
         self.configuration = configuration
         self.profileName = nil
+        self.configPath = nil
+        self.httpClient = httpClient
+        self.threadPool = threadPool
+    }
+
+    /// Create an SSOCredentialProvider with explicit config file path (for testing)
+    init(
+        profileName: String? = nil,
+        configPath: String,
+        httpClient: AWSHTTPClient,
+        threadPool: NIOThreadPool = .singleton
+    ) {
+        self.configuration = nil
+        self.profileName = profileName
+        self.configPath = configPath
         self.httpClient = httpClient
         self.threadPool = threadPool
     }
@@ -55,6 +71,7 @@ public struct SSOCredentialProvider: CredentialProvider {
     ) {
         self.configuration = nil
         self.profileName = profileName
+        self.configPath = nil
         self.httpClient = httpClient
         self.threadPool = .singleton
     }
@@ -103,7 +120,7 @@ public struct SSOCredentialProvider: CredentialProvider {
         if let configuration = configuration {
             return configuration
         }
-        return try await loadConfiguration(profileName: profileName)
+        return try await loadConfiguration(profileName: profileName, configPath: configPath)
     }
 
     private func loadConfiguration(

--- a/Sources/SotoCore/Credential/SSO/SSOCredentialProvider.swift
+++ b/Sources/SotoCore/Credential/SSO/SSOCredentialProvider.swift
@@ -69,19 +69,14 @@ public struct SSOCredentialProvider: CredentialProvider {
         let tokenPath = try tokenManager.constructTokenPath(config: config)
 
         // Load token from cache (with automatic refresh if modern format)
-        let token: SSOToken
-        do {
-            token = try await tokenManager.getToken(
-                from: tokenPath,
-                config: config,
-                profileName: profile,
-                fileIO: fileIO,
-                threadPool: threadPool,
-                logger: logger
-            )
-        } catch let error as AWSSSOCredentialError where error.code == "invalidTokenFormat" {
-            throw AWSSSOCredentialError.tokenCacheNotFound(profile)
-        }
+        let token = try await tokenManager.getToken(
+            from: tokenPath,
+            config: config,
+            profileName: profile,
+            fileIO: fileIO,
+            threadPool: threadPool,
+            logger: logger
+        )
 
         // Call SSO GetRoleCredentials API
         let credentials = try await getRoleCredentials(

--- a/Sources/SotoCore/Credential/SSO/SSODataStructures.swift
+++ b/Sources/SotoCore/Credential/SSO/SSODataStructures.swift
@@ -14,14 +14,11 @@
 
 // SSO Configuration, Token, and Error Types
 
-import struct Foundation.CharacterSet
-import struct Foundation.Data
-import struct Foundation.Date
-import class Foundation.ISO8601DateFormatter
-import class Foundation.JSONDecoder
-import class Foundation.JSONEncoder
-import struct Foundation.TimeInterval
-import struct Foundation.URL
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 // MARK: - SSO Configuration
 

--- a/Sources/SotoCore/Credential/SSO/SSODataStructures.swift
+++ b/Sources/SotoCore/Credential/SSO/SSODataStructures.swift
@@ -1,0 +1,168 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Soto for AWS open source project
+//
+// Copyright (c) 2017-2026 the Soto project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Soto project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+// SSO Configuration, Token, and Error Types
+
+import struct Foundation.CharacterSet
+import struct Foundation.Data
+import struct Foundation.Date
+import class Foundation.ISO8601DateFormatter
+import class Foundation.JSONDecoder
+import class Foundation.JSONEncoder
+import struct Foundation.TimeInterval
+import struct Foundation.URL
+
+// MARK: - SSO Configuration
+
+struct SSOConfiguration {
+    /// SSO start URL (e.g., https://d-90678022de.awsapps.com/start)
+    let ssoStartUrl: String
+    /// Region for SSO service
+    let ssoRegion: Region
+    /// AWS account ID
+    let ssoAccountId: String
+    /// IAM role name
+    let ssoRoleName: String
+    /// Target region for credentials (optional)
+    let region: Region?
+    /// Session name for modern format (enables refresh)
+    let sessionName: String?
+}
+
+// MARK: - SSO Token (cache file format)
+
+struct SSOToken: Codable {
+    /// OAuth access token
+    let accessToken: String
+    /// ISO8601 date string for expiration
+    let expiresAt: String
+    /// For token refresh (modern format only)
+    let refreshToken: String?
+    /// OAuth client ID (modern format only)
+    let clientId: String?
+    /// OAuth client secret (modern format only)
+    let clientSecret: String?
+    /// Client registration expiry (modern format only)
+    let registrationExpiresAt: String?
+    /// SSO start URL
+    let startUrl: String?
+    /// SSO region
+    let region: String?
+}
+
+// MARK: - SSO-OIDC CreateToken Response
+
+struct CreateTokenResponse: Codable {
+    let accessToken: String
+    let expiresIn: Int
+    let tokenType: String?
+    let refreshToken: String?
+}
+
+// MARK: - SSO GetRoleCredentials Response
+
+struct SSOGetRoleCredentialsResponse: Codable {
+    let roleCredentials: SSORoleCredentials
+}
+
+struct SSORoleCredentials: Codable {
+    let accessKeyId: String
+    let secretAccessKey: String
+    let sessionToken: String
+    /// Unix timestamp in milliseconds
+    let expiration: Int64
+}
+
+// MARK: - SSO Credential Error
+
+/// Error type for AWS SSO credential operations
+public struct AWSSSOCredentialError: Error, Equatable, CustomStringConvertible {
+    /// Error code identifying the type of error
+    public let code: String
+    /// Human-readable error message
+    public let message: String
+
+    private init(code: String, message: String) {
+        self.code = code
+        self.message = message
+    }
+
+    public var description: String {
+        "\(code): \(message)"
+    }
+
+    // MARK: - Predefined Error Types
+
+    /// Configuration file not found at specified path
+    public static func configFileNotFound(_ path: String) -> AWSSSOCredentialError {
+        AWSSSOCredentialError(code: "configFileNotFound", message: "Configuration file not found at path: \(path)")
+    }
+
+    /// Profile not found in configuration file
+    public static func profileNotFound(_ profile: String) -> AWSSSOCredentialError {
+        AWSSSOCredentialError(code: "profileNotFound", message: "Profile '\(profile)' not found in configuration file")
+    }
+
+    /// Profile missing SSO configuration
+    public static func ssoConfigMissing(_ profile: String) -> AWSSSOCredentialError {
+        AWSSSOCredentialError(
+            code: "ssoConfigMissing",
+            message: "Profile '\(profile)' does not have SSO configuration. Configure with 'aws configure sso'."
+        )
+    }
+
+    /// Referenced sso-session not found in config
+    public static func ssoSessionNotFound(_ sessionName: String) -> AWSSSOCredentialError {
+        AWSSSOCredentialError(code: "ssoSessionNotFound", message: "SSO session '\(sessionName)' not found in ~/.aws/config")
+    }
+
+    /// Token cache file not found - user needs to run 'aws sso login'
+    public static func tokenCacheNotFound(_ profile: String) -> AWSSSOCredentialError {
+        AWSSSOCredentialError(
+            code: "tokenCacheNotFound",
+            message: "SSO token not found. Run 'aws sso login --profile \(profile)' to authenticate."
+        )
+    }
+
+    /// Access token expired, no refresh token available
+    public static func tokenExpired(_ profile: String) -> AWSSSOCredentialError {
+        AWSSSOCredentialError(
+            code: "tokenExpired",
+            message: "SSO token expired. Run 'aws sso login --profile \(profile)' to re-authenticate."
+        )
+    }
+
+    /// Token refresh API call failed
+    public static func tokenRefreshFailed(_ reason: String) -> AWSSSOCredentialError {
+        AWSSSOCredentialError(code: "tokenRefreshFailed", message: reason)
+    }
+
+    /// OAuth client registration expired
+    public static func clientRegistrationExpired(_ profile: String) -> AWSSSOCredentialError {
+        AWSSSOCredentialError(
+            code: "clientRegistrationExpired",
+            message: "OAuth client registration expired. Run 'aws sso login --profile \(profile)' to re-register."
+        )
+    }
+
+    /// Corrupted cache file
+    public static func invalidTokenFormat(_ reason: String) -> AWSSSOCredentialError {
+        AWSSSOCredentialError(code: "invalidTokenFormat", message: reason)
+    }
+
+    /// SSO GetRoleCredentials API error
+    public static func getRoleCredentialsFailed(_ reason: String) -> AWSSSOCredentialError {
+        AWSSSOCredentialError(code: "getRoleCredentialsFailed", message: reason)
+    }
+}

--- a/Sources/SotoCore/Credential/SSO/SSOTokenManager.swift
+++ b/Sources/SotoCore/Credential/SSO/SSOTokenManager.swift
@@ -1,0 +1,247 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Soto for AWS open source project
+//
+// Copyright (c) 2017-2026 the Soto project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Soto project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+// SSO Token Cache Management - Disk I/O and Token Refresh
+
+import Crypto
+import Logging
+import NIOCore
+import NIOFoundationCompat
+import NIOPosix
+
+import struct Foundation.Data
+import struct Foundation.Date
+import class Foundation.ISO8601DateFormatter
+import class Foundation.JSONDecoder
+import class Foundation.JSONEncoder
+import class Foundation.ProcessInfo
+import struct Foundation.TimeInterval
+import struct Foundation.URL
+
+struct SSOTokenManager {
+    private let httpClient: AWSHTTPClient
+
+    /// Refresh window: start refreshing when token expires in less than 15 minutes (same as botocore)
+    let refreshWindow: TimeInterval = 15 * 60
+
+    init(httpClient: AWSHTTPClient) {
+        self.httpClient = httpClient
+    }
+
+    // MARK: - Token Path Construction
+
+    /// Construct the path to the cached SSO token file.
+    /// The filename is the SHA-1 hash of the cache key, hex-encoded, with .json extension.
+    /// - For modern format: cache key is the session name
+    /// - For legacy format: cache key is the SSO start URL
+    func constructTokenPath(config: SSOConfiguration) throws -> String {
+        guard let homeDir = ProcessInfo.processInfo.environment["HOME"] else {
+            throw AWSSSOCredentialError.invalidTokenFormat("Cannot determine HOME directory")
+        }
+        let baseDir = "\(homeDir)/.aws/sso/cache"
+
+        // Modern format uses session name as cache key, legacy uses start URL
+        let cacheKey = config.sessionName ?? config.ssoStartUrl
+        let keyData = Data(cacheKey.utf8)
+        let hash = Insecure.SHA1.hash(data: keyData)
+        let hashString = hash.compactMap { String(format: "%02x", $0) }.joined()
+
+        return "\(baseDir)/\(hashString).json"
+    }
+
+    // MARK: - Token Loading
+
+    func loadToken(from path: String, fileIO: NonBlockingFileIO) async throws -> SSOToken {
+        let byteBuffer: ByteBuffer
+        do {
+            byteBuffer = try await fileIO.withFileRegion(path: path) { fileRegion in
+                try await fileIO.read(
+                    fileHandle: fileRegion.fileHandle,
+                    byteCount: fileRegion.readableBytes,
+                    allocator: ByteBufferAllocator()
+                )
+            }
+        } catch {
+            throw AWSSSOCredentialError.invalidTokenFormat("Cannot read token file at \(path)")
+        }
+
+        guard let data = byteBuffer.getData(at: 0, length: byteBuffer.readableBytes) else {
+            throw AWSSSOCredentialError.invalidTokenFormat("Cannot read token data from \(path)")
+        }
+
+        let decoder = JSONDecoder()
+        guard let token = try? decoder.decode(SSOToken.self, from: data) else {
+            throw AWSSSOCredentialError.invalidTokenFormat("Failed to parse SSO token JSON at \(path)")
+        }
+
+        return token
+    }
+
+    // MARK: - Token Saving
+
+    func saveToken(_ token: SSOToken, to path: String, fileIO: NonBlockingFileIO, threadPool: NIOThreadPool) async throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .prettyPrinted
+        let data = try encoder.encode(token)
+
+        var buffer = ByteBufferAllocator().buffer(capacity: data.count)
+        buffer.writeBytes(data)
+
+        // Delete file if it exists to ensure clean write
+        _ = try? await threadPool.runIfActive { unlink(path) }
+
+        try await fileIO.withFileHandle(
+            path: path,
+            mode: .write,
+            flags: .allowFileCreation(posixMode: 0o600)
+        ) { fileHandle in
+            try await fileIO.write(fileHandle: fileHandle, buffer: buffer)
+        }
+    }
+
+    // MARK: - Token Retrieval with Refresh
+
+    /// Get a valid SSO token, refreshing if needed (modern format only).
+    func getToken(
+        from tokenPath: String,
+        config: SSOConfiguration,
+        profileName: String,
+        fileIO: NonBlockingFileIO,
+        threadPool: NIOThreadPool,
+        logger: Logger
+    ) async throws -> SSOToken {
+        var token = try await loadToken(from: tokenPath, fileIO: fileIO)
+
+        // Parse expiration
+        let formatter = ISO8601DateFormatter()
+        guard let expiration = formatter.date(from: token.expiresAt) else {
+            throw AWSSSOCredentialError.invalidTokenFormat("Invalid expiresAt date format: \(token.expiresAt)")
+        }
+
+        // Check if token needs refresh (within 15 min window)
+        if expiration.timeIntervalSinceNow < self.refreshWindow {
+            // Check if we have refresh capability (modern format)
+            guard let refreshToken = token.refreshToken,
+                let clientId = token.clientId,
+                let clientSecret = token.clientSecret
+            else {
+                // Legacy format or missing refresh fields - cannot refresh
+                guard expiration > Date() else {
+                    throw AWSSSOCredentialError.tokenExpired(profileName)
+                }
+                // Token hasn't actually expired yet, just within refresh window
+                return token
+            }
+
+            // Check client registration hasn't expired
+            if let regExpiry = token.registrationExpiresAt {
+                if let registrationExpiration = formatter.date(from: regExpiry) {
+                    guard registrationExpiration > Date() else {
+                        throw AWSSSOCredentialError.clientRegistrationExpired(profileName)
+                    }
+                }
+            }
+
+            logger.trace("SSO token expiring soon, refreshing via SSO-OIDC CreateToken")
+
+            // Refresh token via SSO-OIDC CreateToken API
+            let newToken = try await refreshAccessToken(
+                refreshToken: refreshToken,
+                clientId: clientId,
+                clientSecret: clientSecret,
+                region: config.ssoRegion,
+                originalToken: token,
+                logger: logger
+            )
+
+            // Save updated token to cache
+            try await saveToken(newToken, to: tokenPath, fileIO: fileIO, threadPool: threadPool)
+
+            token = newToken
+        }
+
+        return token
+    }
+
+    // MARK: - Token Refresh via SSO-OIDC CreateToken
+
+    private func refreshAccessToken(
+        refreshToken: String,
+        clientId: String,
+        clientSecret: String,
+        region: Region,
+        originalToken: SSOToken,
+        logger: Logger
+    ) async throws -> SSOToken {
+        let endpoint = "oidc.\(region.rawValue).amazonaws.com"
+
+        // Build form-encoded body manually
+        let formParams = [
+            "grant_type=refresh_token",
+            "client_id=\(RequestEncodingContainer.urlEncodeQueryParam(clientId))",
+            "client_secret=\(RequestEncodingContainer.urlEncodeQueryParam(clientSecret))",
+            "refresh_token=\(RequestEncodingContainer.urlEncodeQueryParam(refreshToken))",
+        ]
+        let bodyString = formParams.joined(separator: "&")
+        let bodyData = Data(bodyString.utf8)
+
+        // Create HTTP request
+        var headers = HTTPHeaders()
+        headers.add(name: "Content-Type", value: "application/x-www-form-urlencoded")
+        headers.add(name: "Accept", value: "application/json")
+        headers.add(name: "Host", value: endpoint)
+        headers.add(name: "Content-Length", value: "\(bodyData.count)")
+
+        guard let url = URL(string: "https://\(endpoint)/token") else {
+            throw AWSSSOCredentialError.tokenRefreshFailed("Failed to construct SSO-OIDC endpoint URL")
+        }
+
+        let request = AWSHTTPRequest(
+            url: url,
+            method: .POST,
+            headers: headers,
+            body: .init(bytes: bodyData)
+        )
+
+        // Execute request (no signing - uses OAUTH client credentials)
+        let response = try await httpClient.execute(request: request, timeout: .seconds(30), logger: logger)
+
+        guard (200...299).contains(response.status.code) else {
+            throw AWSSSOCredentialError.tokenRefreshFailed(
+                "Failed to refresh SSO token: HTTP \(response.status.code)"
+            )
+        }
+
+        let body = try await response.body.collect(upTo: 1024 * 1024)
+        let decoder = JSONDecoder()
+        let tokenResponse = try decoder.decode(CreateTokenResponse.self, from: Data(buffer: body))
+
+        // Calculate new expiration
+        let newExpiration = Date(timeIntervalSinceNow: TimeInterval(tokenResponse.expiresIn))
+        let formatter = ISO8601DateFormatter()
+
+        // Return updated token, preserving original fields where new values not provided
+        return SSOToken(
+            accessToken: tokenResponse.accessToken,
+            expiresAt: formatter.string(from: newExpiration),
+            refreshToken: tokenResponse.refreshToken ?? refreshToken,
+            clientId: clientId,
+            clientSecret: clientSecret,
+            registrationExpiresAt: originalToken.registrationExpiresAt,
+            startUrl: originalToken.startUrl,
+            region: originalToken.region
+        )
+    }
+
+}

--- a/Sources/SotoCore/Credential/SSO/SSOTokenManager.swift
+++ b/Sources/SotoCore/Credential/SSO/SSOTokenManager.swift
@@ -85,12 +85,8 @@ struct SSOTokenManager {
             throw AWSSSOCredentialError.tokenCacheNotFound(profileName)
         }
 
-        guard let data = byteBuffer.getData(at: 0, length: byteBuffer.readableBytes) else {
-            throw AWSSSOCredentialError.invalidTokenFormat("Cannot read token data from \(path)")
-        }
-
         let decoder = JSONDecoder()
-        guard let token = try? decoder.decode(SSOToken.self, from: data) else {
+        guard let token = try? decoder.decode(SSOToken.self, from: byteBuffer) else {
             throw AWSSSOCredentialError.invalidTokenFormat("Failed to parse SSO token JSON at \(path)")
         }
 
@@ -232,7 +228,7 @@ struct SSOTokenManager {
 
         let body = try await response.body.collect(upTo: 1024 * 1024)
         let decoder = JSONDecoder()
-        let tokenResponse = try decoder.decode(CreateTokenResponse.self, from: Data(buffer: body))
+        let tokenResponse = try decoder.decode(CreateTokenResponse.self, from: body)
 
         // Calculate new expiration
         let newExpiration = Date(timeIntervalSinceNow: TimeInterval(tokenResponse.expiresIn))

--- a/Sources/SotoCore/Credential/SSO/SSOTokenManager.swift
+++ b/Sources/SotoCore/Credential/SSO/SSOTokenManager.swift
@@ -254,24 +254,7 @@ struct SSOTokenManager {
     /// Parse an ISO8601 date string, handling both with and without fractional seconds.
     /// AWS CLI writes dates with fractional seconds (e.g., "2026-02-18T16:59:23.216Z").
     /// but not all token files have them.
-    /// Date.ISO8601FormatStyle(includingFractionalSeconds:true) only parses strings with fractional seconds
-    /// it rejects 2026-02-18T16:59:23Z. And .iso8601 only parses strings without fractional seconds.                  
-    /// So we try fractional first (most common from AWS CLI), fall back to without.                                                                                       
     func parseISO8601Date(_ string: String) -> Date? {
-        #if canImport(FoundationEssentials)
-        if let date = try? Date(string, strategy: Date.ISO8601FormatStyle(includingFractionalSeconds: true)) {
-            return date
-        }
-        return try? Date(string, strategy: .iso8601)
-        #else
-        if #available(iOS 15, macOS 12, tvOS 15, watchOS 8, *) {
-            if let date = try? Date(string, strategy: Date.ISO8601FormatStyle(includingFractionalSeconds: true)) {
-                return date
-            }
-            return try? Date(string, strategy: .iso8601)
-        } else {
-            return ISO8601DateCoder.dateFormatters.lazy.compactMap { $0.date(from: string) }.first
-        }
-        #endif
+        ISO8601DateCoder.dateFormatters.lazy.compactMap { $0.date(from: string) }.first
     }
 }

--- a/Sources/SotoCore/Credential/SSO/SSOTokenManager.swift
+++ b/Sources/SotoCore/Credential/SSO/SSOTokenManager.swift
@@ -240,7 +240,7 @@ struct SSOTokenManager {
         // Return updated token, preserving original fields where new values not provided
         return SSOToken(
             accessToken: tokenResponse.accessToken,
-            expiresAt: ISO8601DateCoder.string(from: newExpiration) ?? "",
+            expiresAt: formatISO8601Date(newExpiration) ?? "",
             refreshToken: tokenResponse.refreshToken ?? refreshToken,
             clientId: clientId,
             clientSecret: clientSecret,
@@ -285,5 +285,19 @@ struct SSOTokenManager {
         }
         #endif
         return nil
+    }
+
+    func formatISO8601Date(_ date: Date) -> String? {
+        #if canImport(FoundationEssentials)
+        return date.formatted(Date.ISO8601FormatStyle(includingFractionalSeconds: true))
+        #else
+        if #available(iOS 15, macOS 12, tvOS 15, watchOS 8, *) {
+            return date.formatted(Date.ISO8601FormatStyle(includingFractionalSeconds: true))
+        } else {
+            let formatterWithSeconds = ISO8601DateFormatter()
+            formatterWithSeconds.formatOptions = [.withFullDate, .withFullTime, .withFractionalSeconds]
+            return formatterWithSeconds.string(from: date)
+        }
+        #endif        
     }
 }

--- a/Sources/SotoCore/Credential/SSO/SSOTokenManager.swift
+++ b/Sources/SotoCore/Credential/SSO/SSOTokenManager.swift
@@ -294,6 +294,6 @@ struct SSOTokenManager {
             formatterWithSeconds.formatOptions = [.withFullDate, .withFullTime, .withFractionalSeconds]
             return formatterWithSeconds.string(from: date)
         }
-        #endif        
+        #endif
     }
 }

--- a/Tests/SotoCoreTests/Credential/SSO/SSOCredentialProviderTests.swift
+++ b/Tests/SotoCoreTests/Credential/SSO/SSOCredentialProviderTests.swift
@@ -1,0 +1,758 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Soto for AWS open source project
+//
+// Copyright (c) 2017-2025 the Soto project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Soto project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+// SSO Credential Provider Tests
+
+import Crypto
+import Foundation
+import Logging
+import NIOCore
+import NIOHTTP1
+import Testing
+
+@testable import SotoCore
+
+@Suite("SSO Credential Provider", .serialized)
+final class SSOCredentialProviderTests {
+
+    // MARK: - Configuration Parsing Tests
+
+    @Test("Parse modern SSO config with sso-session reference")
+    func parseModernSSOConfig() async throws {
+        try await withTempDirectory { tempDirectory in
+            // Create config file
+            let configContent = """
+                [profile test]
+                sso_session = my-sso
+                sso_account_id = 123456789012
+                sso_role_name = TestRole
+                region = us-east-1
+
+                [sso-session my-sso]
+                sso_start_url = https://test.awsapps.com/start
+                sso_region = us-west-2
+                """
+
+            // Create a valid token file so the provider doesn't fail before we test config
+            let futureDate = ISO8601DateFormatter().string(from: Date(timeIntervalSinceNow: 3600))
+            let tokenJSON = """
+                {
+                    "accessToken": "test-access-token",
+                    "expiresAt": "\(futureDate)",
+                    "startUrl": "https://test.awsapps.com/start",
+                    "region": "us-west-2"
+                }
+                """
+
+            // The modern format uses session name as cache key
+            let cacheDir = tempDirectory.appendingPathComponent(".aws/sso/cache")
+            try FileManager.default.createDirectory(at: cacheDir, withIntermediateDirectories: true)
+            _ = try createTokenFile(cacheKey: "my-sso", tokenJSON: tokenJSON, inDirectory: cacheDir)
+
+            // Mock HTTP client for GetRoleCredentials
+            let mockHTTPClient = MockAWSHTTPClient { request in
+                // Verify it's a GetRoleCredentials request
+                #expect(request.headers["x-amz-sso_bearer_token"].first == "test-access-token")
+                let urlString = request.url.absoluteString
+                #expect(urlString.contains("role_name=TestRole"))
+                #expect(urlString.contains("account_id=123456789012"))
+                #expect(urlString.contains("portal.sso.us-west-2.amazonaws.com"))
+
+                let responseJSON = """
+                    {
+                        "roleCredentials": {
+                            "accessKeyId": "AKIATEST123",
+                            "secretAccessKey": "testsecret",
+                            "sessionToken": "testsession",
+                            "expiration": \(Int64(Date(timeIntervalSinceNow: 3600).timeIntervalSince1970 * 1000))
+                        }
+                    }
+                    """
+                return (.ok, responseJSON.data(using: .utf8)!)
+            }
+
+            // Write config to temp file
+            let configPath = tempDirectory.appendingPathComponent("config")
+            try configContent.write(to: configPath, atomically: true, encoding: .utf8)
+
+            // Temporarily override HOME for token path resolution
+            try await withEnvironmentVariables(["HOME": tempDirectory.path]) {
+                // Create provider with explicit config to test parsing
+                let config = SSOConfiguration(
+                    ssoStartUrl: "https://test.awsapps.com/start",
+                    ssoRegion: .uswest2,
+                    ssoAccountId: "123456789012",
+                    ssoRoleName: "TestRole",
+                    region: .useast1,
+                    sessionName: "my-sso"
+                )
+
+                let provider = SSOCredentialProvider(
+                    configuration: config,
+                    httpClient: mockHTTPClient
+                )
+
+                let logger = Logger(label: "test")
+                let credential = try await provider.getCredential(logger: logger)
+
+                #expect(credential.accessKeyId == "AKIATEST123")
+                #expect(credential.secretAccessKey == "testsecret")
+                #expect(credential.sessionToken == "testsession")
+            }
+        }
+    }
+
+    @Test("Parse legacy SSO config with direct SSO fields")
+    func parseLegacySSOConfig() async throws {
+        try await withTempDirectory { tempDirectory in
+            let futureDate = ISO8601DateFormatter().string(from: Date(timeIntervalSinceNow: 3600))
+            let tokenJSON = """
+                {
+                    "accessToken": "legacy-access-token",
+                    "expiresAt": "\(futureDate)"
+                }
+                """
+
+            // Legacy format uses start URL as cache key
+            let cacheDir = tempDirectory.appendingPathComponent(".aws/sso/cache")
+            try FileManager.default.createDirectory(at: cacheDir, withIntermediateDirectories: true)
+            _ = try createTokenFile(
+                cacheKey: "https://test.awsapps.com/start",
+                tokenJSON: tokenJSON,
+                inDirectory: cacheDir
+            )
+
+            let mockHTTPClient = MockAWSHTTPClient { request in
+                #expect(request.headers["x-amz-sso_bearer_token"].first == "legacy-access-token")
+
+                let responseJSON = """
+                    {
+                        "roleCredentials": {
+                            "accessKeyId": "AKIALEGACY",
+                            "secretAccessKey": "legacysecret",
+                            "sessionToken": "legacysession",
+                            "expiration": \(Int64(Date(timeIntervalSinceNow: 3600).timeIntervalSince1970 * 1000))
+                        }
+                    }
+                    """
+                return (.ok, responseJSON.data(using: .utf8)!)
+            }
+
+            try await withEnvironmentVariables(["HOME": tempDirectory.path]) {
+                // Legacy config (no sessionName)
+                let config = SSOConfiguration(
+                    ssoStartUrl: "https://test.awsapps.com/start",
+                    ssoRegion: .useast1,
+                    ssoAccountId: "123456789012",
+                    ssoRoleName: "TestRole",
+                    region: .useast1,
+                    sessionName: nil
+                )
+
+                let provider = SSOCredentialProvider(
+                    configuration: config,
+                    httpClient: mockHTTPClient
+                )
+
+                let logger = Logger(label: "test")
+                let credential = try await provider.getCredential(logger: logger)
+
+                #expect(credential.accessKeyId == "AKIALEGACY")
+                #expect(credential.secretAccessKey == "legacysecret")
+                #expect(credential.sessionToken == "legacysession")
+            }
+        }
+    }
+
+    // MARK: - Token Cache Tests
+
+    @Test("Token cache not found throws tokenCacheNotFound error")
+    func tokenCacheNotFound() async throws {
+        try await withTempDirectory { tempDirectory in
+            // Create cache directory but no token file
+            let cacheDir = tempDirectory.appendingPathComponent(".aws/sso/cache")
+            try FileManager.default.createDirectory(at: cacheDir, withIntermediateDirectories: true)
+
+            try await withEnvironmentVariables(["HOME": tempDirectory.path]) {
+                let config = SSOConfiguration(
+                    ssoStartUrl: "https://nonexistent.awsapps.com/start",
+                    ssoRegion: .useast1,
+                    ssoAccountId: "123456789012",
+                    ssoRoleName: "TestRole",
+                    region: .useast1,
+                    sessionName: nil
+                )
+
+                let provider = SSOCredentialProvider(
+                    configuration: config,
+                    httpClient: MockAWSHTTPClient()
+                )
+
+                let logger = Logger(label: "test")
+                let error = await #expect(throws: AWSSSOCredentialError.self) {
+                    try await provider.getCredential(logger: logger)
+                }
+                #expect(error?.code == "tokenCacheNotFound")
+            }
+        }
+    }
+
+    @Test("Expired legacy token without refresh throws tokenExpired error")
+    func expiredLegacyToken() async throws {
+        try await withTempDirectory { tempDirectory in
+            let pastDate = ISO8601DateFormatter().string(from: Date(timeIntervalSinceNow: -3600))
+            let tokenJSON = """
+                {
+                    "accessToken": "expired-token",
+                    "expiresAt": "\(pastDate)"
+                }
+                """
+
+            let cacheDir = tempDirectory.appendingPathComponent(".aws/sso/cache")
+            try FileManager.default.createDirectory(at: cacheDir, withIntermediateDirectories: true)
+            _ = try createTokenFile(
+                cacheKey: "https://test.awsapps.com/start",
+                tokenJSON: tokenJSON,
+                inDirectory: cacheDir
+            )
+
+            try await withEnvironmentVariables(["HOME": tempDirectory.path]) {
+                let config = SSOConfiguration(
+                    ssoStartUrl: "https://test.awsapps.com/start",
+                    ssoRegion: .useast1,
+                    ssoAccountId: "123456789012",
+                    ssoRoleName: "TestRole",
+                    region: .useast1,
+                    sessionName: nil
+                )
+
+                let provider = SSOCredentialProvider(
+                    configuration: config,
+                    httpClient: MockAWSHTTPClient()
+                )
+
+                let logger = Logger(label: "test")
+                let error = await #expect(throws: AWSSSOCredentialError.self) {
+                    try await provider.getCredential(logger: logger)
+                }
+                #expect(error?.code == "tokenExpired")
+            }
+        }
+    }
+
+    // MARK: - Token Refresh Tests (Modern Format)
+
+    @Test("Modern token within refresh window triggers refresh")
+    func modernTokenRefresh() async throws {
+        try await withTempDirectory { tempDirectory in
+            // Token expiring in 10 minutes (within 15 minute refresh window)
+            let soonDate = ISO8601DateFormatter().string(from: Date(timeIntervalSinceNow: 10 * 60))
+            let futureRegDate = ISO8601DateFormatter().string(from: Date(timeIntervalSinceNow: 90 * 24 * 60 * 60))
+
+            let tokenJSON = """
+                {
+                    "accessToken": "expiring-soon-token",
+                    "expiresAt": "\(soonDate)",
+                    "refreshToken": "refresh-token-value",
+                    "clientId": "client-id",
+                    "clientSecret": "client-secret",
+                    "registrationExpiresAt": "\(futureRegDate)",
+                    "startUrl": "https://test.awsapps.com/start",
+                    "region": "us-east-1"
+                }
+                """
+
+            let cacheDir = tempDirectory.appendingPathComponent(".aws/sso/cache")
+            try FileManager.default.createDirectory(at: cacheDir, withIntermediateDirectories: true)
+            let tokenPath = try createTokenFile(
+                cacheKey: "my-sso",
+                tokenJSON: tokenJSON,
+                inDirectory: cacheDir
+            )
+
+            let refreshTestCounter = RequestCounter()
+            let mockHTTPClient = MockAWSHTTPClient { request in
+                await refreshTestCounter.record(request.url.absoluteString)
+
+                if request.url.absoluteString.contains("oidc.") {
+                    // SSO-OIDC CreateToken refresh request
+                    #expect(request.method == .POST)
+                    #expect(request.headers["Content-Type"].first == "application/x-www-form-urlencoded")
+
+                    let bodyBuffer = try await request.body.collect(upTo: 1024 * 1024)
+                    let bodyString = String(buffer: bodyBuffer)
+                    #expect(bodyString.contains("grant_type=refresh_token"))
+                    #expect(bodyString.contains("client_id=client-id"))
+                    #expect(bodyString.contains("refresh_token=refresh-token-value"))
+
+                    let responseJSON = """
+                        {
+                            "accessToken": "refreshed-access-token",
+                            "expiresIn": 28800,
+                            "tokenType": "Bearer",
+                            "refreshToken": "new-refresh-token"
+                        }
+                        """
+                    return (.ok, responseJSON.data(using: .utf8)!)
+                } else {
+                    // SSO GetRoleCredentials request
+                    #expect(request.headers["x-amz-sso_bearer_token"].first == "refreshed-access-token")
+
+                    let responseJSON = """
+                        {
+                            "roleCredentials": {
+                                "accessKeyId": "AKIAREFRESHED",
+                                "secretAccessKey": "refreshedsecret",
+                                "sessionToken": "refreshedsession",
+                                "expiration": \(Int64(Date(timeIntervalSinceNow: 3600).timeIntervalSince1970 * 1000))
+                            }
+                        }
+                        """
+                    return (.ok, responseJSON.data(using: .utf8)!)
+                }
+            }
+
+            try await withEnvironmentVariables(["HOME": tempDirectory.path]) {
+                let config = SSOConfiguration(
+                    ssoStartUrl: "https://test.awsapps.com/start",
+                    ssoRegion: .useast1,
+                    ssoAccountId: "123456789012",
+                    ssoRoleName: "TestRole",
+                    region: .useast1,
+                    sessionName: "my-sso"
+                )
+
+                let provider = SSOCredentialProvider(
+                    configuration: config,
+                    httpClient: mockHTTPClient
+                )
+
+                let logger = Logger(label: "test")
+                let credential = try await provider.getCredential(logger: logger)
+
+                // Should have made both refresh and GetRoleCredentials requests
+                let refreshUrls = await refreshTestCounter.urls
+                #expect(refreshUrls.count == 2)
+                #expect(credential.accessKeyId == "AKIAREFRESHED")
+                #expect(credential.secretAccessKey == "refreshedsecret")
+                #expect(credential.sessionToken == "refreshedsession")
+
+                // Verify token file was updated with refreshed token
+                let updatedTokenData = try Data(contentsOf: tokenPath)
+                let updatedToken = try JSONDecoder().decode(SSOToken.self, from: updatedTokenData)
+                #expect(updatedToken.accessToken == "refreshed-access-token")
+                #expect(updatedToken.refreshToken == "new-refresh-token")
+                #expect(updatedToken.clientId == "client-id")
+                #expect(updatedToken.clientSecret == "client-secret")
+            }
+        }
+    }
+
+    @Test("Token refresh failure throws tokenRefreshFailed error")
+    func tokenRefreshFailure() async throws {
+        try await withTempDirectory { tempDirectory in
+            let soonDate = ISO8601DateFormatter().string(from: Date(timeIntervalSinceNow: 10 * 60))
+            let futureRegDate = ISO8601DateFormatter().string(from: Date(timeIntervalSinceNow: 90 * 24 * 60 * 60))
+
+            let tokenJSON = """
+                {
+                    "accessToken": "expiring-soon-token",
+                    "expiresAt": "\(soonDate)",
+                    "refreshToken": "refresh-token-value",
+                    "clientId": "client-id",
+                    "clientSecret": "client-secret",
+                    "registrationExpiresAt": "\(futureRegDate)",
+                    "startUrl": "https://test.awsapps.com/start",
+                    "region": "us-east-1"
+                }
+                """
+
+            let cacheDir = tempDirectory.appendingPathComponent(".aws/sso/cache")
+            try FileManager.default.createDirectory(at: cacheDir, withIntermediateDirectories: true)
+            _ = try createTokenFile(cacheKey: "my-sso", tokenJSON: tokenJSON, inDirectory: cacheDir)
+
+            let mockHTTPClient = MockAWSHTTPClient { _ in
+                // Return error for refresh request
+                (.badRequest, Data())
+            }
+
+            try await withEnvironmentVariables(["HOME": tempDirectory.path]) {
+                let config = SSOConfiguration(
+                    ssoStartUrl: "https://test.awsapps.com/start",
+                    ssoRegion: .useast1,
+                    ssoAccountId: "123456789012",
+                    ssoRoleName: "TestRole",
+                    region: .useast1,
+                    sessionName: "my-sso"
+                )
+
+                let provider = SSOCredentialProvider(
+                    configuration: config,
+                    httpClient: mockHTTPClient
+                )
+
+                let logger = Logger(label: "test")
+                let error = await #expect(throws: AWSSSOCredentialError.self) {
+                    try await provider.getCredential(logger: logger)
+                }
+                #expect(error?.code == "tokenRefreshFailed")
+            }
+        }
+    }
+
+    @Test("Client registration expired throws clientRegistrationExpired error")
+    func clientRegistrationExpired() async throws {
+        try await withTempDirectory { tempDirectory in
+            let soonDate = ISO8601DateFormatter().string(from: Date(timeIntervalSinceNow: 10 * 60))
+            // Client registration already expired
+            let pastRegDate = ISO8601DateFormatter().string(from: Date(timeIntervalSinceNow: -3600))
+
+            let tokenJSON = """
+                {
+                    "accessToken": "expiring-soon-token",
+                    "expiresAt": "\(soonDate)",
+                    "refreshToken": "refresh-token-value",
+                    "clientId": "client-id",
+                    "clientSecret": "client-secret",
+                    "registrationExpiresAt": "\(pastRegDate)",
+                    "startUrl": "https://test.awsapps.com/start",
+                    "region": "us-east-1"
+                }
+                """
+
+            let cacheDir = tempDirectory.appendingPathComponent(".aws/sso/cache")
+            try FileManager.default.createDirectory(at: cacheDir, withIntermediateDirectories: true)
+            _ = try createTokenFile(cacheKey: "my-sso", tokenJSON: tokenJSON, inDirectory: cacheDir)
+
+            try await withEnvironmentVariables(["HOME": tempDirectory.path]) {
+                let config = SSOConfiguration(
+                    ssoStartUrl: "https://test.awsapps.com/start",
+                    ssoRegion: .useast1,
+                    ssoAccountId: "123456789012",
+                    ssoRoleName: "TestRole",
+                    region: .useast1,
+                    sessionName: "my-sso"
+                )
+
+                let provider = SSOCredentialProvider(
+                    configuration: config,
+                    httpClient: MockAWSHTTPClient()
+                )
+
+                let logger = Logger(label: "test")
+                let error = await #expect(throws: AWSSSOCredentialError.self) {
+                    try await provider.getCredential(logger: logger)
+                }
+                #expect(error?.code == "clientRegistrationExpired")
+            }
+        }
+    }
+
+    // MARK: - GetRoleCredentials API Tests
+
+    @Test("GetRoleCredentials HTTP error throws getRoleCredentialsFailed")
+    func getRoleCredentialsHTTPError() async throws {
+        try await withTempDirectory { tempDirectory in
+            let futureDate = ISO8601DateFormatter().string(from: Date(timeIntervalSinceNow: 3600))
+            let tokenJSON = """
+                {
+                    "accessToken": "valid-token",
+                    "expiresAt": "\(futureDate)"
+                }
+                """
+
+            let cacheDir = tempDirectory.appendingPathComponent(".aws/sso/cache")
+            try FileManager.default.createDirectory(at: cacheDir, withIntermediateDirectories: true)
+            _ = try createTokenFile(
+                cacheKey: "https://test.awsapps.com/start",
+                tokenJSON: tokenJSON,
+                inDirectory: cacheDir
+            )
+
+            let mockHTTPClient = MockAWSHTTPClient { _ in
+                (.forbidden, Data())
+            }
+
+            try await withEnvironmentVariables(["HOME": tempDirectory.path]) {
+                let config = SSOConfiguration(
+                    ssoStartUrl: "https://test.awsapps.com/start",
+                    ssoRegion: .useast1,
+                    ssoAccountId: "123456789012",
+                    ssoRoleName: "TestRole",
+                    region: .useast1,
+                    sessionName: nil
+                )
+
+                let provider = SSOCredentialProvider(
+                    configuration: config,
+                    httpClient: mockHTTPClient
+                )
+
+                let logger = Logger(label: "test")
+                let error = await #expect(throws: AWSSSOCredentialError.self) {
+                    try await provider.getCredential(logger: logger)
+                }
+                #expect(error?.code == "getRoleCredentialsFailed")
+                #expect(error?.message.contains("403") == true)
+            }
+        }
+    }
+
+    // MARK: - Token Path Construction Tests
+
+    @Test("Token path uses SHA-1 hash of session name for modern format")
+    func tokenPathModernFormat() throws {
+        let tokenManager = SSOTokenManager(httpClient: MockAWSHTTPClient())
+        let config = SSOConfiguration(
+            ssoStartUrl: "https://test.awsapps.com/start",
+            ssoRegion: .useast1,
+            ssoAccountId: "123456789012",
+            ssoRoleName: "TestRole",
+            region: .useast1,
+            sessionName: "my-sso"
+        )
+
+        let path = try tokenManager.constructTokenPath(config: config)
+
+        // Should use session name as cache key
+        let expectedHash = Insecure.SHA1.hash(data: Data("my-sso".utf8))
+            .compactMap { String(format: "%02x", $0) }.joined()
+        #expect(path.hasSuffix("\(expectedHash).json"))
+        #expect(path.contains(".aws/sso/cache"))
+    }
+
+    @Test("Token path uses SHA-1 hash of start URL for legacy format")
+    func tokenPathLegacyFormat() throws {
+        let tokenManager = SSOTokenManager(httpClient: MockAWSHTTPClient())
+        let config = SSOConfiguration(
+            ssoStartUrl: "https://test.awsapps.com/start",
+            ssoRegion: .useast1,
+            ssoAccountId: "123456789012",
+            ssoRoleName: "TestRole",
+            region: .useast1,
+            sessionName: nil
+        )
+
+        let path = try tokenManager.constructTokenPath(config: config)
+
+        // Should use start URL as cache key
+        let expectedHash = Insecure.SHA1.hash(data: Data("https://test.awsapps.com/start".utf8))
+            .compactMap { String(format: "%02x", $0) }.joined()
+        #expect(path.hasSuffix("\(expectedHash).json"))
+        #expect(path.contains(".aws/sso/cache"))
+    }
+
+    // MARK: - Valid Token (No Refresh Needed) Tests
+
+    @Test("Valid token does not trigger refresh or HTTP call for token")
+    func validTokenNoRefresh() async throws {
+        try await withTempDirectory { tempDirectory in
+            // Token with plenty of time left (2 hours)
+            let futureDate = ISO8601DateFormatter().string(from: Date(timeIntervalSinceNow: 2 * 60 * 60))
+            let tokenJSON = """
+                {
+                    "accessToken": "valid-token",
+                    "expiresAt": "\(futureDate)",
+                    "refreshToken": "refresh-token",
+                    "clientId": "client-id",
+                    "clientSecret": "client-secret",
+                    "startUrl": "https://test.awsapps.com/start",
+                    "region": "us-east-1"
+                }
+                """
+
+            let cacheDir = tempDirectory.appendingPathComponent(".aws/sso/cache")
+            try FileManager.default.createDirectory(at: cacheDir, withIntermediateDirectories: true)
+            _ = try createTokenFile(cacheKey: "my-sso", tokenJSON: tokenJSON, inDirectory: cacheDir)
+
+            let requestCounter = RequestCounter()
+            let mockHTTPClient = MockAWSHTTPClient { request in
+                await requestCounter.record(request.url.absoluteString)
+
+                let responseJSON = """
+                    {
+                        "roleCredentials": {
+                            "accessKeyId": "AKIAVALID",
+                            "secretAccessKey": "validsecret",
+                            "sessionToken": "validsession",
+                            "expiration": \(Int64(Date(timeIntervalSinceNow: 3600).timeIntervalSince1970 * 1000))
+                        }
+                    }
+                    """
+                return (.ok, responseJSON.data(using: .utf8)!)
+            }
+
+            try await withEnvironmentVariables(["HOME": tempDirectory.path]) {
+                let config = SSOConfiguration(
+                    ssoStartUrl: "https://test.awsapps.com/start",
+                    ssoRegion: .useast1,
+                    ssoAccountId: "123456789012",
+                    ssoRoleName: "TestRole",
+                    region: .useast1,
+                    sessionName: "my-sso"
+                )
+
+                let provider = SSOCredentialProvider(
+                    configuration: config,
+                    httpClient: mockHTTPClient
+                )
+
+                let logger = Logger(label: "test")
+                let credential = try await provider.getCredential(logger: logger)
+
+                // Only one request (GetRoleCredentials), no OIDC refresh
+                let urls = await requestCounter.urls
+                #expect(urls.count == 1)
+                #expect(urls[0].contains("portal.sso"))
+                #expect(!urls[0].contains("oidc"))
+
+                #expect(credential.accessKeyId == "AKIAVALID")
+            }
+        }
+    }
+
+    // MARK: - Error Type Tests
+
+    @Test("AWSSSOCredentialError is Equatable")
+    func errorEquatable() {
+        let error1 = AWSSSOCredentialError.profileNotFound("test")
+        let error2 = AWSSSOCredentialError.profileNotFound("test")
+        let error3 = AWSSSOCredentialError.tokenExpired("test")
+
+        #expect(error1 == error2)
+        #expect(error1 != error3)
+    }
+
+    @Test("AWSSSOCredentialError description format")
+    func errorDescription() {
+        let error = AWSSSOCredentialError.profileNotFound("dev")
+        #expect(error.description.contains("profileNotFound"))
+        #expect(error.description.contains("dev"))
+    }
+
+    // MARK: - Invalid Response Tests
+
+    @Test("Invalid GetRoleCredentials JSON throws decoding error")
+    func invalidGetRoleCredentialsResponse() async throws {
+        try await withTempDirectory { tempDirectory in
+            let futureDate = ISO8601DateFormatter().string(from: Date(timeIntervalSinceNow: 3600))
+            let tokenJSON = """
+                {
+                    "accessToken": "valid-token",
+                    "expiresAt": "\(futureDate)"
+                }
+                """
+
+            let cacheDir = tempDirectory.appendingPathComponent(".aws/sso/cache")
+            try FileManager.default.createDirectory(at: cacheDir, withIntermediateDirectories: true)
+            _ = try createTokenFile(
+                cacheKey: "https://test.awsapps.com/start",
+                tokenJSON: tokenJSON,
+                inDirectory: cacheDir
+            )
+
+            let mockHTTPClient = MockAWSHTTPClient { _ in
+                (.ok, "invalid json".data(using: .utf8)!)
+            }
+
+            try await withEnvironmentVariables(["HOME": tempDirectory.path]) {
+                let config = SSOConfiguration(
+                    ssoStartUrl: "https://test.awsapps.com/start",
+                    ssoRegion: .useast1,
+                    ssoAccountId: "123456789012",
+                    ssoRoleName: "TestRole",
+                    region: .useast1,
+                    sessionName: nil
+                )
+
+                let provider = SSOCredentialProvider(
+                    configuration: config,
+                    httpClient: mockHTTPClient
+                )
+
+                let logger = Logger(label: "test")
+                await #expect(throws: DecodingError.self) {
+                    try await provider.getCredential(logger: logger)
+                }
+            }
+        }
+    }
+
+    @Test("Provider is immutable")
+    func providerIsImmutable() throws {
+        let provider = SSOCredentialProvider(
+            profileName: "test",
+            httpClient: MockAWSHTTPClient()
+        )
+
+        #expect(provider.description.contains("SSOCredentialProvider"))
+    }
+
+    // MARK: - Helper Methods
+
+    func withTempDirectory<T>(_ body: (URL) async throws -> T) async throws -> T {
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        return try await body(tempDir)
+    }
+
+    /// Create a token file at the expected cache path for the given cache key (session name or start URL)
+    func createTokenFile(
+        cacheKey: String,
+        tokenJSON: String,
+        inDirectory directory: URL
+    ) throws -> URL {
+        let keyData = Data(cacheKey.utf8)
+        let hash = Insecure.SHA1.hash(data: keyData)
+        let hashString = hash.compactMap { String(format: "%02x", $0) }.joined()
+
+        let tokenPath = directory.appendingPathComponent("\(hashString).json")
+        try tokenJSON.write(to: tokenPath, atomically: true, encoding: .utf8)
+        return tokenPath
+    }
+
+    /// Sets environment variables for the duration of `body`, then restores originals (or unsets them).
+    private func withEnvironmentVariables<T>(_ env: [String: String], body: () async throws -> T) async throws -> T {
+        // Save original values
+        var saved: [String: String?] = [:]
+        for key in env.keys {
+            saved[key] = ProcessInfo.processInfo.environment[key]
+        }
+        // Set new values
+        for (key, value) in env {
+            setenv(key, value, 1)
+        }
+        defer {
+            for (key, original) in saved {
+                if let original {
+                    setenv(key, original, 1)
+                } else {
+                    unsetenv(key)
+                }
+            }
+        }
+        return try await body()
+    }
+
+}
+
+/// Thread-safe request counter for use in @Sendable closures
+private actor RequestCounter {
+    var urls: [String] = []
+
+    func record(_ url: String) {
+        urls.append(url)
+    }
+}

--- a/Tests/SotoCoreTests/Credential/SSO/SSOCredentialProviderTests.swift
+++ b/Tests/SotoCoreTests/Credential/SSO/SSOCredentialProviderTests.swift
@@ -288,13 +288,13 @@ final class SSOCredentialProviderTests {
                 if request.url.absoluteString.contains("oidc.") {
                     // SSO-OIDC CreateToken refresh request
                     #expect(request.method == .POST)
-                    #expect(request.headers["Content-Type"].first == "application/x-www-form-urlencoded")
+                    #expect(request.headers["Content-Type"].first == "application/json")
 
                     let bodyBuffer = try await request.body.collect(upTo: 1024 * 1024)
-                    let bodyString = String(buffer: bodyBuffer)
-                    #expect(bodyString.contains("grant_type=refresh_token"))
-                    #expect(bodyString.contains("client_id=client-id"))
-                    #expect(bodyString.contains("refresh_token=refresh-token-value"))
+                    let bodyJSON = try JSONSerialization.jsonObject(with: Data(buffer: bodyBuffer)) as! [String: String]
+                    #expect(bodyJSON["grantType"] == "refresh_token")
+                    #expect(bodyJSON["clientId"] == "client-id")
+                    #expect(bodyJSON["refreshToken"] == "refresh-token-value")
 
                     let responseJSON = """
                         {

--- a/Tests/SotoCoreTests/Credential/SSO/SSOCredentialProviderTests.swift
+++ b/Tests/SotoCoreTests/Credential/SSO/SSOCredentialProviderTests.swift
@@ -13,6 +13,13 @@
 //===----------------------------------------------------------------------===//
 
 // SSO Credential Provider Tests
+//
+// Note: The ideal pattern for error assertions in Swift Testing is:
+//   let error = await #expect(throws: AWSSSOCredentialError.self) { ... }
+//   #expect(error?.code == "expectedCode")
+// However, the return-value variant of #expect(throws:) was introduced in Swift 6.1.
+// On Swift 6.0 it returns Void, so we use the closure-based validation pattern instead:
+//   await #expect { ... } throws: { error in (error as? AWSSSOCredentialError)?.code == "expectedCode" }
 
 import Crypto
 import Foundation
@@ -200,10 +207,11 @@ final class SSOCredentialProviderTests {
                 )
 
                 let logger = Logger(label: "test")
-                let error = await #expect(throws: AWSSSOCredentialError.self) {
+                await #expect {
                     try await provider.getCredential(logger: logger)
+                } throws: { error in
+                    (error as? AWSSSOCredentialError)?.code == "tokenCacheNotFound"
                 }
-                #expect(error?.code == "tokenCacheNotFound")
             }
         }
     }
@@ -243,10 +251,11 @@ final class SSOCredentialProviderTests {
                 )
 
                 let logger = Logger(label: "test")
-                let error = await #expect(throws: AWSSSOCredentialError.self) {
+                await #expect {
                     try await provider.getCredential(logger: logger)
+                } throws: { error in
+                    (error as? AWSSSOCredentialError)?.code == "tokenExpired"
                 }
-                #expect(error?.code == "tokenExpired")
             }
         }
     }
@@ -403,10 +412,11 @@ final class SSOCredentialProviderTests {
                 )
 
                 let logger = Logger(label: "test")
-                let error = await #expect(throws: AWSSSOCredentialError.self) {
+                await #expect {
                     try await provider.getCredential(logger: logger)
+                } throws: { error in
+                    (error as? AWSSSOCredentialError)?.code == "tokenRefreshFailed"
                 }
-                #expect(error?.code == "tokenRefreshFailed")
             }
         }
     }
@@ -451,10 +461,11 @@ final class SSOCredentialProviderTests {
                 )
 
                 let logger = Logger(label: "test")
-                let error = await #expect(throws: AWSSSOCredentialError.self) {
+                await #expect {
                     try await provider.getCredential(logger: logger)
+                } throws: { error in
+                    (error as? AWSSSOCredentialError)?.code == "clientRegistrationExpired"
                 }
-                #expect(error?.code == "clientRegistrationExpired")
             }
         }
     }
@@ -500,11 +511,12 @@ final class SSOCredentialProviderTests {
                 )
 
                 let logger = Logger(label: "test")
-                let error = await #expect(throws: AWSSSOCredentialError.self) {
+                await #expect {
                     try await provider.getCredential(logger: logger)
+                } throws: { error in
+                    guard let error = error as? AWSSSOCredentialError else { return false }
+                    return error.code == "getRoleCredentialsFailed" && error.message.contains("403")
                 }
-                #expect(error?.code == "getRoleCredentialsFailed")
-                #expect(error?.message.contains("403") == true)
             }
         }
     }

--- a/Tests/SotoCoreTests/Credential/SSO/SSOCredentialProviderTests.swift
+++ b/Tests/SotoCoreTests/Credential/SSO/SSOCredentialProviderTests.swift
@@ -191,13 +191,15 @@ final class SSOCredentialProviderTests {
 
     @Test("Profile not found throws profileNotFound error")
     func profileNotFound() async throws {
-        try await withConfigFile("""
+        try await withConfigFile(
+            """
             [profile existing]
             sso_start_url = https://test.awsapps.com/start
             sso_region = us-east-1
             sso_account_id = 123456789012
             sso_role_name = TestRole
-            """) { configPath in
+            """
+        ) { configPath in
             let provider = SSOCredentialProvider(profileName: "nonexistent", configPath: configPath, httpClient: MockAWSHTTPClient())
 
             await #expect {
@@ -210,12 +212,14 @@ final class SSOCredentialProviderTests {
 
     @Test("Missing sso-session section throws ssoSessionNotFound error")
     func ssoSessionNotFound() async throws {
-        try await withConfigFile("""
+        try await withConfigFile(
+            """
             [profile broken]
             sso_session = nonexistent-session
             sso_account_id = 123456789012
             sso_role_name = TestRole
-            """) { configPath in
+            """
+        ) { configPath in
             let provider = SSOCredentialProvider(profileName: "broken", configPath: configPath, httpClient: MockAWSHTTPClient())
 
             await #expect {
@@ -229,7 +233,8 @@ final class SSOCredentialProviderTests {
     @Test("Missing required SSO fields throws ssoConfigMissing error")
     func ssoConfigMissingFields() async throws {
         // Session section missing sso_start_url
-        try await withConfigFile("""
+        try await withConfigFile(
+            """
             [profile incomplete]
             sso_session = my-sso
             sso_account_id = 123456789012
@@ -237,7 +242,8 @@ final class SSOCredentialProviderTests {
 
             [sso-session my-sso]
             sso_region = us-east-1
-            """) { configPath in
+            """
+        ) { configPath in
             let provider = SSOCredentialProvider(profileName: "incomplete", configPath: configPath, httpClient: MockAWSHTTPClient())
 
             await #expect {
@@ -251,12 +257,14 @@ final class SSOCredentialProviderTests {
     @Test("Legacy profile missing required fields throws ssoConfigMissing error")
     func legacyConfigMissingFields() async throws {
         // Legacy profile missing sso_role_name
-        try await withConfigFile("""
+        try await withConfigFile(
+            """
             [profile partial]
             sso_start_url = https://test.awsapps.com/start
             sso_region = us-east-1
             sso_account_id = 123456789012
-            """) { configPath in
+            """
+        ) { configPath in
             let provider = SSOCredentialProvider(profileName: "partial", configPath: configPath, httpClient: MockAWSHTTPClient())
 
             await #expect {
@@ -363,7 +371,11 @@ final class SSOCredentialProviderTests {
                     return Self.makeCreateTokenResponse()
                 } else {
                     #expect(request.headers["x-amz-sso_bearer_token"].first == "refreshed-access-token")
-                    return Self.makeRoleCredentialsResponse(accessKeyId: "AKIAREFRESHED", secretAccessKey: "refreshedsecret", sessionToken: "refreshedsession")
+                    return Self.makeRoleCredentialsResponse(
+                        accessKeyId: "AKIAREFRESHED",
+                        secretAccessKey: "refreshedsecret",
+                        sessionToken: "refreshedsession"
+                    )
                 }
             }
 

--- a/Tests/SotoCoreTests/Credential/SSO/SSOTestHelpers.swift
+++ b/Tests/SotoCoreTests/Credential/SSO/SSOTestHelpers.swift
@@ -1,0 +1,272 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Soto for AWS open source project
+//
+// Copyright (c) 2017-2025 the Soto project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Soto project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+// Shared test helpers for SSO Credential Provider tests
+
+import Crypto
+import Logging
+import NIOCore
+import NIOHTTP1
+
+@testable import SotoCore
+
+#if canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import Musl
+#elseif canImport(Darwin)
+import Darwin.C
+#elseif canImport(Android)
+import Android
+#else
+#error("Unsupported platform")
+#endif
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+// MARK: - Fixture Builders
+
+extension SSOCredentialProviderTests {
+
+    static let ssoCacheDirectory = ".aws/sso/cache"
+
+    /// Build a legacy SSOConfiguration (no session name, no refresh)
+    func makeLegacyConfig(
+        startUrl: String = "https://test.awsapps.com/start",
+        ssoRegion: Region = .useast1,
+        accountId: String = "123456789012",
+        roleName: String = "TestRole"
+    ) -> SSOConfiguration {
+        SSOConfiguration(
+            ssoStartUrl: startUrl,
+            ssoRegion: ssoRegion,
+            ssoAccountId: accountId,
+            ssoRoleName: roleName,
+            region: ssoRegion,
+            sessionName: nil
+        )
+    }
+
+    /// Build a modern SSOConfiguration (with session name, supports refresh)
+    func makeModernConfig(
+        startUrl: String = "https://test.awsapps.com/start",
+        ssoRegion: Region = .useast1,
+        accountId: String = "123456789012",
+        roleName: String = "TestRole",
+        sessionName: String = "my-sso"
+    ) -> SSOConfiguration {
+        SSOConfiguration(
+            ssoStartUrl: startUrl,
+            ssoRegion: ssoRegion,
+            ssoAccountId: accountId,
+            ssoRoleName: roleName,
+            region: ssoRegion,
+            sessionName: sessionName
+        )
+    }
+
+    /// Build a modern token JSON with refresh fields.
+    /// Token expires within the 15-min refresh window by default (triggers refresh).
+    func makeModernTokenJSON(
+        accessToken: String = "test-access-token",
+        expiresIn: TimeInterval = 10 * 60,
+        refreshToken: String = "refresh-token-value",
+        clientId: String = "client-id",
+        clientSecret: String = "client-secret",
+        registrationExpiresIn: TimeInterval = 90 * 24 * 3600
+    ) -> String {
+        """
+        {
+            "accessToken": "\(accessToken)",
+            "expiresAt": "\(iso8601(offsetFromNow: expiresIn))",
+            "refreshToken": "\(refreshToken)",
+            "clientId": "\(clientId)",
+            "clientSecret": "\(clientSecret)",
+            "registrationExpiresAt": "\(iso8601(offsetFromNow: registrationExpiresIn))",
+            "startUrl": "https://test.awsapps.com/start",
+            "region": "us-east-1"
+        }
+        """
+    }
+
+    /// Build a successful GetRoleCredentials response
+    func makeRoleCredentialsResponse(
+        accessKeyId: String = "AKIATEST123",
+        secretAccessKey: String = "testsecret",
+        sessionToken: String = "testsession"
+    ) -> (HTTPResponseStatus, Data) {
+        let json = """
+            {
+                "roleCredentials": {
+                    "accessKeyId": "\(accessKeyId)",
+                    "secretAccessKey": "\(secretAccessKey)",
+                    "sessionToken": "\(sessionToken)",
+                    "expiration": \(Int64(Date(timeIntervalSinceNow: 3600).timeIntervalSince1970 * 1000))
+                }
+            }
+            """
+        return (.ok, json.data(using: .utf8)!)
+    }
+
+    /// Build a successful SSO-OIDC CreateToken refresh response
+    func makeCreateTokenResponse(
+        accessToken: String = "refreshed-access-token",
+        refreshToken: String = "new-refresh-token"
+    ) -> (HTTPResponseStatus, Data) {
+        let json = """
+            {
+                "accessToken": "\(accessToken)",
+                "expiresIn": 28800,
+                "tokenType": "Bearer",
+                "refreshToken": "\(refreshToken)"
+            }
+            """
+        return (.ok, json.data(using: .utf8)!)
+    }
+}
+
+// MARK: - Test Environment Helpers
+
+extension SSOCredentialProviderTests {
+
+    /// Context passed to test closures by `withSSOEnvironment`
+    struct TestEnvironment {
+        let tempDirectory: URL
+        let tokenPath: URL?
+        let configPath: String?
+    }
+
+    /// Set up a temp directory with a token cache file and HOME override.
+    /// Optionally writes a config file.
+    func withSSOEnvironment<T>(
+        cacheKey: String,
+        expiresIn: TimeInterval = 3600,
+        accessToken: String = "test-access-token",
+        configContent: String? = nil,
+        body: (TestEnvironment) async throws -> T
+    ) async throws -> T {
+        let tokenJSON = """
+            {
+                "accessToken": "\(accessToken)",
+                "expiresAt": "\(iso8601(offsetFromNow: expiresIn))"
+            }
+            """
+        return try await withSSOEnvironment(
+            cacheKey: cacheKey,
+            tokenJSON: tokenJSON,
+            configContent: configContent,
+            body: body
+        )
+    }
+
+    /// Core environment setup: temp directory + token cache + HOME override + optional config file.
+    func withSSOEnvironment<T>(
+        cacheKey: String,
+        tokenJSON: String,
+        configContent: String? = nil,
+        body: (TestEnvironment) async throws -> T
+    ) async throws -> T {
+        try await withTempCacheDirectory { cacheDir in
+            let tokenPath = try self.createTokenFile(cacheKey: cacheKey, tokenJSON: tokenJSON, inDirectory: cacheDir)
+
+            var configPath: String?
+            if let configContent {
+                let configURL = cacheDir.appendingPathComponent("config")
+                try configContent.write(to: configURL, atomically: true, encoding: .utf8)
+                configPath = configURL.path
+            }
+
+            let env = TestEnvironment(tempDirectory: cacheDir, tokenPath: tokenPath, configPath: configPath)
+            return try await body(env)
+        }
+    }
+
+    /// Create a `.aws/sso/cache` directory in a temporary directory
+    /// and set the HOME env variable with the new temporary directory
+    func withTempCacheDirectory<T>(body: (URL) async throws -> T) async throws -> T {
+        try await withTempDirectory { tempDirectory in
+            let cacheDir = tempDirectory.appendingPathComponent(Self.ssoCacheDirectory)
+            try FileManager.default.createDirectory(at: cacheDir, withIntermediateDirectories: true)
+            return try await self.withEnvironmentVariables(["HOME": tempDirectory.path]) {
+                try await body(cacheDir)
+            }
+        }
+    }
+
+    /// Write a config file to a temp directory and pass its path to the body.
+    func withConfigFile<T>(_ content: String, body: (String) async throws -> T) async throws -> T {
+        try await withTempDirectory { tempDirectory in
+            let configURL = tempDirectory.appendingPathComponent("config")
+            try content.write(to: configURL, atomically: true, encoding: .utf8)
+            return try await body(configURL.path)
+        }
+    }
+
+    // MARK: - Low-Level Helpers
+
+    func iso8601(offsetFromNow seconds: TimeInterval) -> String {
+        ISO8601DateCoder.string(from: Date(timeIntervalSinceNow: seconds)) ?? ""
+    }
+
+    func withTempDirectory<T>(_ body: (URL) async throws -> T) async throws -> T {
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        return try await body(tempDir)
+    }
+
+    /// Create a token file at the expected cache path for the given cache key (session name or start URL)
+    @discardableResult
+    func createTokenFile(cacheKey: String, tokenJSON: String, inDirectory directory: URL) throws -> URL {
+        let hash = Insecure.SHA1.hash(data: Data(cacheKey.utf8))
+            .compactMap { String(format: "%02x", $0) }.joined()
+        let tokenPath = directory.appendingPathComponent("\(hash).json")
+        try tokenJSON.write(to: tokenPath, atomically: true, encoding: .utf8)
+        return tokenPath
+    }
+
+    /// Sets environment variables for the duration of `body`, then restores originals.
+    func withEnvironmentVariables<T>(_ env: [String: String], body: () async throws -> T) async throws -> T {
+        var saved: [String: String?] = [:]
+        for key in env.keys {
+            saved[key] = ProcessInfo.processInfo.environment[key]
+        }
+        for (key, value) in env {
+            setenv(key, value, 1)
+        }
+        defer {
+            for (key, original) in saved {
+                if let original {
+                    setenv(key, original, 1)
+                } else {
+                    unsetenv(key)
+                }
+            }
+        }
+        return try await body()
+    }
+}
+
+/// Thread-safe request counter for use in @Sendable closures
+actor RequestCounter {
+    var urls: [String] = []
+
+    func record(_ url: String) {
+        urls.append(url)
+    }
+}

--- a/Tests/SotoCoreTests/Credential/SSO/SSOTokenManagerTests.swift
+++ b/Tests/SotoCoreTests/Credential/SSO/SSOTokenManagerTests.swift
@@ -1,0 +1,209 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Soto for AWS open source project
+//
+// Copyright (c) 2017-2025 the Soto project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Soto project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+// SSO Token Manager Tests (cache, refresh, path construction)
+
+import Crypto
+import Logging
+import NIOCore
+import NIOHTTP1
+import Testing
+
+@testable import SotoCore
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+extension SSOCredentialProviderTests {
+
+    // MARK: - Token Cache Tests
+
+    @Test("Invalid token JSON throws invalidTokenFormat error")
+    func invalidTokenJSON() async throws {
+        try await withSSOEnvironment(cacheKey: "https://test.awsapps.com/start", tokenJSON: "{ not valid json") { env in
+            let provider = SSOCredentialProvider(configuration: self.makeLegacyConfig(), httpClient: MockAWSHTTPClient())
+
+            await #expect {
+                try await provider.getCredential(logger: self.logger)
+            } throws: { error in
+                (error as? AWSSSOCredentialError)?.code == "invalidTokenFormat"
+            }
+        }
+    }
+
+    @Test("Invalid expiresAt date format throws invalidTokenFormat error")
+    func invalidExpiresAtFormat() async throws {
+        let tokenJSON = """
+            {
+                "accessToken": "test-token",
+                "expiresAt": "not-a-date"
+            }
+            """
+
+        try await withSSOEnvironment(cacheKey: "https://test.awsapps.com/start", tokenJSON: tokenJSON) { env in
+            let provider = SSOCredentialProvider(configuration: self.makeLegacyConfig(), httpClient: MockAWSHTTPClient())
+
+            await #expect {
+                try await provider.getCredential(logger: self.logger)
+            } throws: { error in
+                (error as? AWSSSOCredentialError)?.code == "invalidTokenFormat"
+            }
+        }
+    }
+
+    @Test("Token cache not found throws tokenCacheNotFound error")
+    func tokenCacheNotFound() async throws {
+        try await withTempCacheDirectory { cacheDirectory in
+            // Use a cache directory but no token file
+            let provider = SSOCredentialProvider(
+                configuration: self.makeLegacyConfig(startUrl: "https://nonexistent.awsapps.com/start"),
+                httpClient: MockAWSHTTPClient()
+            )
+
+            await #expect {
+                try await provider.getCredential(logger: self.logger)
+            } throws: { error in
+                (error as? AWSSSOCredentialError)?.code == "tokenCacheNotFound"
+            }
+        }
+    }
+
+    @Test("Expired legacy token without refresh throws tokenExpired error")
+    func expiredLegacyToken() async throws {
+        let startUrl = "https://test.awsapps.com/start"
+        try await withSSOEnvironment(cacheKey: startUrl, expiresIn: -3600, accessToken: "expired-token") { env in
+            let provider = SSOCredentialProvider(configuration: self.makeLegacyConfig(), httpClient: MockAWSHTTPClient())
+
+            await #expect {
+                try await provider.getCredential(logger: self.logger)
+            } throws: { error in
+                (error as? AWSSSOCredentialError)?.code == "tokenExpired"
+            }
+        }
+    }
+
+    // MARK: - Token Refresh Tests (Modern Format)
+
+    @Test("Modern token within refresh window triggers refresh")
+    func modernTokenRefresh() async throws {
+        try await withSSOEnvironment(
+            cacheKey: "my-sso",
+            tokenJSON: makeModernTokenJSON(accessToken: "expiring-soon-token")
+        ) { env in
+            let requestCounter = RequestCounter()
+            let mockHTTPClient = MockAWSHTTPClient { request in
+                await requestCounter.record(request.url.absoluteString)
+
+                if request.url.absoluteString.contains("oidc.") {
+                    #expect(request.method == .POST)
+                    #expect(request.headers["Content-Type"].first == "application/json")
+
+                    struct CreateTokenRequest: Decodable {
+                        let grantType: String
+                        let clientId: String
+                        let refreshToken: String
+                    }
+                    let bodyBuffer = try await request.body.collect(upTo: 1024 * 1024)
+                    let body = try JSONDecoder().decode(CreateTokenRequest.self, from: Data(buffer: bodyBuffer))
+                    #expect(body.grantType == "refresh_token")
+                    #expect(body.clientId == "client-id")
+                    #expect(body.refreshToken == "refresh-token-value")
+
+                    return self.makeCreateTokenResponse()
+                } else {
+                    #expect(request.headers["x-amz-sso_bearer_token"].first == "refreshed-access-token")
+                    return self.makeRoleCredentialsResponse(
+                        accessKeyId: "AKIAREFRESHED",
+                        secretAccessKey: "refreshedsecret",
+                        sessionToken: "refreshedsession"
+                    )
+                }
+            }
+
+            let provider = SSOCredentialProvider(configuration: self.makeModernConfig(), httpClient: mockHTTPClient)
+            let credential = try await provider.getCredential(logger: self.logger)
+
+            let refreshUrls = await requestCounter.urls
+            #expect(refreshUrls.count == 2)
+            #expect(credential.accessKeyId == "AKIAREFRESHED")
+            #expect(credential.secretAccessKey == "refreshedsecret")
+            #expect(credential.sessionToken == "refreshedsession")
+
+            // Verify token file was updated
+            let updatedTokenData = try Data(contentsOf: env.tokenPath!)
+            let updatedToken = try JSONDecoder().decode(SSOToken.self, from: updatedTokenData)
+            #expect(updatedToken.accessToken == "refreshed-access-token")
+            #expect(updatedToken.refreshToken == "new-refresh-token")
+            #expect(updatedToken.clientId == "client-id")
+            #expect(updatedToken.clientSecret == "client-secret")
+        }
+    }
+
+    @Test("Token refresh failure throws tokenRefreshFailed error")
+    func tokenRefreshFailure() async throws {
+        try await withSSOEnvironment(cacheKey: "my-sso", tokenJSON: makeModernTokenJSON()) { env in
+            let mockHTTPClient = MockAWSHTTPClient { _ in (.badRequest, Data()) }
+            let provider = SSOCredentialProvider(configuration: self.makeModernConfig(), httpClient: mockHTTPClient)
+
+            await #expect {
+                try await provider.getCredential(logger: self.logger)
+            } throws: { error in
+                (error as? AWSSSOCredentialError)?.code == "tokenRefreshFailed"
+            }
+        }
+    }
+
+    @Test("Client registration expired throws clientRegistrationExpired error")
+    func clientRegistrationExpired() async throws {
+        try await withSSOEnvironment(
+            cacheKey: "my-sso",
+            tokenJSON: makeModernTokenJSON(registrationExpiresIn: -3600)
+        ) { env in
+            let provider = SSOCredentialProvider(configuration: self.makeModernConfig(), httpClient: MockAWSHTTPClient())
+
+            await #expect {
+                try await provider.getCredential(logger: self.logger)
+            } throws: { error in
+                (error as? AWSSSOCredentialError)?.code == "clientRegistrationExpired"
+            }
+        }
+    }
+
+    // MARK: - Token Path Construction Tests
+
+    @Test("Token path uses SHA-1 hash of session name for modern format")
+    func tokenPathModernFormat() throws {
+        let tokenManager = SSOTokenManager(httpClient: MockAWSHTTPClient())
+        let path = try tokenManager.constructTokenPath(config: makeModernConfig())
+
+        let expectedHash = Insecure.SHA1.hash(data: Data("my-sso".utf8))
+            .compactMap { String(format: "%02x", $0) }.joined()
+        #expect(path.hasSuffix("\(expectedHash).json"))
+        #expect(path.contains(Self.ssoCacheDirectory))
+    }
+
+    @Test("Token path uses SHA-1 hash of start URL for legacy format")
+    func tokenPathLegacyFormat() throws {
+        let tokenManager = SSOTokenManager(httpClient: MockAWSHTTPClient())
+        let path = try tokenManager.constructTokenPath(config: makeLegacyConfig())
+
+        let expectedHash = Insecure.SHA1.hash(data: Data("https://test.awsapps.com/start".utf8))
+            .compactMap { String(format: "%02x", $0) }.joined()
+        #expect(path.hasSuffix("\(expectedHash).json"))
+        #expect(path.contains(Self.ssoCacheDirectory))
+    }
+}


### PR DESCRIPTION
Add support for AWS IAM Identity Center (SSO) credentials. This lets soto-based apps authenticate using `aws sso login` cached tokens, the same way the AWS CLI does.         
                                                                                                                                                                   
Supports both the modern `sso-session` config format (with automatic token refresh via SSO-OIDC) and the legacy format (direct SSO fields in the profile).

The provider is added to the default credential chain, after `configFile()` and before `login()`.

To test this, you need to:
1. setup AWS IAM Identity Center in your AWS account (https://docs.aws.amazon.com/singlesignon/latest/userguide/getting-started.html)
2. configure the AWS CLI to authenticate with `aws sso login` (https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sso.html) 

This implements https://github.com/soto-project/soto-core/issues/681

disclaimer : the swift docc comments and the majority of the tests have been generated automatically.