### PR TITLE
Rename TokenFileManager to LoginTokenManager

### DIFF
--- a/Sources/SotoCore/Credential/Login/LoginCredentialProvider.swift
+++ b/Sources/SotoCore/Credential/Login/LoginCredentialProvider.swift
@@ -68,7 +68,7 @@ public struct LoginCredentialProvider: CredentialProvider {
         let configuration = try await getConfiguration()
 
         // Construct token path
-        let tokenFileManager = TokenFileManager()
+        let tokenFileManager = LoginTokenManager()
         let tokenPath = try tokenFileManager.constructTokenPath(
             loginSession: configuration.loginSession,
             cacheDirectory: configuration.cacheDirectory

--- a/Sources/SotoCore/Credential/Login/LoginTokenManager.swift
+++ b/Sources/SotoCore/Credential/Login/LoginTokenManager.swift
@@ -25,7 +25,7 @@ import FoundationEssentials
 import Foundation
 #endif
 
-struct TokenFileManager {
+struct LoginTokenManager {
     private struct AccessToken: Codable {
         let accessKeyId: String
         let secretAccessKey: String

--- a/Tests/SotoCoreTests/Credential/Login/LoginTokenManagerTests.swift
+++ b/Tests/SotoCoreTests/Credential/Login/LoginTokenManagerTests.swift
@@ -27,9 +27,9 @@ import FoundationEssentials
 import Foundation
 #endif
 
-@Suite("Token File Manager")
-final class TokenFileManagerTests {
-    let manager = TokenFileManager()
+@Suite("Login Token Manager")
+final class LoginTokenManagerTests {
+    let manager = LoginTokenManager()
 
     // Helper to create a unique temp directory for each test
     func createTempDirectory() throws -> URL {


### PR DESCRIPTION
Small PR to prepare the future merge of #686 
The SSO provider will introduce another `TokenManager`. With this PR, we will have `LoginTokenManager`. The SSO PR will add a `SSOTokenManager` 