### PR TITLE
Follow source_profile in the AWS config, and improve the handling of role_arn + SSO configurations

### DIFF
--- a/Sources/SotoCore/Credential/ConfigFileCredentialProvider.swift
+++ b/Sources/SotoCore/Credential/ConfigFileCredentialProvider.swift
@@ -70,7 +70,11 @@ final class ConfigFileCredentialProvider: CredentialProviderSelector {
             profile: profile,
             threadPool: threadPool
         )
-        return try self.credentialProvider(from: sharedCredentials, context: context, endpoint: endpoint)
+        let provider = try self.credentialProvider(from: sharedCredentials, context: context, endpoint: endpoint)
+        // Tag any error surfaced from this provider with the originating profile, so a failure
+        // inside a credential chain (source profile, SSO source, STS AssumeRole, etc.) names
+        // the profile the caller actually asked to resolve.
+        return ProfileScopedCredentialProvider(inner: provider, profile: profile)
     }
 
     /// Generate credential provider based on shared credentials and profile configuration
@@ -102,5 +106,38 @@ final class ConfigFileCredentialProvider: CredentialProviderSelector {
                 endpoint: endpoint
             )
         }
+    }
+}
+
+/// Wraps a credential provider so any error it raises is reported in terms of the profile
+/// the caller asked to resolve. Without this, an error from a source profile, SSO source, or
+/// STS AssumeRole call does not mention the profile that initiated the lookup.
+struct ProfileScopedCredentialProvider: CredentialProvider {
+    let inner: CredentialProvider
+    let profile: String
+
+    var description: String { "\(inner) (profile: \(profile))" }
+
+    func getCredential(logger: Logger) async throws -> Credential {
+        do {
+            return try await self.inner.getCredential(logger: logger)
+        } catch {
+            throw ProfileCredentialError(profile: self.profile, underlying: error)
+        }
+    }
+
+    func shutdown() async throws {
+        try await self.inner.shutdown()
+    }
+}
+
+/// Error thrown when credential resolution for a profile fails. Preserves the underlying
+/// error so callers can still inspect the original cause.
+struct ProfileCredentialError: Error, CustomStringConvertible {
+    let profile: String
+    let underlying: any Error
+
+    var description: String {
+        "Failed to resolve credentials for profile '\(self.profile)': \(self.underlying)"
     }
 }

--- a/Sources/SotoCore/Credential/ConfigFileCredentialProvider.swift
+++ b/Sources/SotoCore/Credential/ConfigFileCredentialProvider.swift
@@ -133,11 +133,18 @@ struct ProfileScopedCredentialProvider: CredentialProvider {
 
 /// Error thrown when credential resolution for a profile fails. Preserves the underlying
 /// error so callers can still inspect the original cause.
-struct ProfileCredentialError: Error, CustomStringConvertible {
-    let profile: String
-    let underlying: any Error
+public struct ProfileCredentialError: Error, CustomStringConvertible {
+    /// The profile the caller asked to resolve.
+    public let profile: String
+    /// The error raised somewhere within the credential resolution for `profile`.
+    public let underlying: any Error
 
-    var description: String {
+    public init(profile: String, underlying: any Error) {
+        self.profile = profile
+        self.underlying = underlying
+    }
+
+    public var description: String {
         "Failed to resolve credentials for profile '\(self.profile)': \(self.underlying)"
     }
 }

--- a/Sources/SotoCore/Credential/ConfigFileLoader.swift
+++ b/Sources/SotoCore/Credential/ConfigFileLoader.swift
@@ -176,7 +176,7 @@ enum ConfigFileLoader {
     ///   - fileIO: non-blocking file IO
     /// - Returns: INIParser
     static func loadINIFile(path: String, fileIO: NonBlockingFileIO) async throws -> INIParser {
-        let buffer: ByteBuffer 
+        let buffer: ByteBuffer
         do {
             buffer = try await loadFile(path: path, fileIO: fileIO)
         } catch let error as IOError where error.errnoCode == ENOENT {

--- a/Sources/SotoCore/Credential/ConfigFileLoader.swift
+++ b/Sources/SotoCore/Credential/ConfigFileLoader.swift
@@ -88,6 +88,7 @@ enum ConfigFileLoader {
     /// - missingSecretAccessKey: If the secret access key was not found
     public struct ConfigFileError: Error, Equatable {
         enum Internal: Equatable {
+            case fileDoesNotExist
             case invalidINIFile
             case missingProfile
             case missingAccessKeyId
@@ -95,6 +96,8 @@ enum ConfigFileLoader {
         }
         let value: Internal
 
+        /// Credentials or profile ini file does not exist
+        public static var fileDoesNotExist: Self { .init(value: .fileDoesNotExist) }
         /// Credentials or profile ini file failed to load
         public static var invalidINIFile: Self { .init(value: .invalidINIFile) }
         /// Cannot find profile in ini file
@@ -126,13 +129,13 @@ enum ConfigFileLoader {
         let credentialsINIParser: INIParser?
         do {
             credentialsINIParser = try await self.loadINIFile(path: credentialsFilePath, fileIO: fileIO)
-        } catch let error as IOError where error.errnoCode == ENOENT {
+        } catch let error as ConfigFileError where error == ConfigFileError.fileDoesNotExist {
             credentialsINIParser = nil
         }
         let configINIParser: INIParser?
         do {
             configINIParser = try await self.loadINIFile(path: configFilePath, fileIO: fileIO)
-        } catch let error as IOError where error.errnoCode == ENOENT {
+        } catch let error as ConfigFileError where error == ConfigFileError.fileDoesNotExist {
             configINIParser = nil
         }
 
@@ -173,7 +176,13 @@ enum ConfigFileLoader {
     ///   - fileIO: non-blocking file IO
     /// - Returns: INIParser
     static func loadINIFile(path: String, fileIO: NonBlockingFileIO) async throws -> INIParser {
-        let buffer = try await loadFile(path: path, fileIO: fileIO)
+        let buffer: ByteBuffer 
+        do {
+            buffer = try await loadFile(path: path, fileIO: fileIO)
+        } catch let error as IOError where error.errnoCode == ENOENT {
+            throw ConfigFileError.fileDoesNotExist
+        }
+
         let content = String(buffer: buffer)
         guard let parser = try? INIParser(content) else {
             throw ConfigFileError.invalidINIFile

--- a/Sources/SotoCore/Credential/ConfigFileLoader.swift
+++ b/Sources/SotoCore/Credential/ConfigFileLoader.swift
@@ -120,16 +120,19 @@ enum ConfigFileLoader {
         threadPool: NIOThreadPool = .singleton
     ) async throws -> SharedCredentials {
         let fileIO = NonBlockingFileIO(threadPool: threadPool)
+        // Only treat "file does not exist" as a soft miss. Other failures (permission denied,
+        // I/O errors, malformed INI) propagate so the caller sees why credential lookup failed
+        // instead of silently falling through to the next provider.
         let credentialsINIParser: INIParser?
         do {
             credentialsINIParser = try await self.loadINIFile(path: credentialsFilePath, fileIO: fileIO)
-        } catch {
+        } catch let error as IOError where error.errnoCode == ENOENT {
             credentialsINIParser = nil
         }
         let configINIParser: INIParser?
         do {
             configINIParser = try await self.loadINIFile(path: configFilePath, fileIO: fileIO)
-        } catch {
+        } catch let error as IOError where error.errnoCode == ENOENT {
             configINIParser = nil
         }
 

--- a/Sources/SotoCore/Credential/ConfigFileLoader.swift
+++ b/Sources/SotoCore/Credential/ConfigFileLoader.swift
@@ -120,28 +120,36 @@ enum ConfigFileLoader {
         threadPool: NIOThreadPool = .singleton
     ) async throws -> SharedCredentials {
         let fileIO = NonBlockingFileIO(threadPool: threadPool)
-        let credentialsINIParser: INIParser
+        let credentialsINIParser: INIParser?
         do {
-            // Load credentials file
-            credentialsINIParser = try await self.loadINIFile(
-                path: credentialsFilePath,
-                fileIO: fileIO
-            )
+            credentialsINIParser = try await self.loadINIFile(path: credentialsFilePath, fileIO: fileIO)
         } catch {
-            // Throw `.noProvider` error if credential file cannot be loaded
-            throw CredentialProviderError.noProvider
+            credentialsINIParser = nil
         }
         let configINIParser: INIParser?
         do {
-            // Load profile config file
-            configINIParser = try await self.loadINIFile(
-                path: configFilePath,
-                fileIO: fileIO
-            )
+            configINIParser = try await self.loadINIFile(path: configFilePath, fileIO: fileIO)
         } catch {
             configINIParser = nil
         }
-        return try self.parseSharedCredentials(from: credentialsINIParser, configINIParser: configINIParser, for: profile)
+
+        // If neither file is available there's nothing to resolve — fall through to the next
+        // provider in the chain, matching the historical contract for a missing credentials file.
+        if credentialsINIParser == nil && configINIParser == nil {
+            throw CredentialProviderError.noProvider
+        }
+
+        do {
+            return try self.parseSharedCredentials(
+                from: credentialsINIParser,
+                configINIParser: configINIParser,
+                for: profile
+            )
+        } catch let error as ConfigFileError where error == .missingProfile && credentialsINIParser == nil {
+            // The credentials file was unavailable and the config file didn't supply the profile
+            // either — preserve the "fall through to the next provider" behavior.
+            throw CredentialProviderError.noProvider
+        }
     }
 
     /// Load a file from disk without blocking the current thread
@@ -184,34 +192,58 @@ enum ConfigFileLoader {
     ///   - profile: named profile to load (optional)
     /// - Returns: Parsed SharedCredentials
     static func parseSharedCredentials(
-        from credentialsINIParser: INIParser,
+        from credentialsINIParser: INIParser?,
         configINIParser: INIParser?,
         for profile: String
     ) throws -> SharedCredentials {
         let config = try configINIParser.flatMap { try self.parseProfileConfig(from: $0, for: profile) }
-        let credentials = try parseCredentials(from: credentialsINIParser, for: profile, sourceProfile: config?.sourceProfile)
+
+        // The profile may live only in the config file (typical for assume-role chains whose
+        // source is an SSO profile). Tolerate `.missingProfile` from `parseCredentials` when
+        // the config file already supplies a `role_arn`, and skip the call entirely when
+        // the credentials file is unavailable.
+        let credentials: ProfileCredentials?
+        if let credentialsINIParser {
+            do {
+                credentials = try parseCredentials(from: credentialsINIParser, for: profile, sourceProfile: config?.sourceProfile)
+            } catch let error as ConfigFileError where error == .missingProfile && config?.roleArn != nil {
+                credentials = nil
+            }
+        } else {
+            credentials = nil
+        }
 
         // If `role_arn` is defined, check for source profile or credential source
-        if let roleArn = credentials.roleArn ?? config?.roleArn {
-            let sessionName = credentials.roleSessionName ?? config?.roleSessionName ?? UUID().uuidString
+        if let roleArn = credentials?.roleArn ?? config?.roleArn {
+            let sessionName = credentials?.roleSessionName ?? config?.roleSessionName ?? UUID().uuidString
             let region = config?.region ?? .useast1
             // If `source_profile` is defined, temporary credentials must be loaded via STS AssumeRole operation
-            if let _ = credentials.sourceProfile ?? config?.sourceProfile {
-                guard let accessKey = credentials.accessKey else {
+            if let sourceProfileName = credentials?.sourceProfile ?? config?.sourceProfile {
+                // If the source profile is an SSO profile (per the config file), use SSO to obtain
+                // the source credentials instead of looking up static keys.
+                if let configINIParser, Self.isSSOProfile(in: configINIParser, profile: sourceProfileName) {
+                    return .assumeRole(
+                        roleArn: roleArn,
+                        sessionName: sessionName,
+                        region: region,
+                        sourceCredentialProvider: .sso(profileName: sourceProfileName)
+                    )
+                }
+                guard let accessKey = credentials?.accessKey else {
                     throw ConfigFileError.missingAccessKeyId
                 }
-                guard let secretAccessKey = credentials.secretAccessKey else {
+                guard let secretAccessKey = credentials?.secretAccessKey else {
                     throw ConfigFileError.missingSecretAccessKey
                 }
                 let provider: CredentialProviderFactory = .static(
                     accessKeyId: accessKey,
                     secretAccessKey: secretAccessKey,
-                    sessionToken: credentials.sessionToken
+                    sessionToken: credentials?.sessionToken
                 )
                 return .assumeRole(roleArn: roleArn, sessionName: sessionName, region: region, sourceCredentialProvider: provider)
             }
             // If `credental_source` is defined, temporary credentials must be loaded from source
-            else if let credentialSource = credentials.credentialSource ?? config?.credentialSource {
+            else if let credentialSource = credentials?.credentialSource ?? config?.credentialSource {
                 let provider: CredentialProviderFactory
                 switch credentialSource {
                 case .environment:
@@ -228,6 +260,9 @@ enum ConfigFileLoader {
         }
 
         // Return static credentials
+        guard let credentials else {
+            throw ConfigFileError.missingProfile
+        }
         guard let accessKey = credentials.accessKey else {
             throw ConfigFileError.missingAccessKeyId
         }
@@ -236,6 +271,14 @@ enum ConfigFileLoader {
         }
         let credential = StaticCredential(accessKeyId: accessKey, secretAccessKey: secretAccessKey, sessionToken: credentials.sessionToken)
         return .staticCredential(credential: credential)
+    }
+
+    /// Returns true if the given profile's section in the AWS config file declares SSO
+    /// (either the modern `sso_session` reference or the legacy `sso_start_url` keys).
+    static func isSSOProfile(in configINIParser: INIParser, profile: String) -> Bool {
+        let sectionKey = profile == Self.defaultProfile ? profile : "profile \(profile)"
+        guard let section = configINIParser.sections[sectionKey] else { return false }
+        return section["sso_session"] != nil || section["sso_start_url"] != nil
     }
 
     /// Parse profile configuraton from a file (passed in as byte-buffer), usually `~/.aws/config`

--- a/Tests/SotoCoreTests/Credential/ConfigFileCredentialProviderTests.swift
+++ b/Tests/SotoCoreTests/Credential/ConfigFileCredentialProviderTests.swift
@@ -135,15 +135,22 @@ class ConfigFileCredentialProviderTests: XCTestCase {
     }
 
     func testConfigFileNotAvailable() async {
-        let filename = #function
-        let filenameURL = URL(fileURLWithPath: filename)
+        let credentialsFilename = "credentials_\(#function)"
+        let credentialsFilenameURL = URL(fileURLWithPath: credentialsFilename)
+
+        let configFilename = "config_\(#function)"
+        let configFilenameURL = URL(fileURLWithPath: configFilename)
 
         let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         let eventLoop = eventLoopGroup.next()
         defer { XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully()) }
         let httpClient = HTTPClient(eventLoopGroupProvider: .shared(eventLoop))
         defer { XCTAssertNoThrow(try httpClient.syncShutdown()) }
-        let factory = CredentialProviderFactory.configFile(credentialsFilePath: filenameURL.path)
+
+        let factory = CredentialProviderFactory.configFile(
+            credentialsFilePath: credentialsFilenameURL.path,
+            configFilePath: configFilenameURL.path,
+        )
 
         let provider = factory.createProvider(context: .init(httpClient: httpClient, logger: TestEnvironment.logger, options: .init()))
 

--- a/Tests/SotoCoreTests/Credential/ConfigFileCredentialProviderTests.swift
+++ b/Tests/SotoCoreTests/Credential/ConfigFileCredentialProviderTests.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import AsyncHTTPClient
+import Logging
 import NIOCore
 import NIOPosix
 import SotoTestUtils
@@ -74,6 +75,57 @@ class ConfigFileCredentialProviderTests: XCTestCase {
             XCTAssertEqual(sessionName, "baz")
         default: XCTFail()
         }
+
+        try await provider.shutdown()
+        try await httpClient.shutdown()
+    }
+
+    func testProfileScopedProviderWrapsErrorWithProfileName() async throws {
+        // Direct unit test for the wrapper: any error from the inner provider must surface as
+        // a `ProfileCredentialError` whose description includes the profile name and whose
+        // `underlying` preserves the original error.
+        struct StubError: Error, Equatable {}
+        struct ThrowingProvider: CredentialProvider {
+            func getCredential(logger: Logger) async throws -> Credential { throw StubError() }
+        }
+        let wrapped = ProfileScopedCredentialProvider(inner: ThrowingProvider(), profile: "dev")
+
+        do {
+            _ = try await wrapped.getCredential(logger: TestEnvironment.logger)
+            XCTFail("Expected ProfileCredentialError")
+        } catch let error as ProfileCredentialError {
+            XCTAssertEqual(error.profile, "dev")
+            XCTAssertTrue(error.underlying is StubError)
+            XCTAssertTrue(error.description.contains("dev"), "Description should name the profile: \(error.description)")
+        } catch {
+            XCTFail("Expected ProfileCredentialError, got \(error)")
+        }
+    }
+
+    func testCredentialProviderTagsErrorsWithProfileFromFile() async throws {
+        // Integration check: loading via the file overload must produce a `ProfileScopedCredentialProvider`
+        // bound to the requested profile, so any failure from inside the chain surfaces with that profile.
+        let profile = "dev"
+        let credentialsFile = """
+            [\(profile)]
+            aws_access_key_id = AKIAIOSFODNN7EXAMPLE
+            aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+            """
+        let credentialsPath = "creds-\(UUID().uuidString)"
+        try credentialsFile.write(toFile: credentialsPath, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(atPath: credentialsPath) }
+        let (context, httpClient) = self.makeContext()
+
+        let provider = try await ConfigFileCredentialProvider.credentialProvider(
+            from: credentialsPath,
+            configFilePath: "/dev/null",
+            for: profile,
+            context: context,
+            endpoint: nil
+        )
+
+        let scoped = try XCTUnwrap(provider as? ProfileScopedCredentialProvider)
+        XCTAssertEqual(scoped.profile, profile)
 
         try await provider.shutdown()
         try await httpClient.shutdown()

--- a/Tests/SotoCoreTests/Credential/ConfigFileLoaderTests.swift
+++ b/Tests/SotoCoreTests/Credential/ConfigFileLoaderTests.swift
@@ -285,6 +285,181 @@ class ConfigFileLoadersTests: XCTestCase {
         }
     }
 
+    func testLoadFileSSOSourceProfile() async throws {
+        // Assume-role profile lives only in ~/.aws/config and points at an SSO source profile.
+        // This is the standard layout written by `aws configure sso` for multi-account setups.
+        let profile = "dev"
+        let sourceProfile = "sso-base"
+        let roleArn = "arn:aws:iam::222222222222:role/Developer"
+        let credentialsFile = ""
+        let configFile = """
+            [profile \(profile)]
+            role_arn = \(roleArn)
+            source_profile = \(sourceProfile)
+            region = us-west-2
+
+            [profile \(sourceProfile)]
+            sso_session = my-org
+            sso_account_id = 111111111111
+            sso_role_name = SSOAccess
+
+            [sso-session my-org]
+            sso_start_url = https://my-org.awsapps.com/start
+            sso_region = us-east-1
+            """
+
+        let credentialsPath = try save(content: credentialsFile, prefix: "creds-\(#function)")
+        let configPath = try save(content: configFile, prefix: "config-\(#function)")
+        let (context, httpClient) = try makeContext()
+
+        try await withTeardown {
+            let shared = try await ConfigFileLoader.loadSharedCredentials(
+                credentialsFilePath: credentialsPath,
+                configFilePath: configPath,
+                profile: profile
+            )
+
+            switch shared {
+            case .assumeRole(let aRoleArn, _, let region, let sourceFactory):
+                XCTAssertEqual(aRoleArn, roleArn)
+                XCTAssertEqual(region, .uswest2)
+                let sourceProvider = sourceFactory.createProvider(context: context)
+                let rotating = try XCTUnwrap(sourceProvider as? RotatingCredentialProvider)
+                XCTAssert(
+                    rotating.provider is SSOCredentialProvider,
+                    "Expected SSOCredentialProvider as the source, got \(type(of: rotating.provider))"
+                )
+                try await sourceProvider.shutdown()
+            default:
+                XCTFail("Expected .assumeRole with an SSO source provider")
+            }
+        } teardown: {
+            try? FileManager.default.removeItem(atPath: credentialsPath)
+            try? FileManager.default.removeItem(atPath: configPath)
+            try? await httpClient.shutdown()
+        }
+    }
+
+    func testLoadFileMissingCredentialsButConfigHasSSOSource() async throws {
+        // Many SSO-only setups have no ~/.aws/credentials file at all. As long as the config
+        // file fully describes the assume-role chain (and its SSO source), credential loading
+        // should still succeed instead of falling through to .noProvider.
+        let profile = "dev"
+        let sourceProfile = "sso-base"
+        let roleArn = "arn:aws:iam::222222222222:role/Developer"
+        let configFile = """
+            [profile \(profile)]
+            role_arn = \(roleArn)
+            source_profile = \(sourceProfile)
+
+            [profile \(sourceProfile)]
+            sso_session = my-org
+            sso_account_id = 111111111111
+            sso_role_name = SSOAccess
+
+            [sso-session my-org]
+            sso_start_url = https://my-org.awsapps.com/start
+            sso_region = us-east-1
+            """
+
+        let credentialsPath = "missing-credentials-\(UUID().uuidString)"
+        let configPath = try save(content: configFile, prefix: "config-\(#function)")
+        let (context, httpClient) = try makeContext()
+
+        try await withTeardown {
+            let shared = try await ConfigFileLoader.loadSharedCredentials(
+                credentialsFilePath: credentialsPath,
+                configFilePath: configPath,
+                profile: profile
+            )
+
+            switch shared {
+            case .assumeRole(let aRoleArn, _, _, let sourceFactory):
+                XCTAssertEqual(aRoleArn, roleArn)
+                let sourceProvider = sourceFactory.createProvider(context: context)
+                let rotating = try XCTUnwrap(sourceProvider as? RotatingCredentialProvider)
+                XCTAssert(rotating.provider is SSOCredentialProvider)
+                try await sourceProvider.shutdown()
+            default:
+                XCTFail("Expected .assumeRole with an SSO source provider")
+            }
+        } teardown: {
+            try? FileManager.default.removeItem(atPath: configPath)
+            try? await httpClient.shutdown()
+        }
+    }
+
+    func testLoadFileBothFilesMissing() async throws {
+        // Neither file exists at all — provider must still report `.noProvider` so the
+        // credential chain can move on to the next provider.
+        let credentialsPath = "missing-credentials-\(UUID().uuidString)"
+        let configPath = "missing-config-\(UUID().uuidString)"
+        let (_, httpClient) = try makeContext()
+
+        try await withTeardown {
+            do {
+                _ = try await ConfigFileLoader.loadSharedCredentials(
+                    credentialsFilePath: credentialsPath,
+                    configFilePath: configPath,
+                    profile: ConfigFileLoader.defaultProfile
+                )
+                XCTFail("Expected CredentialProviderError.noProvider")
+            } catch let error as CredentialProviderError where error == .noProvider {
+                // pass
+            } catch {
+                XCTFail("Expected CredentialProviderError.noProvider, got \(error.localizedDescription)")
+            }
+        } teardown: {
+            try? await httpClient.shutdown()
+        }
+    }
+
+    func testLoadFileSSOSourceProfileLegacyFormat() async throws {
+        // Same scenario, but the source profile uses the legacy SSO format (direct sso_start_url
+        // rather than an sso_session reference). Both should be detected.
+        let profile = "dev"
+        let sourceProfile = "sso-base"
+        let roleArn = "arn:aws:iam::222222222222:role/Developer"
+        let credentialsFile = ""
+        let configFile = """
+            [profile \(profile)]
+            role_arn = \(roleArn)
+            source_profile = \(sourceProfile)
+
+            [profile \(sourceProfile)]
+            sso_start_url = https://my-org.awsapps.com/start
+            sso_region = us-east-1
+            sso_account_id = 111111111111
+            sso_role_name = SSOAccess
+            """
+
+        let credentialsPath = try save(content: credentialsFile, prefix: "creds-\(#function)")
+        let configPath = try save(content: configFile, prefix: "config-\(#function)")
+        let (context, httpClient) = try makeContext()
+
+        try await withTeardown {
+            let shared = try await ConfigFileLoader.loadSharedCredentials(
+                credentialsFilePath: credentialsPath,
+                configFilePath: configPath,
+                profile: profile
+            )
+
+            switch shared {
+            case .assumeRole(_, _, _, let sourceFactory):
+                let sourceProvider = sourceFactory.createProvider(context: context)
+                let rotating = try XCTUnwrap(sourceProvider as? RotatingCredentialProvider)
+                XCTAssert(rotating.provider is SSOCredentialProvider)
+                try await sourceProvider.shutdown()
+            default:
+                XCTFail("Expected .assumeRole with an SSO source provider")
+            }
+        } teardown: {
+            try? FileManager.default.removeItem(atPath: credentialsPath)
+            try? FileManager.default.removeItem(atPath: configPath)
+            try? await httpClient.shutdown()
+        }
+    }
+
     func testLoadFileRoleArnOnly() async throws {
         let profile = "marketingadmin"
         let roleArn = "arn:aws:iam::123456789012:role/marketingadminrole"

--- a/Tests/SotoCoreTests/Credential/ConfigFileLoaderTests.swift
+++ b/Tests/SotoCoreTests/Credential/ConfigFileLoaderTests.swift
@@ -445,6 +445,93 @@ class ConfigFileLoadersTests: XCTestCase {
         }
     }
 
+    func testLoadFileMalformedCredentialsFileSurfacesError() async throws {
+        // A credentials file that exists but cannot be parsed must surface `.invalidINIFile`
+        // rather than being silently treated as "no credentials file". Only ENOENT should
+        // degrade to a soft miss.
+        let credentialsPath = try save(content: "this line is not valid ini\n", prefix: "creds-\(#function)")
+        let configPath = "missing-config-\(UUID().uuidString)"
+        let (_, httpClient) = try makeContext()
+
+        try await withTeardown {
+            do {
+                _ = try await ConfigFileLoader.loadSharedCredentials(
+                    credentialsFilePath: credentialsPath,
+                    configFilePath: configPath,
+                    profile: ConfigFileLoader.defaultProfile
+                )
+                XCTFail("Expected ConfigFileError.invalidINIFile")
+            } catch let error as ConfigFileLoader.ConfigFileError where error == .invalidINIFile {
+                // pass
+            } catch {
+                XCTFail("Expected ConfigFileError.invalidINIFile, got \(error.localizedDescription)")
+            }
+        } teardown: {
+            try? FileManager.default.removeItem(atPath: credentialsPath)
+            try? await httpClient.shutdown()
+        }
+    }
+
+    func testLoadFileMalformedConfigFileSurfacesError() async throws {
+        // Same contract for the config file: a parseable credentials file alongside a
+        // malformed config file must propagate the parse error rather than silently
+        // proceeding with the credentials file alone.
+        let credentialsFile = """
+            [\(ConfigFileLoader.defaultProfile)]
+            aws_access_key_id = AKIAIOSFODNN7EXAMPLE
+            aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+            """
+        let credentialsPath = try save(content: credentialsFile, prefix: "creds-\(#function)")
+        let configPath = try save(content: "this line is not valid ini\n", prefix: "config-\(#function)")
+        let (_, httpClient) = try makeContext()
+
+        try await withTeardown {
+            do {
+                _ = try await ConfigFileLoader.loadSharedCredentials(
+                    credentialsFilePath: credentialsPath,
+                    configFilePath: configPath,
+                    profile: ConfigFileLoader.defaultProfile
+                )
+                XCTFail("Expected ConfigFileError.invalidINIFile")
+            } catch let error as ConfigFileLoader.ConfigFileError where error == .invalidINIFile {
+                // pass
+            } catch {
+                XCTFail("Expected ConfigFileError.invalidINIFile, got \(error.localizedDescription)")
+            }
+        } teardown: {
+            try? FileManager.default.removeItem(atPath: credentialsPath)
+            try? FileManager.default.removeItem(atPath: configPath)
+            try? await httpClient.shutdown()
+        }
+    }
+
+    func testLoadFileMissingCredentialsWithMalformedConfigSurfacesError() async throws {
+        // A missing credentials file is fine on its own, but if the config file that we'd
+        // fall back to is malformed, we must surface the parse error rather than reporting
+        // `.noProvider` (which would hide the real problem from the user).
+        let credentialsPath = "missing-credentials-\(UUID().uuidString)"
+        let configPath = try save(content: "this line is not valid ini\n", prefix: "config-\(#function)")
+        let (_, httpClient) = try makeContext()
+
+        try await withTeardown {
+            do {
+                _ = try await ConfigFileLoader.loadSharedCredentials(
+                    credentialsFilePath: credentialsPath,
+                    configFilePath: configPath,
+                    profile: ConfigFileLoader.defaultProfile
+                )
+                XCTFail("Expected ConfigFileError.invalidINIFile")
+            } catch let error as ConfigFileLoader.ConfigFileError where error == .invalidINIFile {
+                // pass
+            } catch {
+                XCTFail("Expected ConfigFileError.invalidINIFile, got \(error.localizedDescription)")
+            }
+        } teardown: {
+            try? FileManager.default.removeItem(atPath: configPath)
+            try? await httpClient.shutdown()
+        }
+    }
+
     func testLoadFileSSOSourceProfileLegacyFormat() async throws {
         // Same scenario, but the source profile uses the legacy SSO format (direct sso_start_url
         // rather than an sso_session reference). Both should be detected.

--- a/Tests/SotoCoreTests/Credential/ConfigFileLoaderTests.swift
+++ b/Tests/SotoCoreTests/Credential/ConfigFileLoaderTests.swift
@@ -414,6 +414,37 @@ class ConfigFileLoadersTests: XCTestCase {
         }
     }
 
+    func testLoadFileMissingCredentialsAndConfigHasNoRoleArn() async throws {
+        // Credentials file is unavailable and the config file exists but doesn't supply a
+        // `role_arn` for the requested profile. The provider must signal `.noProvider` so the
+        // credential chain can move on (e.g. to the standalone `.sso()` step).
+        let configFile = """
+            [profile dev]
+            region = us-east-1
+            """
+        let credentialsPath = "missing-credentials-\(#function)"
+        let configPath = try save(content: configFile, prefix: "config-\(#function)")
+        let (_, httpClient) = try makeContext()
+
+        try await withTeardown {
+            do {
+                _ = try await ConfigFileLoader.loadSharedCredentials(
+                    credentialsFilePath: credentialsPath,
+                    configFilePath: configPath,
+                    profile: "dev"
+                )
+                XCTFail("Expected CredentialProviderError.noProvider")
+            } catch let error as CredentialProviderError where error == .noProvider {
+                // pass
+            } catch {
+                XCTFail("Expected CredentialProviderError.noProvider, got \(error.localizedDescription)")
+            }
+        } teardown: {
+            try? FileManager.default.removeItem(atPath: configPath)
+            try? await httpClient.shutdown()
+        }
+    }
+
     func testLoadFileSSOSourceProfileLegacyFormat() async throws {
         // Same scenario, but the source profile uses the legacy SSO format (direct sso_start_url
         // rather than an sso_session reference). Both should be detected.

--- a/Tests/SotoCoreTests/Credential/CredentialProviderTests.swift
+++ b/Tests/SotoCoreTests/Credential/CredentialProviderTests.swift
@@ -103,15 +103,21 @@ final class CredentialProviderTests: XCTestCase {
     }
 
     func testConfigFileNotAvailable() async throws {
-        let filename = "credentials_not_existing"
-        let filenameURL = URL(fileURLWithPath: filename)
+        let credentialsFilename = "credentials_not_existing"
+        let credentialsFilenameURL = URL(fileURLWithPath: credentialsFilename)
+
+        let configFilename = "config_not_existing"
+        let configFilenameURL = URL(fileURLWithPath: configFilename)
 
         let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         let eventLoop = eventLoopGroup.next()
         defer { XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully()) }
         let httpClient = HTTPClient(eventLoopGroupProvider: .shared(eventLoop))
         defer { XCTAssertNoThrow(try httpClient.syncShutdown()) }
-        let factory = CredentialProviderFactory.configFile(credentialsFilePath: filenameURL.path)
+        let factory = CredentialProviderFactory.configFile(
+            credentialsFilePath: credentialsFilenameURL.path,
+            configFilePath: configFilenameURL.path,
+        )
 
         let provider = factory.createProvider(context: .init(httpClient: httpClient, logger: TestEnvironment.logger, options: .init()))
 


### PR DESCRIPTION
This pull request improves support for AWS configuration files with the following changes:

- loadSharedCredentials now tolerates each file independently. Throws .noProvider only when both are unavailable; converts a downstream .missingProfile back to .noProvider if the credentials file was the missing one (preserving chain-fallthrough).
- parseSharedCredentials signature: Skips the parseCredentials call when credentialsINIParser is nil. Catches .missingProfile and proceeds when the config file supplies a role_arn; the static-credentials final path now explicitly requires a non-nil credentials.
- Assume-role branch detects SSO source profiles (looking up the source's section in the config parser) and routes to .sso(profileName: sourceProfile) instead of demanding static keys.
- New isSSOProfile(in:profile:) helper detects both modern sso_session and legacy sso_start_url formats.

This PR was produced with the assistance of Claude Code (Opus 4.7), but I have reviewed the entirety personally, and made changes where the LLM made bad decisions. I have tested this against a real project using Soto, and have run the test suite.